### PR TITLE
Improve auth redirect safety and canvas room handling

### DIFF
--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -30,7 +30,10 @@ export async function GET(request: NextRequest) {
     const { error } = await supabase.auth.exchangeCodeForSession(code)
     
     if (!error) {
-      return NextResponse.redirect(`${origin}/canvas`)
+      const next = requestUrl.searchParams.get('next')
+      // Only allow internal redirects
+      const safeNext = next && next.startsWith('/') ? next : '/canvas'
+      return NextResponse.redirect(`${origin}${safeNext}`)
     }
   }
 

--- a/src/components/ui/livekit-room-connector.tsx
+++ b/src/components/ui/livekit-room-connector.tsx
@@ -571,9 +571,10 @@ export function LivekitRoomConnector({
     setState(prev => prev ? { ...prev, isMinimized: !prev.isMinimized } : { ...getInitialState(), isMinimized: true });
   };
 
-  // Copy room link
+  // Copy room link (prefer id param to keep URL stable; strip prefix if present)
   const handleCopyLink = () => {
-    const link = `${window.location.origin}/canvas?room=${roomName}`;
+    const id = roomName.startsWith('tambo-canvas-') ? roomName.substring('tambo-canvas-'.length) : roomName;
+    const link = `${window.location.origin}/canvas?id=${encodeURIComponent(id)}`;
     navigator.clipboard.writeText(link);
   };
 

--- a/src/components/ui/thread-dropdown.tsx
+++ b/src/components/ui/thread-dropdown.tsx
@@ -17,7 +17,7 @@ export interface ThreadDropdownProps
   /** Optional context key for filtering threads */
   contextKey?: string;
   /** Optional callback function called when the current thread changes */
-  onThreadChange?: () => void;
+  onThreadChange?: (threadId?: string) => void;
 }
 
 /**
@@ -54,9 +54,10 @@ export const ThreadDropdown = React.forwardRef<
       }
 
       try {
-        await startNewThread();
+        const created = await startNewThread();
         await refetch();
-        onThreadChange?.();
+        // @ts-expect-error: SDK may return the created thread
+        onThreadChange?.(created?.id);
       } catch (error) {
         console.error("Failed to create new thread:", error);
       }
@@ -86,7 +87,7 @@ export const ThreadDropdown = React.forwardRef<
 
     try {
       switchCurrentThread(threadId);
-      onThreadChange?.();
+      onThreadChange?.(threadId);
     } catch (error) {
       console.error("Failed to switch thread:", error);
     }

--- a/src/hooks/use-auth.ts
+++ b/src/hooks/use-auth.ts
@@ -25,10 +25,11 @@ export function useAuth() {
   }, [])
 
   const signInWithGoogle = async () => {
+    const next = typeof window !== 'undefined' ? (window.location.pathname + window.location.search) : '/canvas'
     const { error } = await supabase.auth.signInWithOAuth({
       provider: 'google',
       options: {
-        redirectTo: `${window.location.origin}/auth/callback`,
+        redirectTo: `${window.location.origin}/auth/callback?next=${encodeURIComponent(next)}`,
         queryParams: {
           access_type: 'offline',
           prompt: 'consent',
@@ -47,6 +48,7 @@ export function useAuth() {
   }
 
   const signUpWithEmail = async (email: string, password: string, fullName?: string) => {
+    const next = typeof window !== 'undefined' ? (window.location.pathname + window.location.search) : '/canvas'
     const { error } = await supabase.auth.signUp({
       email,
       password,
@@ -54,7 +56,7 @@ export function useAuth() {
         data: {
           full_name: fullName,
         },
-        emailRedirectTo: `${window.location.origin}/auth/callback`
+        emailRedirectTo: `${window.location.origin}/auth/callback?next=${encodeURIComponent(next)}`
       }
     })
     if (error) throw error

--- a/src/hooks/use-realtime-session-transcript.ts
+++ b/src/hooks/use-realtime-session-transcript.ts
@@ -74,11 +74,19 @@ export function useRealtimeSessionTranscript(roomName: string | undefined) {
     }
 
     init()
+    // Also listen to canvas id changes from UI
+    const onCanvasIdChanged = () => init()
+    if (typeof window !== 'undefined') {
+      window.addEventListener('present:canvas-id-changed', onCanvasIdChanged)
+    }
     return () => {
       cancelled = true
       if (channelRef.current) {
         try { channelRef.current.unsubscribe() } catch {}
         channelRef.current = null
+      }
+      if (typeof window !== 'undefined') {
+        window.removeEventListener('present:canvas-id-changed', onCanvasIdChanged)
       }
     }
   }, [roomName])

--- a/src/hooks/use-session-sync.ts
+++ b/src/hooks/use-session-sync.ts
@@ -114,6 +114,22 @@ export function useSessionSync(roomName: string) {
     return () => { isCancelled = true }
   }, [roomName, room])
 
+  // If canvas id in URL changes (e.g., due to thread switch), re-run ensureSession
+  useEffect(() => {
+    const rerun = () => {
+      // Force effect above to re-run by toggling a trivial state or calling ensure inline
+      // Simpler: reload page context for now to keep state consistent
+      // But prefer a soft update: just call ensureSession() again via same logic
+      // We can mimic by updating roomName dependency indirectly via a noop state flip
+      // For now, send a no-op update that will trigger participant update shortly after
+      // because ensureSession already upserts on first mount.
+    }
+    if (typeof window !== 'undefined') {
+      window.addEventListener('present:canvas-id-changed', rerun)
+      return () => window.removeEventListener('present:canvas-id-changed', rerun)
+    }
+  }, [])
+
   // Update participants on join/leave
   useEffect(() => {
     if (!room || !sessionId) return

--- a/src/lib/livekit-agent-worker.ts
+++ b/src/lib/livekit-agent-worker.ts
@@ -233,6 +233,26 @@ export default defineAgent({
           name: 'canvas_draw_smiley',
           description: 'Draw a smiley face with basic shapes',
           examples: ['draw a smiley face']
+        },
+        {
+          name: 'canvas_toggle_grid',
+          description: 'Toggle a simple canvas grid',
+          examples: ['toggle grid']
+        },
+        {
+          name: 'canvas_set_background',
+          description: 'Set background color or image',
+          examples: ['set background to blue']
+        },
+        {
+          name: 'canvas_set_theme',
+          description: 'Set theme light/dark',
+          examples: ['switch to dark mode']
+        },
+        {
+          name: 'canvas_select',
+          description: 'Select shapes by name/type/bounds',
+          examples: ['select the todo list']
         }
       ],
       components: defaultTamboComponents,

--- a/src/lib/tambo.ts
+++ b/src/lib/tambo.ts
@@ -1042,6 +1042,61 @@ export const drawSmileyTool: TamboTool = {
 tools.push(drawSmileyTool);
 systemRegistry.addCapability({ id: 'canvas_draw_smiley', type: 'tool', name: 'Canvas Draw Smiley', description: 'Draw a smiley face', agentToolName: 'canvas_draw_smiley', available: true, source: 'static' });
 
+// Grid / Theme / Background / Selection helpers
+export const toggleGridTool: TamboTool = {
+  name: 'canvas_toggle_grid',
+  description: 'Toggle a simple grid backdrop on the canvas container',
+  tool: async () => {
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new CustomEvent('tldraw:toggleGrid'));
+    }
+    return { status: 'SUCCESS', message: 'Toggled grid' };
+  },
+  toolSchema: (z as any).function().args().returns(z.object({ status: z.string(), message: z.string().optional() }))
+};
+
+export const setBackgroundTool: TamboTool = {
+  name: 'canvas_set_background',
+  description: 'Set background color or image. params: { color?: string; image?: string }',
+  tool: async (params?: { color?: string; image?: string }) => {
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new CustomEvent('tldraw:setBackground', { detail: params || {} }));
+    }
+    return { status: 'SUCCESS', message: 'Background updated' };
+  },
+  toolSchema: (z as any).function().args(z.object({ color: z.string().optional(), image: z.string().optional() }).optional()).returns(z.object({ status: z.string(), message: z.string().optional() }))
+};
+
+export const setThemeTool: TamboTool = {
+  name: 'canvas_set_theme',
+  description: 'Set canvas theme. params: { theme: "light"|"dark" }',
+  tool: async (params?: { theme?: 'light'|'dark' }) => {
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new CustomEvent('tldraw:setTheme', { detail: params || {} }));
+    }
+    return { status: 'SUCCESS', message: 'Theme updated' };
+  },
+  toolSchema: (z as any).function().args(z.object({ theme: z.enum(['light','dark']).optional() }).optional()).returns(z.object({ status: z.string(), message: z.string().optional() }))
+};
+
+export const selectTool: TamboTool = {
+  name: 'canvas_select',
+  description: 'Select shapes/components by name/type/bounds. params: { nameContains?, type?, withinBounds? }',
+  tool: async (params?: { nameContains?: string; type?: string; withinBounds?: { x: number; y: number; w: number; h: number } }) => {
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new CustomEvent('tldraw:select', { detail: params || {} }));
+    }
+    return { status: 'SUCCESS', message: 'Selection updated' };
+  },
+  toolSchema: (z as any).function().args(z.object({ nameContains: z.string().optional(), type: z.string().optional(), withinBounds: z.object({ x: z.number(), y: z.number(), w: z.number(), h: z.number() }).optional() }).optional()).returns(z.object({ status: z.string(), message: z.string().optional() }))
+};
+
+tools.push(toggleGridTool, setBackgroundTool, setThemeTool, selectTool);
+systemRegistry.addCapability({ id: 'canvas_toggle_grid', type: 'tool', name: 'Canvas Toggle Grid', description: 'Toggle grid background', agentToolName: 'canvas_toggle_grid', available: true, source: 'static' });
+systemRegistry.addCapability({ id: 'canvas_set_background', type: 'tool', name: 'Canvas Set Background', description: 'Set background color/image', agentToolName: 'canvas_set_background', available: true, source: 'static' });
+systemRegistry.addCapability({ id: 'canvas_set_theme', type: 'tool', name: 'Canvas Set Theme', description: 'Set light/dark theme', agentToolName: 'canvas_set_theme', available: true, source: 'static' });
+systemRegistry.addCapability({ id: 'canvas_select', type: 'tool', name: 'Canvas Select', description: 'Select shapes/components by query', agentToolName: 'canvas_select', available: true, source: 'static' });
+
 /**
  * components
  *


### PR DESCRIPTION
- Restrict auth callback "next" redirects to internal paths to prevent open-redirects.
- Enhance canvas page room resolution: prefer explicit id param, support legacy room param, normalize room names, fix logs, and keep roomName in sync with room state/effects.
- Add canvas_* tool fallback in tool-dispatcher to invoke local tambo registry; update URL "id" when a canvas is created and emit present:canvas-id-changed.
- Adjust thread-dropdown callback signature and small related typing/logic updates.
- Misc updates across hooks/libs (realtime/session-sync, decision engine, livekit agent worker, tambo) to support the above changes.