### PR TITLE
Trigger steward flowchart pipeline from ToolDispatcher

### DIFF
--- a/src/app/api/steward/run/route.ts
+++ b/src/app/api/steward/run/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { runFlowchartSteward } from '@/lib/agents/subagents/flowchart-steward';
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json().catch(() => null);
+    const roomRaw = typeof body?.room === 'string' ? body.room : undefined;
+    const docRaw = typeof body?.docId === 'string' ? body.docId : undefined;
+    const windowMsRaw = typeof body?.windowMs === 'number' ? body.windowMs : undefined;
+
+    const room = roomRaw?.trim();
+    const docId = docRaw?.trim();
+    if (!room || !docId) {
+      return NextResponse.json({ error: 'room and docId are required' }, { status: 400 });
+    }
+
+    const windowMs = windowMsRaw ? Math.max(1000, Math.min(600000, windowMsRaw)) : undefined;
+    const effectiveWindow = windowMs ?? 60000;
+
+    try {
+      console.log('[Steward][run] starting', { room, docId, windowMs: effectiveWindow });
+    } catch {}
+
+    void runFlowchartSteward({ room, docId, windowMs: effectiveWindow })
+      .then((result) => {
+        try {
+          console.log('[Steward][run] completed', { room, docId, windowMs: effectiveWindow, result });
+        } catch {}
+      })
+      .catch((error) => {
+        try {
+          console.error('[Steward][run] failed', { room, docId, windowMs: effectiveWindow, error });
+        } catch {}
+      });
+
+    return NextResponse.json({ status: 'running' });
+  } catch (error: any) {
+    return NextResponse.json({ error: error?.message || 'Unknown error' }, { status: 500 });
+  }
+}

--- a/src/lib/agents/realtime/voice-agent.ts
+++ b/src/lib/agents/realtime/voice-agent.ts
@@ -10,13 +10,15 @@ import * as openai from '@livekit/agents-plugin-openai';
 export default defineAgent({
   entry: async (job: JobContext) => {
     await job.connect();
-    const instructions = `You control the UI via exactly two tools: create_component and update_component. Keep text responses short.
+    const instructions = `You control the UI via create_component and update_component for direct manipulation, and may delegate work via dispatch_to_conductor. Keep text responses short.
 
 TOOLS (JSON schemas):
 1) create_component({ type: string, spec: string })
    - Create a new component on the canvas. 'type' is the component type, 'spec' is the initial content.
 2) update_component({ componentId: string, patch: string })
    - Update an existing component with a natural-language patch or structured fields.
+3) dispatch_to_conductor({ task: string, params: object })
+   - Ask the conductor to run a steward/sub-agent task on your behalf.
 
 Always return to tool calls rather than long monologues.`;
     const model = new openai.realtime.RealtimeModel({ model: 'gpt-realtime', instructions, modalities: ['text'] });
@@ -42,8 +44,14 @@ Always return to tool calls rather than long monologues.`;
         };
         await job.room.localParticipant?.publishData(new TextEncoder().encode(JSON.stringify(toolCallEvent)), { reliable: true, topic: 'tool_call' });
         session.conversation.item.create({ type: 'function_call_output', call_id: evt.call_id, output: JSON.stringify({ status: 'DISPATCHED' }) });
+        try {
+          (session as any).response?.create?.({ instructions: 'continue' });
+        } catch {}
       } catch (e) {
         session.conversation.item.create({ type: 'function_call_output', call_id: evt.call_id, output: JSON.stringify({ status: 'ERROR', message: String(e) }) });
+        try {
+          (session as any).response?.create?.({ instructions: 'continue' });
+        } catch {}
       }
     });
 

--- a/src/lib/agents/subagents/flowchart-steward.ts
+++ b/src/lib/agents/subagents/flowchart-steward.ts
@@ -22,7 +22,11 @@ const get_current_flowchart = tool({
   description: 'Fetch current flowchart doc for a room/docId from Supabase.',
   parameters: GetCurrentArgs,
   async execute({ room, docId }) {
-    return await getFlowchartDoc(room, docId);
+    const doc = await getFlowchartDoc(room, docId);
+    try {
+      console.log('📄 [Steward] get_current_flowchart', { room, docId, version: doc?.version ?? 0 });
+    } catch {}
+    return doc;
   },
 });
 
@@ -32,7 +36,12 @@ const get_context = tool({
   parameters: GetContextArgs,
   async execute({ room, windowMs }) {
     const spanMs = typeof windowMs === 'number' ? windowMs : 60000;
-    return await getTranscriptWindow(room, spanMs);
+    const window = await getTranscriptWindow(room, spanMs);
+    try {
+      const count = Array.isArray(window?.transcript) ? window.transcript.length : 0;
+      console.log('📝 [Steward] get_context', { room, windowMs: spanMs, lines: count });
+    } catch {}
+    return window;
   },
 });
 
@@ -41,28 +50,83 @@ const commit_flowchart = tool({
   description: 'Commit a new version of the flowchart with optimistic concurrency.',
   parameters: CommitArgs,
   async execute({ room, docId, format, doc, rationale, prevVersion }) {
-    // Minimal safety: if format is markdown/streamdown, require at least one mermaid fence
     if (format !== 'mermaid') {
       const hasFence = /```mermaid[\s\S]*?```/i.test(doc);
       if (!hasFence) {
         throw new Error('INVALID_DOC: Missing mermaid code fence in markdown/streamdown');
       }
     }
-    const res = await commitFlowchartDoc(room, docId, {
-      format,
-      doc,
-      prevVersion: typeof prevVersion === 'number' ? prevVersion : undefined,
-      rationale: typeof rationale === 'string' ? rationale : undefined,
-    });
-    try {
-      const base = process.env.NEXT_PUBLIC_BASE_URL || process.env.BASE_URL || '';
-      await fetch(`${base}/api/steward/commit`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ room, componentId: docId, flowchartDoc: doc, format, version: res.version }),
-      }).catch(() => {});
-    } catch {}
-    return res;
+
+    const resolveBroadcastUrl = () => {
+      const candidates = [
+        process.env.STEWARD_COMMIT_BASE_URL,
+        process.env.NEXT_PUBLIC_BASE_URL,
+        process.env.BASE_URL,
+        process.env.NEXT_PUBLIC_SITE_URL,
+        process.env.SITE_URL,
+        process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : undefined,
+        'http://127.0.0.1:3000',
+      ];
+      for (const candidate of candidates) {
+        if (!candidate) continue;
+        try {
+          const normalized = candidate.startsWith('http') ? candidate : `https://${candidate}`;
+          return new URL('/api/steward/commit', normalized).toString();
+        } catch {
+          continue;
+        }
+      }
+      return null;
+    };
+
+    let expectedPrev = typeof prevVersion === 'number' ? prevVersion : undefined;
+    for (let attempt = 0; attempt < 2; attempt++) {
+      try {
+        const res = await commitFlowchartDoc(room, docId, {
+          format,
+          doc,
+          prevVersion: expectedPrev,
+          rationale: typeof rationale === 'string' ? rationale : undefined,
+        });
+        try {
+          console.log('🧾 [Steward] commit_flowchart', { room, docId, prevVersion: expectedPrev ?? null, nextVersion: res.version });
+        } catch {}
+
+        const broadcastUrl = resolveBroadcastUrl();
+        if (broadcastUrl) {
+          try {
+            await fetch(broadcastUrl, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ room, componentId: docId, flowchartDoc: doc, format, version: res.version }),
+            });
+            try {
+              console.log('📡 [Steward] broadcast_flowchart', { room, docId, version: res.version, url: broadcastUrl });
+            } catch {}
+          } catch (err) {
+            try {
+              console.error('⚠️ [Steward] broadcast failed', { room, docId, error: err instanceof Error ? err.message : err });
+            } catch {}
+          }
+        } else {
+          try {
+            console.warn('⚠️ [Steward] broadcast URL unavailable, skipping LiveKit patch');
+          } catch {}
+        }
+        return res;
+      } catch (error) {
+        if (attempt === 0 && error instanceof Error && error.message === 'CONFLICT') {
+          const latest = await getFlowchartDoc(room, docId);
+          try {
+            console.warn('⚠️ [Steward] commit conflict', { room, docId, attemptedPrev: expectedPrev, latestVersion: latest.version });
+          } catch {}
+          expectedPrev = latest.version;
+          continue;
+        }
+        throw error;
+      }
+    }
+    throw new Error('FAILED_COMMIT');
   },
 });
 
@@ -75,8 +139,16 @@ export const flowchartSteward = new Agent({
 });
 
 export async function runFlowchartSteward(params: { room: string; docId: string; windowMs?: number }) {
-  const prompt = `Update the flowchart for room ${params.room} doc ${params.docId} with params: ${JSON.stringify(params)}`;
+  const windowMs = params.windowMs ?? 60000;
+  try {
+    console.log('🚀 [Steward] runFlowchartSteward.start', { room: params.room, docId: params.docId, windowMs });
+  } catch {}
+  const prompt = `Update the flowchart for room ${params.room} doc ${params.docId} with params: ${JSON.stringify({ ...params, windowMs })}`;
   const result = await run(flowchartSteward, prompt);
+  try {
+    const preview = typeof result.finalOutput === 'string' ? result.finalOutput.slice(0, 200) : null;
+    console.log('✅ [Steward] runFlowchartSteward.complete', { room: params.room, docId: params.docId, windowMs, preview });
+  } catch {}
   return result.finalOutput;
 }
 


### PR DESCRIPTION
## Summary
- ensure ToolDispatcher recognizes steward triggers, creates the mermaid stream component, debounces `/api/steward/run`, and blocks non-whitelisted tools while logging every step
- teach the canvas collaboration layer to consume steward `ui_update` payloads verbatim, clear incremental session state, and log the applied patch
- harden the steward server pieces by logging start/finish, defaulting the transcript window, retrying conflicted commits, and rebroadcasting flowchart docs; prompt the voice agent to continue after tool calls

## Testing
- npm run lint *(fails: `next` binary missing in this environment)*
- npm test *(fails: `jest` binary missing in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbcbaedc408326aae100d6f9ef62f8