### PR TITLE
fix(canvas): sync TLDraw color scheme to app theme

### DIFF
--- a/tests/ui/theme-toggle.e2e.spec.ts
+++ b/tests/ui/theme-toggle.e2e.spec.ts
@@ -12,6 +12,8 @@ test.describe('Theme bootstrap', () => {
 
     await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');
     await expect(page.locator('html')).toHaveClass(/dark/);
+    // TLDraw chrome should follow the app theme to avoid mixed light/dark tokens.
+    await expect(page.locator('.tl-container')).toHaveClass(/tl-theme__dark/);
 
     // Flip to light and ensure it persists after reload.
     await page.evaluate(() => window.localStorage.setItem('present:theme', 'light'));
@@ -19,5 +21,6 @@ test.describe('Theme bootstrap', () => {
 
     await expect(page.locator('html')).toHaveAttribute('data-theme', 'light');
     await expect(page.locator('html')).not.toHaveClass(/dark/);
+    await expect(page.locator('.tl-container')).toHaveClass(/tl-theme__light/);
   });
 });


### PR DESCRIPTION
Fixes mixed light/dark styling on `/canvas` where TLDraw chrome could remain in light mode while the app theme was dark (or vice versa), causing low-contrast / illegible UI.

Changes:
- Sync TLDraw `editor.user` `colorScheme` to `PresentThemeProvider` mode.
- Strengthen Playwright `theme-toggle` test to assert TLDraw theme class matches app theme.

Tested:
- `npm test`
- `npm run lint`
- `npm run build`
- `npx playwright test tests/ui` (with `PLAYWRIGHT_BASE_URL=http://localhost:3010` + `NEXT_PUBLIC_CANVAS_DEV_BYPASS=true`)