### PR TITLE
Fix: Fairy UI does not disable server canvas agent

### DIFF
--- a/src/components/ui/tldraw/fairy/fairy-livekit-bridge.tsx
+++ b/src/components/ui/tldraw/fairy/fairy-livekit-bridge.tsx
@@ -8,8 +8,6 @@ import type { FairyModeDefinition, FairyProject, FairyProjectRole } from '@tldra
 import { toProjectId } from '@tldraw/fairy-shared';
 import { createLiveKitBus } from '@/lib/livekit/livekit-bus';
 import { useFairyApp } from '@/vendor/tldraw-fairy/fairy/fairy-app/FairyAppProvider';
-import { useViewportSelectionPublisher } from '@/components/ui/canvas/hooks/useViewportSelectionPublisher';
-import { useScreenshotRequestHandler } from '@/components/ui/canvas/hooks/useScreenshotRequestHandler';
 import type { FairyAgent } from '@/vendor/tldraw-fairy/fairy/fairy-agent/FairyAgent';
 import { useFairyPromptData } from './fairy-prompt-data';
 
@@ -151,8 +149,8 @@ export function FairyLiveKitBridge({ room }: FairyLiveKitBridgeProps) {
   const processedIdsRef = useRef<Set<string>>(new Set());
   const buildPromptData = useFairyPromptData();
 
-  useViewportSelectionPublisher(editor, room, true);
-  useScreenshotRequestHandler(editor, room);
+  // NOTE: Viewport + screenshot bridging is handled by the unified CanvasAgentController.
+  // Keep the fairy bridge focused on fairy-specific prompt handling to avoid duplicate handlers.
 
   useEffect(() => {
     if (!bus) return;

--- a/src/components/ui/tldraw/tldraw-with-collaboration.tsx
+++ b/src/components/ui/tldraw/tldraw-with-collaboration.tsx
@@ -161,11 +161,14 @@ function CollaborationEditorEffects({
     return null;
   }
 
-  if (isFairyEnabled) {
-    return <FairyIntegration room={room} />;
-  }
-
-  return <CanvasAgentController editor={editor} room={room} />;
+  return (
+    <>
+      {/* Always mount the unified server-driven canvas agent bridge. */}
+      <CanvasAgentController editor={editor} room={room} />
+      {/* Fairy UI is optional and should not disable the server steward path. */}
+      {isFairyEnabled && <FairyIntegration room={room} />}
+    </>
+  );
 }
 
 export default React.memo(TldrawWithCollaboration);


### PR DESCRIPTION
When NEXT_PUBLIC_FAIRY_ENABLED is set, we still need the unified server-driven CanvasAgentController mounted to apply action envelopes and handle screenshot/viewport bridges.

This change:
- Always mounts CanvasAgentController.
- Renders FairyIntegration as an optional overlay.
- Removes duplicate viewport/screenshot handler mounts from the fairy LiveKit bridge (CanvasAgentController owns them).