### PR TITLE
Investigate speech-to-ubi pipeline agent issues

### DIFF
--- a/src/components/LiveCaptions.tsx
+++ b/src/components/LiveCaptions.tsx
@@ -362,6 +362,10 @@ const LiveCaptions: React.FC<LiveCaptionsProps> = ({
           if (!prevState) return prevState;
           
           const prevTranscripts = prevState.transcripts;
+          // Guard: prevent duplicates when receiving the same final line via multiple paths
+          if (data.is_final && prevTranscripts.some(t => t.id === transcriptId && t.isFinal)) {
+            return prevState;
+          }
           // Check if this is an update to an existing interim transcript
           const existingIndex = prevTranscripts.findIndex(t => 
             t.speaker === data.speaker && !t.isFinal && 

--- a/src/components/tool-dispatcher.tsx
+++ b/src/components/tool-dispatcher.tsx
@@ -1067,7 +1067,7 @@ Please consider both the processed summary above and the original transcript con
           // If from component, send response via event
           if (isFromComponent) {
             window.dispatchEvent(new CustomEvent('tambo:mcpToolResponse', {
-              detail: { tool: toolName.replace('mcp_', ''), result, error: null, resolved: resolvedToolKey }
+              detail: { tool: toolName, result, error: null, resolved: resolvedToolKey }
             }));
           }
         } else {
@@ -1079,6 +1079,13 @@ Please consider both the processed summary above and the original transcript con
             status: 'SUCCESS',
             message: `MCP tool ${toolName} execution initiated via Tambo`,
           };
+
+          // Also notify component listeners that the request was initiated (no direct result)
+          if (isFromComponent) {
+            window.dispatchEvent(new CustomEvent('tambo:mcpToolResponse', {
+              detail: { tool: toolName, result, error: null, resolved: null }
+            }));
+          }
         }
       } else if (payload.tool === 'youtube_search') {
         // Handle YouTube search with smart filtering

--- a/src/lib/mcp-bridge.ts
+++ b/src/lib/mcp-bridge.ts
@@ -47,8 +47,14 @@ export function initializeMCPBridge() {
     // Return a promise that resolves when we get a response
     return new Promise((resolve, reject) => {
       const responseHandler = (e: any) => {
-        const { tool, result, error } = e.detail;
-        if (tool === toolName) {
+        const { tool, result, error, resolved } = e.detail;
+        const normalize = (s: string) => (s || '').toLowerCase().replace(/^mcp_/, '').trim();
+        const requested = normalize(toolName);
+        const responded = normalize(tool);
+        const resolvedKey = normalize(resolved || '');
+
+        // Match if the responded tool (or resolved key) matches requested (ignoring mcp_ prefix)
+        if (responded === requested || (!!resolvedKey && resolvedKey === requested)) {
           window.removeEventListener('tambo:mcpToolResponse', responseHandler);
           if (error) reject(error);
           else resolve(result);


### PR DESCRIPTION
Normalize MCP bridge response matching, ensure ToolDispatcher sends responses to component sub-agents, and add a duplicate guard for live captions to improve agent-to-component communication and stability.

These changes address multiple issues in the speech-to-Ubi pipeline, including agent-to-component MCP call timeouts and mismatches, sub-agents hanging due to missing responses, and duplicate transcripts appearing in live captions during state replays.

---
<a href="https://cursor.com/background-agent?bcId=bc-14253566-8a14-401b-8978-aadf62c78ff8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-14253566-8a14-401b-8978-aadf62c78ff8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

