### PR TITLE
Fix codex dependency version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@tldraw/tlschema": "^3.13.3",
         "@uidotdev/usehooks": "^2.4.1",
         "class-variance-authority": "^0.7.1",
-        "codex": "^0.31.0",
+        "codex": "^0.2.3",
         "dompurify": "^3.0.6",
         "framer-motion": "^12.16.0",
         "highlight.js": "^11.11.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@tldraw/tlschema": "^3.13.3",
     "@uidotdev/usehooks": "^2.4.1",
     "class-variance-authority": "^0.7.1",
-    "codex": "^0.31.0",
+    "codex": "^0.2.3",
     "dompurify": "^3.0.6",
     "framer-motion": "^12.16.0",
     "highlight.js": "^11.11.1",


### PR DESCRIPTION
## Summary
- update the codex dependency range to the latest published version
- align the lockfile entry with the updated codex range

## Testing
- npm install --no-progress
- npm run lint *(fails: numerous pre-existing lint errors)*
- npm test *(fails: jest syntax error in src/components/ui/tldraw-canvas.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68cbd4917c388326b121bcf7f6cac497