### PR TITLE
Enable multiple components and fix transcription attribution

### DIFF
--- a/src/app/canvas/page.tsx
+++ b/src/app/canvas/page.tsx
@@ -16,7 +16,7 @@ import { CanvasSpace } from "@/components/ui/canvas-space";
 import { MessageThreadCollapsible } from "@/components/ui/message-thread-collapsible";
 import { LivekitRoomConnector, CanvasLiveKitContext } from "@/components/ui/livekit-room-connector";
 import { loadMcpServers, suppressDevelopmentWarnings, suppressViolationWarnings } from "@/lib/mcp-utils";
-import { components } from "@/lib/tambo";
+import { components, tools } from "@/lib/tambo";
 import { TamboProvider } from "@tambo-ai/react";
 import { EnhancedMcpProvider } from "@/components/ui/enhanced-mcp-provider";
 import { Room, ConnectionState, RoomEvent, VideoPresets, RoomOptions } from "livekit-client";
@@ -26,9 +26,7 @@ import { useAuth } from "@/hooks/use-auth";
 import { SpeechTranscription } from '@/components/ui/speech-transcription';
 import { ToolDispatcher } from '@/components/tool-dispatcher';
 // TODO: Investigate best way to "go back" to CanvasSpace once we have a better way to handle adding/updating/managing the state of multiple components on the canvas simultaneously
-import CanvasSpaceSingleComponent from "@/components/ui/hackathon/canvas-space-single-component";
-import { tamboTools, testComponents } from "../hackathon-canvas/test-tambo-setup";
-import tamboAgent from "@/lib/archived-agents/clean-agent";
+
 
 // Suppress development warnings for cleaner console
 suppressDevelopmentWarnings();
@@ -142,10 +140,8 @@ export default function Canvas() {
       {/* Tambo Provider Setup */}
       <TamboProvider
         apiKey={process.env.NEXT_PUBLIC_TAMBO_API_KEY!}
-        // TODO: go back to {components} once we have a better way to handle updating the components on the canvas
-        components={testComponents}
-        // Investigate if we shold leave this here or move it to the ToolDispatcher
-        tools={tamboTools}
+        components={components}
+        tools={tools}
       >
         <EnhancedMcpProvider mcpServers={mcpServers}>
           {/* LiveKit Room Context Provider - wraps everything! */}
@@ -155,9 +151,8 @@ export default function Canvas() {
               {/* Canvas LiveKit Context Provider - provides connection state to all canvas components */}
               <CanvasLiveKitContext.Provider value={roomState}>
               {/* Full-screen Canvas Space */}
-              {/* TODO: go back to CanvasSpace once we have a better way to handle adding/updating/managing the state of multiple components on the canvas simultaneously */}
-              <CanvasSpaceSingleComponent
-                className="absolute inset-0 w-full h-full" 
+              <CanvasSpace
+                className="absolute inset-0 w-full h-full"
                 onTranscriptToggle={toggleTranscript}
               />
 

--- a/src/app/hackathon-canvas/page.tsx
+++ b/src/app/hackathon-canvas/page.tsx
@@ -12,7 +12,7 @@ export const dynamic = "force-dynamic";
 
 // Force client-side rendering to prevent SSG issues with Tambo hooks
 import { ToolDispatcher } from "@/components/tool-dispatcher";
-import CanvasSpaceSingleComponent from "@/components/ui/hackathon/canvas-space-single-component";
+import { CanvasSpace } from "@/components/ui/canvas-space";
 import { CanvasLiveKitContext } from "@/components/ui/livekit-room-connector";
 import { MessageThreadCollapsible } from "@/components/ui/message-thread-collapsible";
 import {
@@ -30,7 +30,8 @@ import {
   VideoPresets,
 } from "livekit-client";
 import React, { useCallback, useState } from "react";
-import { tamboTools, testComponents } from "./test-tambo-setup";
+import { tamboTools } from "./test-tambo-setup";
+import { components } from "@/lib/tambo";
 
 // Suppress development warnings for cleaner console
 suppressDevelopmentWarnings();
@@ -122,7 +123,7 @@ export default function Canvas() {
       {/* Tambo Provider Setup */}
       <TamboProvider
         apiKey={process.env.NEXT_PUBLIC_TAMBO_API_KEY!}
-        components={testComponents}
+        components={components}
         tools={tamboTools}
         tamboUrl={process.env.NEXT_PUBLIC_TAMBO_URL}
       >
@@ -134,7 +135,7 @@ export default function Canvas() {
             {/* Canvas LiveKit Context Provider - provides connection state to all canvas components */}
             <CanvasLiveKitContext.Provider value={roomState}>
               {/* Full-screen Canvas Space */}
-              <CanvasSpaceSingleComponent
+              <CanvasSpace
                 className="absolute inset-0 w-full h-full"
                 onTranscriptToggle={toggleTranscript}
               />


### PR DESCRIPTION
## Summary
- restore the canvas to render multiple components again
- use production components on both canvas pages
- track active speaker in LiveKit and use it to tag transcripts

## Testing
- `npm run lint` *(fails: Unexpected any and other lint errors)*
- `npm test` *(fails: Jest encountered unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_685b1855120083269333fe791953444a