### PR TITLE
feat: add canvas steward for TLDraw automation

### DIFF
--- a/src/app/api/conductor/dispatch/route.ts
+++ b/src/app/api/conductor/dispatch/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { callConductor } from '@/lib/agents/conductor';
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const task = typeof body?.task === 'string' ? body.task.trim() : '';
+    const params = (body?.params && typeof body.params === 'object' ? body.params : {}) as Record<string, unknown>;
+    if (!task) {
+      return NextResponse.json({ error: 'Missing task' }, { status: 400 });
+    }
+    const finalOutput = await callConductor(task, params);
+    return NextResponse.json({ finalOutput: finalOutput ?? null });
+  } catch (error) {
+    console.error('[Conductor][dispatch] error', error);
+    return NextResponse.json({ error: 'Failed to dispatch task' }, { status: 500 });
+  }
+}

--- a/src/lib/agents/realtime/voice-agent.ts
+++ b/src/lib/agents/realtime/voice-agent.ts
@@ -21,6 +21,8 @@ TOOLS (JSON schemas):
    - Update an existing component with a natural-language patch or structured fields.
 3) dispatch_to_conductor({ task: string, params: object })
    - Ask the conductor to run a steward/sub-agent task on your behalf.
+   - Use task 'flowchart.update' for Mermaid diagrams (params: { room, docId, summary }).
+   - Use task 'canvas.autodraw' for TLDraw canvas work (params: { room, request, summary }).
 
 Always return to tool calls rather than long monologues.`;
     const model = new openai.realtime.RealtimeModel({ model: 'gpt-realtime', instructions, modalities: ['text'] });

--- a/src/lib/agents/shared/__tests__/supabase-context.test.ts
+++ b/src/lib/agents/shared/__tests__/supabase-context.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from '@jest/globals';
+import { summarizeCanvasSnapshot } from '../supabase-context';
+
+describe('summarizeCanvasSnapshot', () => {
+  it('returns sorted lightweight summaries for TLDraw shapes', () => {
+    const snapshot = {
+      store: {
+        'shape:rect1': {
+          typeName: 'shape',
+          id: 'shape:rect1',
+          type: 'geo',
+          index: 'a1',
+          x: 10,
+          y: 20,
+          props: { w: 120, h: 80, text: 'Box' },
+        },
+        'camera:page': { typeName: 'camera', id: 'camera:page' },
+        'shape:ellipse1': {
+          typeName: 'shape',
+          id: 'shape:ellipse1',
+          type: 'geo',
+          index: 'a2',
+          x: 100,
+          y: 120,
+          props: { w: 60, h: 60, label: 'Circle' },
+        },
+      },
+    };
+
+    const result = summarizeCanvasSnapshot(snapshot, 10);
+    expect(result.shapeCount).toBe(2);
+    expect(result.shapes).toEqual([
+      expect.objectContaining({ id: 'shape:rect1', type: 'geo', text: 'Box', index: 'a1' }),
+      expect.objectContaining({ id: 'shape:ellipse1', type: 'geo', label: 'Circle', index: 'a2' }),
+    ]);
+    expect(result.updatedAt).toEqual(expect.any(Number));
+  });
+});

--- a/src/lib/agents/shared/livekit-dispatch.ts
+++ b/src/lib/agents/shared/livekit-dispatch.ts
@@ -1,0 +1,66 @@
+import { RoomServiceClient, DataPacket_Kind } from 'livekit-server-sdk';
+import { config } from 'dotenv';
+import { join } from 'path';
+
+try {
+  config({ path: join(process.cwd(), '.env.local') });
+} catch {}
+
+let cachedClient: RoomServiceClient | null = null;
+
+const resolveLivekitConfig = () => {
+  const host =
+    process.env.LIVEKIT_URL || process.env.NEXT_PUBLIC_LK_SERVER_URL || process.env.LIVEKIT_HOST || '';
+  const apiKey = process.env.LIVEKIT_API_KEY || '';
+  const apiSecret = process.env.LIVEKIT_API_SECRET || '';
+  if (!host || !apiKey || !apiSecret) {
+    throw new Error('LiveKit server credentials missing: set LIVEKIT_URL, LIVEKIT_API_KEY, LIVEKIT_API_SECRET');
+  }
+  return { host, apiKey, apiSecret };
+};
+
+const getClient = () => {
+  if (cachedClient) {
+    return cachedClient;
+  }
+  const { host, apiKey, apiSecret } = resolveLivekitConfig();
+  cachedClient = new RoomServiceClient(host, apiKey, apiSecret);
+  return cachedClient;
+};
+
+export async function broadcastToolCall(
+  room: string,
+  payload: { tool: string; params?: Record<string, unknown>; source?: string; metadata?: Record<string, unknown> },
+) {
+  if (!room || typeof room !== 'string') {
+    throw new Error('Room name is required to broadcast tool calls');
+  }
+  const normalizedRoom = room.trim();
+  if (!normalizedRoom) {
+    throw new Error('Room name is required to broadcast tool calls');
+  }
+
+  const id = `steward-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+  const now = Date.now();
+  const event = {
+    id,
+    roomId: normalizedRoom,
+    type: 'tool_call' as const,
+    payload: {
+      tool: payload.tool,
+      params: payload.params ?? {},
+      context: {
+        source: payload.source ?? 'canvas-steward',
+        timestamp: now,
+        ...(payload.metadata ?? {}),
+      },
+    },
+    timestamp: now,
+    source: payload.source ?? 'canvas-steward',
+  };
+
+  const client = getClient();
+  const encoded = new TextEncoder().encode(JSON.stringify(event));
+  await client.sendData(normalizedRoom, encoded, DataPacket_Kind.RELIABLE, { topic: 'tool_call' });
+  return { ok: true, id };
+}

--- a/src/lib/agents/subagents/canvas-steward-registry.ts
+++ b/src/lib/agents/subagents/canvas-steward-registry.ts
@@ -1,0 +1,8 @@
+import type { Agent } from '@openai/agents';
+import { canvasSteward, runCanvasSteward } from './canvas-steward';
+
+export const activeCanvasSteward: Agent = canvasSteward;
+
+export async function runActiveCanvasSteward(params: { room: string; request: string; summary?: string }) {
+  return runCanvasSteward(params);
+}

--- a/src/lib/agents/subagents/canvas-steward.ts
+++ b/src/lib/agents/subagents/canvas-steward.ts
@@ -1,0 +1,152 @@
+import { Agent, run, tool } from '@openai/agents';
+import { z } from 'zod';
+import {
+  getCanvasSnapshot,
+  summarizeCanvasSnapshot,
+  getTranscriptWindow,
+  type CanvasStateSummary,
+} from '../shared/supabase-context';
+import { broadcastToolCall } from '../shared/livekit-dispatch';
+
+const logWithTs = <T extends Record<string, unknown>>(label: string, payload: T) => {
+  try {
+    console.log(label, { ts: new Date().toISOString(), ...payload });
+  } catch {}
+};
+
+const CanvasStateArgs = z.object({
+  room: z.string().min(1),
+  maxShapes: z.number().int().min(1).max(300).optional(),
+  includeSnapshot: z.boolean().optional(),
+});
+
+const GetContextArgs = z.object({
+  room: z.string().min(1),
+  windowMs: z.number().int().min(1_000).max(600_000).nullable().optional(),
+});
+
+const SUPPORTED_CANVAS_TOOLS = [
+  'canvas_focus',
+  'canvas_zoom_all',
+  'canvas_create_note',
+  'canvas_pin_selected',
+  'canvas_unpin_selected',
+  'canvas_lock_selected',
+  'canvas_unlock_selected',
+  'canvas_arrange_grid',
+  'canvas_create_rectangle',
+  'canvas_create_ellipse',
+  'canvas_align_selected',
+  'canvas_distribute_selected',
+  'canvas_draw_smiley',
+  'canvas_toggle_grid',
+  'canvas_set_background',
+  'canvas_set_theme',
+  'canvas_select',
+  'canvas_select_by_note',
+  'canvas_color_shape',
+  'canvas_delete_shape',
+  'canvas_rename_note',
+  'canvas_connect_shapes',
+  'canvas_label_arrow',
+  'canvas_list_shapes',
+] as const;
+
+const CanvasToolName = z.enum(SUPPORTED_CANVAS_TOOLS);
+
+const ExecuteActionsArgs = z.object({
+  room: z.string().min(1),
+  actions: z
+    .array(
+      z.object({
+        tool: CanvasToolName,
+        params: z.record(z.any()).optional(),
+        delayMs: z.number().int().min(0).max(5_000).optional(),
+      }),
+    )
+    .min(1)
+    .max(24),
+});
+
+type CanvasStateResult = { summary: CanvasStateSummary; snapshot?: Record<string, unknown> | null };
+
+export const get_canvas_state = tool({
+  name: 'get_canvas_state',
+  description:
+    'Summarize the TLDraw canvas for a room. Returns a lightweight list of shapes (id, type, text, approximate position).',
+  parameters: CanvasStateArgs,
+  async execute({ room, maxShapes, includeSnapshot }): Promise<CanvasStateResult> {
+    const start = Date.now();
+    const resolvedLimit = typeof maxShapes === 'number' ? maxShapes : 120;
+    const record = await getCanvasSnapshot(room, resolvedLimit);
+    const summary = summarizeCanvasSnapshot(record.snapshot, resolvedLimit);
+    const duration = Date.now() - start;
+    logWithTs('🖼️ [CanvasSteward] get_canvas_state', {
+      room,
+      shapes: summary.shapeCount,
+      durationMs: duration,
+    });
+    return {
+      summary,
+      snapshot: includeSnapshot ? (record.snapshot as Record<string, unknown> | null) : undefined,
+    };
+  },
+});
+
+export const get_context = tool({
+  name: 'get_context',
+  description: 'Fetch recent transcript lines for a room.',
+  parameters: GetContextArgs,
+  async execute({ room, windowMs }) {
+    const window = typeof windowMs === 'number' ? windowMs : 90_000;
+    const start = Date.now();
+    const transcript = await getTranscriptWindow(room, window);
+    const duration = Date.now() - start;
+    const lines = Array.isArray(transcript?.transcript) ? transcript.transcript.length : 0;
+    logWithTs('🗒️ [CanvasSteward] get_context', { room, windowMs: window, lines, durationMs: duration });
+    return transcript;
+  },
+});
+
+export const execute_canvas_actions = tool({
+  name: 'execute_canvas_actions',
+  description:
+    'Run one or more TLDraw canvas tools. Each action maps to a TLDraw event (e.g., canvas_create_rectangle, canvas_focus).',
+  parameters: ExecuteActionsArgs,
+  async execute({ room, actions }) {
+    const executed: Array<{ tool: string }> = [];
+    for (const action of actions) {
+      await broadcastToolCall(room, {
+        tool: action.tool,
+        params: (action.params as Record<string, unknown> | undefined) ?? {},
+        source: 'canvas-steward',
+      });
+      executed.push({ tool: action.tool });
+      if (action.delayMs && action.delayMs > 0) {
+        await new Promise((resolve) => setTimeout(resolve, action.delayMs));
+      }
+    }
+    logWithTs('🛠️ [CanvasSteward] execute_canvas_actions', { room, count: executed.length });
+    return { executed };
+  },
+});
+
+export const CANVAS_STEWARD_INSTRUCTIONS = `You are the Canvas Steward, an expert TLDraw operator. Analyse the existing canvas with get_canvas_state and review the latest instructions with get_context when helpful. Plan your work, then call execute_canvas_actions with concrete drawing steps (create, move, align, colour). Keep updates concise and confirm once finished.`;
+
+export const canvasSteward = new Agent({
+  name: 'CanvasSteward',
+  model: 'gpt-5-mini',
+  instructions: CANVAS_STEWARD_INSTRUCTIONS,
+  tools: [get_canvas_state, get_context, execute_canvas_actions],
+});
+
+export async function runCanvasSteward(params: { room: string; request: string; summary?: string }) {
+  const { room, request, summary } = params;
+  const promptPayload = {
+    room,
+    request,
+    summary: summary?.slice(0, 500) || undefined,
+  };
+  const prompt = `Canvas request: ${JSON.stringify(promptPayload)}`;
+  return run(canvasSteward, prompt);
+}


### PR DESCRIPTION
## Summary
- add a Canvas Steward agent that can inspect the TLDraw document, plan actions, and dispatch canvas tool calls through LiveKit
- extend the conductor, voice agent, and tool dispatcher so canvas-focused requests are routed to the new steward via a dedicated API endpoint
- expose Supabase canvas snapshot helpers with coverage to keep steward reasoning lightweight

## Testing
- npm test -- --runTestsByPath src/lib/agents/shared/__tests__/supabase-context.test.ts
- npm run lint *(fails: existing lint violations across unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68e85b752f648326b26a2f27a91faf43