### PR TITLE
[codex] showcase: remove duplicate mount gate

### DIFF
--- a/src/app/showcase/ui/UiShowcaseClient.tsx
+++ b/src/app/showcase/ui/UiShowcaseClient.tsx
@@ -23,16 +23,6 @@ export function UiShowcaseClient() {
   const theme = usePresentTheme();
   // Deterministic timestamps avoid SSR/CSR hydration mismatches on this page.
   const baseTimeMs = Date.parse('2026-02-08T00:00:00.000Z');
-  const [mounted, setMounted] = React.useState(false);
-  React.useEffect(() => setMounted(true), []);
-
-  // Avoid hydration mismatches on this dev-only page. Theme mode can differ between SSR ("system")
-  // and CSR (localStorage), so we render a minimal shell until mounted.
-  if (!mounted) {
-    return (
-      <div className="min-h-screen bg-surface p-6 md:p-10" suppressHydrationWarning />
-    );
-  }
 
   const sampleResearchResults = [
     {


### PR DESCRIPTION
This is a small hygiene cleanup to keep the dev-only UI showcase simple.

## Problem
We ended up with *two* different "mounted" gates for `/showcase/ui`:
- `UiShowcaseShellClient` already renders nothing until mounted to avoid SSR/CSR hydration mismatch.
- `UiShowcaseClient` also had its own `mounted` state + early return.

That duplication doesn’t add safety and makes the showcase harder to reason about.

## Fix
- Remove the redundant `mounted` state and early-return from `src/app/showcase/ui/UiShowcaseClient.tsx`.
- Keep the single source of truth for hydration safety in `UiShowcaseShellClient`.

## Validation
- `npm test`
- `npm run lint`
- `npm run build`
