### PR TITLE
ci: deploy Cloudflare tldraw sync

### DIFF
--- a/.github/workflows/deploy-cloudflare-tldraw-sync.yml
+++ b/.github/workflows/deploy-cloudflare-tldraw-sync.yml
@@ -1,0 +1,39 @@
+name: Deploy Cloudflare TLDraw Sync
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'cloudflare/tldraw-sync/**'
+      - '.github/workflows/deploy-cloudflare-tldraw-sync.yml'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cloudflare-tldraw-sync-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Deploy Worker
+        working-directory: cloudflare/tldraw-sync
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: npx --yes wrangler deploy
+

--- a/cloudflare/tldraw-sync/wrangler.toml
+++ b/cloudflare/tldraw-sync/wrangler.toml
@@ -21,7 +21,8 @@ binding = "TLDRAW_UPLOADS"
 bucket_name = "present-tldraw-uploads"
 preview_bucket_name = "present-tldraw-uploads-preview"
 
-[[routes]]
-pattern = "sync.present.best"
-custom_domain = true
-zone_name = "present.best"
+# NOTE:
+# We intentionally do not configure a custom domain here because present.best DNS is
+# not currently delegated to Cloudflare (it is on Porkbun/Vercel DNS). If you want
+# `sync.present.best`, either move DNS to Cloudflare or enable Cloudflare "Custom
+# Hostnames" (SSL for SaaS) and then add routes back in.


### PR DESCRIPTION
Adds a GitHub Actions workflow to deploy the Cloudflare TLDraw sync Worker on pushes to main (when cloudflare/tldraw-sync changes). Also removes the sync.present.best custom-domain route from wrangler.toml since present.best DNS is not currently delegated to Cloudflare.\n\nTo use sync.present.best later: move DNS to Cloudflare or enable Cloudflare Custom Hostnames (SSL for SaaS), then re-add routes.