### PR TITLE
Refactor canvas interactions into reusable hooks

### DIFF
--- a/src/components/ui/canvas/canvas-space.tsx
+++ b/src/components/ui/canvas/canvas-space.tsx
@@ -1,53 +1,15 @@
-/**
- * CanvasSpace Component
- *
- * This is the main canvas component that displays the Tldraw canvas and handles
- * the creation and management of custom shapes.
- *
- * DEVELOPER NOTES:
- * - Uses TldrawWithPersistence for persistent canvas state
- * - Handles custom shape creation and updates
- * - Manages message-to-shape mapping for persistent rendering
- * - Handles component addition and deletion
- * - Implements debounced component addition for performance
- * - Manages component state with optimistic updates
- * - Handles custom 'custom:showComponent' events
- * - Manages component store for persistent rendering
- * - Handles thread state changes and resets
- *
- * FEATURES:
- * - Dynamic masonry layout for responsive rendering
- * - Drag-and-drop functionality for component reordering
- * - Persistent rendering of components across thread state changes
- * - Optimized component addition with debouncing
- * - Toast notifications for UI feedback
- *
- * DEPENDENCIES:
- * - @/hooks/use-auth: Authentication state
- * - tldraw: Canvas editor
- * - react-hot-toast: Toast notifications
- * - nanoid: Unique ID generation
- *
- * STYLING:
- * - Uses Tailwind CSS for styling
- * - Implements responsive design with flexbox
- * - Uses gradient background for modern aesthetic
- * - Handles overflow with relative positioning
- */
+/** CanvasSpace hosts the TLDraw editor and coordinates canvas features. */
 
 'use client';
-
 import { cn, createLogger } from '@/lib/utils';
-import { useEffect, useRef, useState, useCallback } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { usecustom } from '@custom-ai/react';
 import * as React from 'react';
 import dynamic from 'next/dynamic';
 import type { Editor } from 'tldraw';
-import { nanoid } from 'nanoid';
 import { Toaster } from 'react-hot-toast';
 
 import { ComponentRegistry } from '@/lib/component-registry';
-import { createShapeId } from 'tldraw';
 import { CanvasLiveKitContext } from './livekit/livekit-room-connector';
 import { useRoomContext } from '@livekit/components-react';
 import { createLiveKitBus } from '../../lib/livekit/livekit-bus';
@@ -57,6 +19,7 @@ import {
   useCanvasRehydration,
   useCanvasThreadReset,
   useCanvasEvents,
+  useCanvasInteractions,
 } from './hooks';
 
 // Dynamic imports for heavy tldraw components - only load when needed
@@ -139,44 +102,6 @@ export function CanvasSpace({ className, onTranscriptToggle }: CanvasSpaceProps)
   const bus = createLiveKitBus(room);
   const logger = createLogger('CanvasSpace');
 
-  // Component toolbox toggle - creates toolbox shape on canvas
-  const toggleComponentToolbox = useCallback(() => {
-    if (!editor) {
-      console.warn('Editor not available');
-      return;
-    }
-
-    // Check if toolbox already exists
-    const existingToolbox = editor.getCurrentPageShapes().find((shape) => shape.type === 'toolbox');
-
-    if (existingToolbox) {
-      // Remove existing toolbox
-      editor.deleteShapes([existingToolbox.id]);
-      logger.info('🗑️ Removed existing component toolbox');
-    } else {
-      // Create new toolbox shape
-      const viewport = editor.getViewportPageBounds();
-      const TOOLBOX_W = 56;
-      const TOOLBOX_H = 560; // taller vertical column
-      const x = viewport ? viewport.minX + 24 : 24; // near left edge
-      const y = viewport ? viewport.midY - TOOLBOX_H / 2 : 24; // vertically centered
-
-      editor.createShape({
-        id: createShapeId(`toolbox-${nanoid()}`),
-        type: 'toolbox',
-        x,
-        y,
-        props: {
-          w: TOOLBOX_W,
-          h: TOOLBOX_H,
-          name: 'Component Toolbox',
-        },
-      });
-
-      logger.info('✅ Created component toolbox shape');
-    }
-  }, [editor, logger]);
-
   const {
     componentStore,
     setMessageIdToShapeIdMap,
@@ -186,6 +111,12 @@ export function CanvasSpace({ className, onTranscriptToggle }: CanvasSpaceProps)
     queuePendingComponent,
     drainPendingComponents,
   } = useCanvasComponentStore(editor, logger);
+
+  const { onDragOver, onDrop, toggleComponentToolbox, showOnboarding } = useCanvasInteractions({
+    editor,
+    componentStore,
+    logger,
+  });
 
   useCanvasRehydration({
     editor,
@@ -312,62 +243,6 @@ export function CanvasSpace({ className, onTranscriptToggle }: CanvasSpaceProps)
     return () => clearTimeout(timeoutId);
   }, [thread?.messages, editor, addComponentToCanvas, addedMessageIds]);
 
-  // Helper function to show onboarding
-  const showOnboarding = useCallback(() => {
-    logger.info('🆘 Help button clicked - creating onboarding guide');
-
-    if (!editor) {
-      console.warn('Editor not available');
-      return;
-    }
-
-    // Create OnboardingGuide component directly
-    const shapeId = createShapeId(nanoid());
-    const OnboardingGuideComponent = components.find(
-      (c) => c.name === 'OnboardingGuide',
-    )?.component;
-
-    if (OnboardingGuideComponent) {
-      const componentInstance = React.createElement(OnboardingGuideComponent, {
-        __custom_message_id: shapeId,
-        context: 'canvas',
-        autoStart: true,
-        state: {},
-        updateState: (patch: Record<string, unknown> | ((prev: any) => any)) => {
-          if (!editor) return;
-          const prev = {} as Record<string, unknown>;
-          const next = typeof patch === 'function' ? (patch as any)(prev) : { ...prev, ...patch };
-          editor.updateShapes([{ id: shapeId, type: 'custom' as const, props: { state: next } }]);
-        },
-      });
-      componentStore.current.set(shapeId, componentInstance);
-      try {
-        window.dispatchEvent(new Event('present:component-store-updated'));
-      } catch { }
-
-      // Get center of viewport for placement
-      const viewport = editor.getViewportPageBounds();
-      const x = viewport ? viewport.midX - 200 : 100;
-      const y = viewport ? viewport.midY - 150 : 100;
-
-      editor.createShape({
-        id: shapeId,
-        type: 'custom',
-        x,
-        y,
-        props: {
-          w: 400,
-          h: 300,
-          customComponent: shapeId,
-          name: 'OnboardingGuide',
-        },
-      });
-
-      logger.info('✅ Onboarding guide created successfully');
-    } else {
-      logger.warn('OnboardingGuide component not found');
-    }
-  }, [editor, componentStore, logger]);
 
   // Export functionality is now handled by TldrawWithPersistence component
 
@@ -385,45 +260,8 @@ export function CanvasSpace({ className, onTranscriptToggle }: CanvasSpaceProps)
       {/* Use tldraw with collaboration for sync support */}
       <div
         className="absolute inset-0 z-0"
-        onDragOver={(e) => {
-          e.preventDefault();
-          e.dataTransfer.dropEffect = 'copy';
-        }}
-        onDrop={(e) => {
-          e.preventDefault();
-          e.stopPropagation();
-          const componentType = e.dataTransfer.getData('application/custom-component');
-          if (componentType && editor) {
-            logger.info('📥 Dropping component:', componentType);
-            const shapeId = createShapeId(nanoid());
-            const Component = components.find((c) => c.name === componentType)?.component;
-            if (Component) {
-              const componentInstance = React.createElement(Component, {
-                __custom_message_id: shapeId,
-              });
-              componentStore.current.set(shapeId, componentInstance);
-              try {
-                window.dispatchEvent(new Event('present:component-store-updated'));
-              } catch { }
-              const pos = editor.screenToPage({ x: e.clientX, y: e.clientY });
-              editor.createShape({
-                id: shapeId,
-                type: 'custom',
-                x: pos.x,
-                y: pos.y,
-                props: {
-                  w: 300,
-                  h: 200,
-                  customComponent: shapeId,
-                  name: componentType,
-                },
-              });
-              logger.info('✅ Component dropped successfully');
-            } else {
-              logger.warn('Failed to find component for type:', componentType);
-            }
-          }
-        }}
+        onDragOver={onDragOver}
+        onDrop={onDrop}
       >
         <TldrawWithCollaboration
           key={livekitCtx?.roomName || 'no-room'}

--- a/src/components/ui/canvas/hooks/index.ts
+++ b/src/components/ui/canvas/hooks/index.ts
@@ -2,3 +2,4 @@ export * from './useCanvasComponentStore';
 export * from './useCanvasRehydration';
 export * from './useCanvasThreadReset';
 export * from './useCanvasEvents';
+export * from './useCanvasInteractions';

--- a/src/components/ui/canvas/hooks/useCanvasInteractions.ts
+++ b/src/components/ui/canvas/hooks/useCanvasInteractions.ts
@@ -1,0 +1,141 @@
+import * as React from 'react';
+import { useCallback } from 'react';
+import { nanoid } from 'nanoid';
+import type { Editor } from 'tldraw';
+import { createShapeId } from 'tldraw';
+
+import { components } from '@/lib/custom';
+
+import type { CanvasLogger } from './useCanvasComponentStore';
+import { createOnboardingGuide } from '../utils/createOnboardingGuide';
+
+export interface CanvasInteractionsOptions {
+  editor: Editor | null;
+  componentStore: React.MutableRefObject<Map<string, React.ReactNode>>;
+  logger: CanvasLogger;
+}
+
+export interface CanvasInteractionsApi {
+  onDragOver: (event: React.DragEvent<HTMLDivElement>) => void;
+  onDrop: (event: React.DragEvent<HTMLDivElement>) => void;
+  toggleComponentToolbox: () => void;
+  showOnboarding: () => void;
+}
+
+export function useCanvasInteractions({
+  editor,
+  componentStore,
+  logger,
+}: CanvasInteractionsOptions): CanvasInteractionsApi {
+  const handleDragOver = useCallback((event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'copy';
+  }, []);
+
+  const handleDrop = useCallback(
+    (event: React.DragEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      event.stopPropagation();
+
+      const componentType = event.dataTransfer.getData('application/custom-component');
+      if (!componentType) {
+        return;
+      }
+
+      if (!editor) {
+        logger.warn('Editor not available, cannot drop component.');
+        return;
+      }
+
+      logger.info('📥 Dropping component:', componentType);
+
+      const Component = components.find((c) => c.name === componentType)?.component;
+      if (!Component) {
+        logger.warn('Failed to find component for type:', componentType);
+        return;
+      }
+
+      const shapeId = createShapeId(nanoid());
+      const componentInstance = React.createElement(Component, {
+        __custom_message_id: shapeId,
+      });
+
+      componentStore.current.set(shapeId, componentInstance);
+      try {
+        window.dispatchEvent(new Event('present:component-store-updated'));
+      } catch {
+        /* ignore */
+      }
+
+      const position = editor.screenToPage({ x: event.clientX, y: event.clientY });
+      editor.createShape({
+        id: shapeId,
+        type: 'custom',
+        x: position.x,
+        y: position.y,
+        props: {
+          w: 300,
+          h: 200,
+          customComponent: shapeId,
+          name: componentType,
+        },
+      });
+
+      logger.info('✅ Component dropped successfully');
+    },
+    [componentStore, editor, logger],
+  );
+
+  const toggleComponentToolbox = useCallback(() => {
+    if (!editor) {
+      logger.warn('Editor not available, cannot toggle toolbox');
+      return;
+    }
+
+    const existingToolbox = editor
+      .getCurrentPageShapes()
+      .find((shape) => shape.type === 'toolbox');
+
+    if (existingToolbox) {
+      editor.deleteShapes([existingToolbox.id]);
+      logger.info('🗑️ Removed existing component toolbox');
+      return;
+    }
+
+    const viewport = editor.getViewportPageBounds();
+    const TOOLBOX_W = 56;
+    const TOOLBOX_H = 560;
+    const x = viewport ? viewport.minX + 24 : 24;
+    const y = viewport ? viewport.midY - TOOLBOX_H / 2 : 24;
+
+    editor.createShape({
+      id: createShapeId(`toolbox-${nanoid()}`),
+      type: 'toolbox',
+      x,
+      y,
+      props: {
+        w: TOOLBOX_W,
+        h: TOOLBOX_H,
+        name: 'Component Toolbox',
+      },
+    });
+
+    logger.info('✅ Created component toolbox shape');
+  }, [editor, logger]);
+
+  const showOnboarding = useCallback(() => {
+    if (!editor) {
+      logger.warn('Editor not available, cannot show onboarding');
+      return;
+    }
+
+    createOnboardingGuide({ editor, componentStore, logger });
+  }, [componentStore, editor, logger]);
+
+  return {
+    onDragOver: handleDragOver,
+    onDrop: handleDrop,
+    toggleComponentToolbox,
+    showOnboarding,
+  };
+}

--- a/src/components/ui/canvas/speech-transcription.tsx
+++ b/src/components/ui/canvas/speech-transcription.tsx
@@ -112,7 +112,7 @@ export function SpeechTranscription({
         room.off('dataReceived', handleDataReceived);
       };
     }
-  }, [room, onTranscription]);
+  }, [room, onTranscription, addTranscription]);
 
   // Monitor agent status
   useEffect(() => {

--- a/src/components/ui/canvas/utils/createOnboardingGuide.ts
+++ b/src/components/ui/canvas/utils/createOnboardingGuide.ts
@@ -1,0 +1,78 @@
+import * as React from 'react';
+import { nanoid } from 'nanoid';
+import type { Editor } from 'tldraw';
+import { createShapeId } from 'tldraw';
+
+import { components } from '@/lib/custom';
+
+import type { CanvasLogger } from '../hooks/useCanvasComponentStore';
+
+export interface CreateOnboardingGuideOptions {
+  editor: Editor;
+  componentStore: React.MutableRefObject<Map<string, React.ReactNode>>;
+  logger: CanvasLogger;
+}
+
+export function createOnboardingGuide({
+  editor,
+  componentStore,
+  logger,
+}: CreateOnboardingGuideOptions) {
+  logger.info('🆘 Help button clicked - creating onboarding guide');
+
+  const shapeId = createShapeId(nanoid());
+  const OnboardingGuideComponent = components.find((c) => c.name === 'OnboardingGuide')?.component;
+
+  if (!OnboardingGuideComponent) {
+    logger.warn('OnboardingGuide component not found');
+    return false;
+  }
+
+  const componentInstance = React.createElement(OnboardingGuideComponent, {
+    __custom_message_id: shapeId,
+    context: 'canvas',
+    autoStart: true,
+    state: {},
+    updateState: (patch: Record<string, unknown> | ((prev: any) => any)) => {
+      const previousState: Record<string, unknown> = {};
+      const nextState =
+        typeof patch === 'function'
+          ? (patch as (prev: Record<string, unknown>) => Record<string, unknown>)(previousState)
+          : { ...previousState, ...(patch || {}) };
+      editor.updateShapes([
+        {
+          id: shapeId,
+          type: 'custom' as const,
+          props: { state: nextState },
+        },
+      ]);
+    },
+  });
+
+  componentStore.current.set(shapeId, componentInstance);
+  try {
+    window.dispatchEvent(new Event('present:component-store-updated'));
+  } catch {
+    /* ignore */
+  }
+
+  const viewport = editor.getViewportPageBounds();
+  const x = viewport ? viewport.midX - 200 : 100;
+  const y = viewport ? viewport.midY - 150 : 100;
+
+  editor.createShape({
+    id: shapeId,
+    type: 'custom',
+    x,
+    y,
+    props: {
+      w: 400,
+      h: 300,
+      customComponent: shapeId,
+      name: 'OnboardingGuide',
+    },
+  });
+
+  logger.info('✅ Onboarding guide created successfully');
+  return true;
+}


### PR DESCRIPTION
## Summary
- extract drag-and-drop, toolbox toggling, and onboarding creation into `useCanvasInteractions` plus `createOnboardingGuide` for stable canvas APIs
- simplify `canvas-space.tsx` to focus on composition while preserving component store, queueing, and LiveKit event wiring
- address eslint dependency warning by updating `speech-transcription` effect dependencies and record LOC changes (canvas-space.tsx 461 → 299, useCanvasInteractions.ts 141, createOnboardingGuide.ts 78)

## Testing
- npx eslint --ext .ts,.tsx src/components/ui/canvas

------
https://chatgpt.com/codex/tasks/task_e_68dd6a87f1f0832683bea1842311d2e2