### PR TITLE
Improve canvas creation, retry, and ID change events

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,71 +9,30 @@
  * - A footer section
  */
 
-import { ApiKeyCheck } from "@/components/ApiKeyCheck";
-import Image from "next/image";
+"use client";
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
 
 export default function Home() {
+  const router = useRouter();
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const hash = window.location.hash || '';
+    const next = '/canvas';
+    // If Supabase returned implicit tokens in the hash, forward them to /auth/finish
+    if (hash.includes('access_token=')) {
+      window.location.replace(`/auth/finish?next=${encodeURIComponent(next)}${hash}`);
+      return;
+    }
+    // Otherwise, just go to the canvas
+    router.replace(next);
+  }, [router]);
+
   return (
-    <div className="min-h-screen p-8 flex flex-col items-center justify-center font-[family-name:var(--font-geist-sans)]">
-      <main className="max-w-2xl w-full space-y-8">
-        <div className="flex flex-col items-center">
-          <a href="https://tambo.co" target="_blank" rel="noopener noreferrer">
-            <Image
-              src="/Octo-Icon.svg"
-              alt="Tambo AI Logo"
-              width={80}
-              height={80}
-              className="mb-4"
-            />
-          </a>
-          <h1 className="text-4xl text-center">tambo-ai chat template</h1>
-        </div>
-
-        <div className="w-full space-y-8">
-          <div className="bg-white px-8 py-4">
-            <h2 className="text-xl font-semibold mb-4">Setup Checklist</h2>
-            <ApiKeyCheck>
-              <div className="flex gap-4 flex-wrap">
-                <a
-                  href="/mcp-config"
-                  className="px-6 py-3 rounded-md font-medium shadow-sm transition-colors text-lg mt-4 bg-[#7FFFC3] hover:bg-[#72e6b0] text-gray-800"
-                >
-                  Go to MCP Config →
-                </a>
-              </div>
-            </ApiKeyCheck>
-          </div>
-
-          <div className="bg-white px-8 py-4">
-            <h2 className="text-xl font-semibold mb-4">How it works:</h2>
-            <p className="text-gray-600 mb-4">
-              This is demo of how to build generative UI and MCP servers.
-            </p>
-            <p className="text-gray-600 mb-4">
-              Right now we only support clientside but server-side + auth is
-              coming soon.
-            </p>
-            <div className="flex gap-4 flex-wrap mt-4">
-              <a
-                href="https://tambo.co/docs"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="px-6 py-3 rounded-md font-medium transition-colors text-lg mt-4 border border-gray-300 hover:bg-gray-50"
-              >
-                View Docs
-              </a>
-              <a
-                href="https://smithery.ai/server/@mikechao/brave-search-mcp"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="px-6 py-3 rounded-md font-medium transition-colors text-lg mt-4 border border-gray-300 hover:bg-gray-50"
-              >
-                Get MCP Servers
-              </a>
-            </div>
-          </div>
-        </div>
-      </main>
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-slate-50 via-blue-50/30 to-indigo-50/20">
+      <div className="text-gray-600">Redirecting…</div>
     </div>
   );
 }

--- a/src/components/TldrawSnapshotBroadcaster.tsx
+++ b/src/components/TldrawSnapshotBroadcaster.tsx
@@ -1,15 +1,42 @@
 "use client";
 
-import React, { useEffect, useMemo, useRef } from 'react'
-import { useEditor } from 'tldraw'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
+import type { Editor } from 'tldraw'
 import { useRoomContext } from '@livekit/components-react'
 import { createLiveKitBus } from '@/lib/livekit-bus'
 
-export function TldrawSnapshotBroadcaster() {
-  const editor = useEditor()
+type Props = { editor?: Editor | null }
+
+export function TldrawSnapshotBroadcaster({ editor: propEditor }: Props) {
   const room = useRoomContext()
   const bus = useMemo(() => createLiveKitBus(room), [room])
   const lastSentRef = useRef(0)
+  const [editor, setEditor] = useState<Editor | null>(propEditor ?? null)
+
+  // Capture editor from global hook or event if not provided via props
+  useEffect(() => {
+    if (propEditor && editor !== propEditor) {
+      setEditor(propEditor)
+      return
+    }
+
+    if (editor) return
+
+    // Try global assignment performed on mount
+    try {
+      const maybe = (window as any).__present?.tldrawEditor as Editor | undefined
+      if (maybe) setEditor(maybe)
+    } catch {}
+
+    // Listen for explicit editor-mounted event
+    const handler = (e: Event) => {
+      const ed = (e as CustomEvent).detail?.editor as Editor | undefined
+      if (ed) setEditor(ed)
+    }
+    window.addEventListener('present:editor-mounted', handler as EventListener)
+    return () => window.removeEventListener('present:editor-mounted', handler as EventListener)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [propEditor])
 
   useEffect(() => {
     if (!editor) return

--- a/src/components/ui/tldraw-with-collaboration.tsx
+++ b/src/components/ui/tldraw-with-collaboration.tsx
@@ -21,6 +21,7 @@ import { ComponentStoreContext } from "./tldraw-canvas";
 import type { TamboShapeUtil, TamboShape } from "./tldraw-canvas";
 import { useRoomContext } from "@livekit/components-react";
 import { RoomEvent } from "livekit-client";
+import TldrawSnapshotBroadcaster from '@/components/TldrawSnapshotBroadcaster';
 
 interface TldrawWithCollaborationProps {
   onMount?: (editor: Editor) => void;
@@ -229,6 +230,9 @@ export function TldrawWithCollaboration({
       if (typeof window !== 'undefined') {
         (window as any).__present = (window as any).__present || {};
         (window as any).__present.tldrawEditor = mountedEditor;
+        try {
+          window.dispatchEvent(new CustomEvent('present:editor-mounted', { detail: { editor: mountedEditor } }))
+        } catch {}
       }
 
       // Set up global pin management using side effects
@@ -782,6 +786,8 @@ export function TldrawWithCollaboration({
           overrides={overrides}
           forceMobile={true}
         />
+        {/* Broadcast TLDraw snapshots to LiveKit and persist to Supabase session */}
+        <TldrawSnapshotBroadcaster />
       </ComponentStoreContext.Provider>
 
       {!isStoreReady && (

--- a/src/components/ui/tldraw-with-collaboration.tsx
+++ b/src/components/ui/tldraw-with-collaboration.tsx
@@ -754,6 +754,13 @@ export function TldrawWithCollaboration({
       (mountedEditor as any)._pinnedShapesCleanup = cleanup;
 
       if (onMount) onMount(mountedEditor);
+
+      // Trigger component rehydration for collaborators who didn't load from persistence
+      try {
+        setTimeout(() => {
+          window.dispatchEvent(new CustomEvent('tambo:rehydrateComponents', { detail: {} }))
+        }, 250);
+      } catch {}
     },
     [onMount, overrides, shapeUtils, store]
   );

--- a/src/components/ui/tldraw-with-persistence.tsx
+++ b/src/components/ui/tldraw-with-persistence.tsx
@@ -355,6 +355,14 @@ export function TldrawWithPersistence({
 
   const handleMount = useCallback((mountedEditor: Editor) => {
     setEditor(mountedEditor);
+    // Expose editor globally and emit event for listeners
+    if (typeof window !== 'undefined') {
+      (window as any).__present = (window as any).__present || {};
+      (window as any).__present.tldrawEditor = mountedEditor;
+      try {
+        window.dispatchEvent(new CustomEvent('present:editor-mounted', { detail: { editor: mountedEditor } }))
+      } catch {}
+    }
     onMount?.(mountedEditor);
   }, [onMount]);
 

--- a/src/hooks/use-session-sync.ts
+++ b/src/hooks/use-session-sync.ts
@@ -49,19 +49,17 @@ export function useSessionSync(roomName: string) {
       const canvasId = getCanvasIdFromUrl()
       canvasIdRef.current = canvasId
 
+      // If no canvas id yet, wait until it resolves to avoid creating null-canvas sessions
+      if (canvasId === null) {
+        return;
+      }
+
       // Try to find existing
       let query = supabase
         .from<CanvasSession>('canvas_sessions' as any)
         .select('*')
         .eq('room_name', roomName)
-      
-      if (canvasId === null) {
-        // match rows where canvas_id IS NULL
-        // @ts-ignore - supabase-js has .is for null checks
-        query = (query as any).is('canvas_id', null)
-      } else {
-        query = query.eq('canvas_id', canvasId)
-      }
+        .eq('canvas_id', canvasId)
 
       const { data: existing, error: selectErr } = await query
         .limit(1)


### PR DESCRIPTION
- Dispatch a "present:canvas-id-changed" window event whenever the active canvas id is set (for URL restore and new-creation paths).
- Defer canvas creation until user auth, add a simple retry loop (2 tries) to avoid transient supabase failures, and log/keep loading on persistent failure instead of falling back to an ephemeral tmp id.
- After successful creation, set the canvas name to its id and update URL, localStorage, and room name for stability.
- Convert app/page to a client component and add navigation/useEffect plumbing.
- Update tldraw persistence/collaboration components and related hooks (use-auth, use-canvas-persistence, use-session-sync) to integrate with the new ID-change event and improved persistence flow.