### PR TITLE
Stream conversation and sync canvas data

### DIFF
--- a/ARCHITECTURE_SYNC_BUS.md
+++ b/ARCHITECTURE_SYNC_BUS.md
@@ -125,3 +125,23 @@ they diverge, latest `timestamp` wins (implement Lamport clocks if needed).
 
 ---
 Happy syncing! 🎉 
+
+## Session Sync to Supabase
+
+A headless `SessionSync` component (see `src/components/SessionSync.tsx`) mounts inside the LiveKit room context and:
+- Ensures a `canvas_sessions` row exists keyed by `room_name` + `canvas_id`
+- Streams `transcription` bus messages into the `transcript` JSONB array
+- Keeps `participants` in sync on join/leave
+- Updates `canvas_state` when `useCanvasPersistence` emits `tambo:sessionCanvasSaved`
+
+Suggested Supabase table `canvas_sessions`:
+- id: uuid primary key default uuid_generate_v4()
+- canvas_id: uuid nullable references canvases(id)
+- room_name: text not null
+- participants: jsonb default '[]'
+- transcript: jsonb default '[]'
+- canvas_state: jsonb
+- created_at: timestamp with time zone default now()
+- updated_at: timestamp with time zone default now()
+
+Add an index on (room_name, canvas_id) unique to dedupe sessions. 

--- a/README.md
+++ b/README.md
@@ -204,3 +204,29 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for development guidelines.
 ## 📄 License
 
 This project is licensed under the MIT License.
+
+### Supabase Session Sync
+
+Set `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` in `.env.local`.
+Create a `canvas_sessions` table to track each meeting session canvas:
+
+```sql
+create table if not exists public.canvas_sessions (
+  id uuid primary key default uuid_generate_v4(),
+  canvas_id uuid references public.canvases(id),
+  room_name text not null,
+  participants jsonb not null default '[]',
+  transcript jsonb not null default '[]',
+  canvas_state jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create unique index if not exists canvas_sessions_room_canvas_uidx
+  on public.canvas_sessions(room_name, canvas_id);
+```
+
+The headless `SessionSync` component will insert/update this row and stream:
+- LiveKit participants
+- LiveKit `transcription` bus messages
+- TLDraw canvas snapshot on save

--- a/src/app/canvas/page.tsx
+++ b/src/app/canvas/page.tsx
@@ -15,6 +15,7 @@ import React, { useState, useEffect, useCallback } from "react";
 import { CanvasSpace } from "@/components/ui/canvas-space";
 import { MessageThreadCollapsible } from "@/components/ui/message-thread-collapsible";
 import { LivekitRoomConnector, CanvasLiveKitContext } from "@/components/ui/livekit-room-connector";
+import SessionSync from "@/components/SessionSync";
 import { loadMcpServers, suppressDevelopmentWarnings, suppressViolationWarnings } from "@/lib/mcp-utils";
 import { components, tools } from "@/lib/tambo";
 import { validateTamboTools } from "@/lib/tambo-tool-validator";
@@ -183,6 +184,8 @@ export default function Canvas() {
                   onTranscriptToggle={toggleTranscript}
                 />
 
+                <SessionSync roomName={roomName} />
+
                 {/* Direct LiveKit Room Connector - positioned bottom left to avoid overlap */}
                 <div className="absolute bottom-4 left-4 z-50">
                   <LivekitRoomConnector 
@@ -220,6 +223,8 @@ export default function Canvas() {
                   className="absolute inset-0 w-full h-full"
                   onTranscriptToggle={toggleTranscript}
                 />
+
+                <SessionSync roomName={roomName} />
 
                 {/* Direct LiveKit Room Connector - positioned bottom left to avoid overlap */}
                 <div className="absolute bottom-4 left-4 z-50">

--- a/src/components/SessionSync.tsx
+++ b/src/components/SessionSync.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import React from 'react'
+import { useSessionSync } from '@/hooks/use-session-sync'
+
+export function SessionSync({ roomName }: { roomName: string }) {
+  useSessionSync(roomName)
+  return null
+}
+
+export default SessionSync

--- a/src/hooks/use-canvas-persistence.ts
+++ b/src/hooks/use-canvas-persistence.ts
@@ -97,6 +97,13 @@ export function useCanvasPersistence(editor: Editor | null, enabled: boolean = t
 
         if (error) throw error;
         setLastSaved(new Date());
+
+        // Notify session sync to update the session's canvas_state
+        try {
+          window.dispatchEvent(new CustomEvent('tambo:sessionCanvasSaved', { detail: { snapshot, canvasId } }))
+        } catch (e) {
+          // no-op
+        }
       } else {
         // Create new canvas
         const { data: newCanvas, error } = await supabase
@@ -116,6 +123,13 @@ export function useCanvasPersistence(editor: Editor | null, enabled: boolean = t
 
         setCanvasId(newCanvas.id);
         setLastSaved(new Date());
+        
+        // Notify session sync to update the session's canvas_state
+        try {
+          window.dispatchEvent(new CustomEvent('tambo:sessionCanvasSaved', { detail: { snapshot, canvasId: newCanvas.id } }))
+        } catch (e) {
+          // no-op
+        }
         
         // Update URL with canvas ID
         const newUrl = new URL(window.location.href);

--- a/src/hooks/use-session-sync.ts
+++ b/src/hooks/use-session-sync.ts
@@ -1,0 +1,191 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { useRoomContext } from '@livekit/components-react'
+import { Room, RoomEvent, Participant } from 'livekit-client'
+import { supabase } from '@/lib/supabase'
+import { createLiveKitBus } from '@/lib/livekit-bus'
+
+export type CanvasSession = {
+  id: string
+  canvas_id: string | null
+  room_name: string
+  participants: any[] | null
+  transcript: any[] | null
+  canvas_state: any | null
+  created_at?: string
+  updated_at?: string
+}
+
+function getCanvasIdFromUrl(): string | null {
+  if (typeof window === 'undefined') return null
+  const urlParams = new URLSearchParams(window.location.search)
+  return urlParams.get('id')
+}
+
+function mapParticipants(room: Room): Array<{ identity: string; name?: string | null; metadata?: string | null }> {
+  const list: Array<{ identity: string; name?: string | null; metadata?: string | null }> = []
+  // local participant
+  if (room.localParticipant) {
+    list.push({ identity: room.localParticipant.identity, name: room.localParticipant.name, metadata: room.localParticipant.metadata })
+  }
+  // remote participants
+  room.remoteParticipants.forEach((p) => {
+    list.push({ identity: p.identity, name: p.name, metadata: p.metadata })
+  })
+  return list
+}
+
+export function useSessionSync(roomName: string) {
+  const room = useRoomContext()
+  const bus = useMemo(() => createLiveKitBus(room), [room])
+  const [sessionId, setSessionId] = useState<string | null>(null)
+  const canvasIdRef = useRef<string | null>(null)
+  const transcriptRef = useRef<any[]>([])
+
+  // Ensure we have or create a session row
+  useEffect(() => {
+    let isCancelled = false
+
+    async function ensureSession() {
+      const canvasId = getCanvasIdFromUrl()
+      canvasIdRef.current = canvasId
+
+      // Try to find existing
+      let query = supabase
+        .from<CanvasSession>('canvas_sessions' as any)
+        .select('*')
+        .eq('room_name', roomName)
+      
+      if (canvasId === null) {
+        // match rows where canvas_id IS NULL
+        // @ts-ignore - supabase-js has .is for null checks
+        query = (query as any).is('canvas_id', null)
+      } else {
+        query = query.eq('canvas_id', canvasId)
+      }
+
+      const { data: existing, error: selectErr } = await query
+        .limit(1)
+        .maybeSingle()
+
+      if (selectErr) {
+        console.error('[useSessionSync] Failed to select session', selectErr)
+      }
+
+      if (!isCancelled && existing?.id) {
+        setSessionId(existing.id)
+        transcriptRef.current = Array.isArray(existing.transcript) ? existing.transcript : []
+        return
+      }
+
+      // Create new
+      const participants = room ? mapParticipants(room) : []
+      const insertPayload = {
+        canvas_id: canvasId,
+        room_name: roomName,
+        participants,
+        transcript: [],
+        canvas_state: null as any,
+      }
+
+      const { data: created, error: insertErr } = await supabase
+        .from<CanvasSession>('canvas_sessions' as any)
+        .insert(insertPayload as any)
+        .select('*')
+        .single()
+
+      if (insertErr) {
+        console.error('[useSessionSync] Failed to create session', insertErr)
+        return
+      }
+
+      if (!isCancelled) {
+        setSessionId(created.id)
+        transcriptRef.current = []
+      }
+    }
+
+    ensureSession()
+    return () => { isCancelled = true }
+  }, [roomName, room])
+
+  // Update participants on join/leave
+  useEffect(() => {
+    if (!room || !sessionId) return
+
+    const updateParticipants = async () => {
+      const participants = mapParticipants(room)
+      const { error } = await supabase
+        .from('canvas_sessions')
+        .update({ participants, updated_at: new Date().toISOString() })
+        .eq('id', sessionId)
+      if (error) console.error('[useSessionSync] Failed to update participants', error)
+    }
+
+    const onConnected = () => updateParticipants()
+    const onDisconnected = () => updateParticipants()
+    const onParticipantConnected = (_p: Participant) => updateParticipants()
+    const onParticipantDisconnected = (_p: Participant) => updateParticipants()
+
+    // Initial push
+    updateParticipants()
+
+    room.on(RoomEvent.Connected, onConnected)
+    room.on(RoomEvent.Disconnected, onDisconnected)
+    room.on(RoomEvent.ParticipantConnected, onParticipantConnected)
+    room.on(RoomEvent.ParticipantDisconnected, onParticipantDisconnected)
+
+    return () => {
+      room.off(RoomEvent.Connected, onConnected)
+      room.off(RoomEvent.Disconnected, onDisconnected)
+      room.off(RoomEvent.ParticipantConnected, onParticipantConnected)
+      room.off(RoomEvent.ParticipantDisconnected, onParticipantDisconnected)
+    }
+  }, [room, sessionId])
+
+  // Stream transcription messages to Supabase
+  useEffect(() => {
+    if (!sessionId) return
+
+    const off = bus.on('transcription', async (msg: any) => {
+      if (!msg || typeof msg.text !== 'string') return
+      const entry = {
+        participantId: msg.participantId ?? msg.speaker ?? 'unknown',
+        text: msg.text,
+        timestamp: typeof msg.timestamp === 'number' ? msg.timestamp : Date.now(),
+      }
+
+      // Append locally and push update
+      transcriptRef.current = [...transcriptRef.current, entry]
+      const { error } = await supabase
+        .from('canvas_sessions')
+        .update({ transcript: transcriptRef.current, updated_at: new Date().toISOString() })
+        .eq('id', sessionId)
+      if (error) console.error('[useSessionSync] Failed to append transcript', error)
+    })
+
+    return off
+  }, [bus, sessionId])
+
+  // Listen for canvas save events to update session canvas_state
+  useEffect(() => {
+    if (!sessionId) return
+
+    const handler = async (e: Event) => {
+      const { snapshot, canvasId } = (e as CustomEvent).detail || {}
+      if (!snapshot) return
+      // If canvasIdRef is set and a different canvas id comes through, ignore
+      if (canvasIdRef.current && canvasId && canvasIdRef.current !== canvasId) return
+
+      const { error } = await supabase
+        .from('canvas_sessions')
+        .update({ canvas_state: snapshot, updated_at: new Date().toISOString() })
+        .eq('id', sessionId)
+      if (error) console.error('[useSessionSync] Failed to update canvas_state', error)
+    }
+
+    window.addEventListener('tambo:sessionCanvasSaved', handler as EventListener)
+    return () => window.removeEventListener('tambo:sessionCanvasSaved', handler as EventListener)
+  }, [sessionId])
+
+  return { sessionId }
+}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -45,3 +45,14 @@ export type Profile = {
   avatar_url?: string
   created_at: string
 } 
+
+export type CanvasSession = {
+  id: string
+  canvas_id: string | null
+  room_name: string
+  participants: Array<{ identity: string; name?: string | null; metadata?: string | null }> | null
+  transcript: Array<{ participantId: string; text: string; timestamp: number }> | null
+  canvas_state: any | null
+  created_at?: string
+  updated_at?: string
+} 


### PR DESCRIPTION
Adds Supabase integration to stream LiveKit session data and TLDraw canvas state for persistence and synchronization.

---
<a href="https://cursor.com/background-agent?bcId=bc-15a9c16b-f726-44e1-9767-89aa66281622">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-15a9c16b-f726-44e1-9767-89aa66281622">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

