### PR TITLE
refactor: split voice-agent helpers into modular services

### DIFF
--- a/src/lib/agents/realtime/voice-agent/__tests__/component-ledger.test.ts
+++ b/src/lib/agents/realtime/voice-agent/__tests__/component-ledger.test.ts
@@ -1,0 +1,31 @@
+import { VoiceComponentLedger } from '../component-ledger';
+
+describe('VoiceComponentLedger', () => {
+  it('tracks per-room last component state independently', () => {
+    let room = 'room-a';
+    const ledger = new VoiceComponentLedger(() => room);
+
+    ledger.setLastComponentForType('DebateScorecard', 'score-a');
+    ledger.setLastCreatedComponentId('score-a');
+    ledger.setRecentCreateFingerprint('DebateScorecard', {
+      fingerprint: 'f-a',
+      messageId: 'score-a',
+      createdAt: 1,
+      turnId: 1,
+      intentId: 'intent-a',
+    });
+
+    room = 'room-b';
+    expect(ledger.getLastComponentForType('DebateScorecard')).toBeUndefined();
+    expect(ledger.getLastCreatedComponentId()).toBeNull();
+    expect(ledger.getRecentCreateFingerprint('DebateScorecard')).toBeUndefined();
+
+    ledger.setLastComponentForType('DebateScorecard', 'score-b');
+    expect(ledger.getLastComponentForType('DebateScorecard')).toBe('score-b');
+
+    room = 'room-a';
+    expect(ledger.getLastComponentForType('DebateScorecard')).toBe('score-a');
+    expect(ledger.getLastCreatedComponentId()).toBe('score-a');
+    expect(ledger.getRecentCreateFingerprint('DebateScorecard')?.intentId).toBe('intent-a');
+  });
+});

--- a/src/lib/agents/realtime/voice-agent/__tests__/manual-routing.test.ts
+++ b/src/lib/agents/realtime/voice-agent/__tests__/manual-routing.test.ts
@@ -1,0 +1,13 @@
+import { createManualInputRouter } from '../manual-routing';
+
+describe('manual routing', () => {
+  it('returns null when anthropic api key is not configured', async () => {
+    const previous = process.env.ANTHROPIC_API_KEY;
+    delete process.env.ANTHROPIC_API_KEY;
+    const routeManualInput = createManualInputRouter();
+    await expect(routeManualInput('draw a cat')).resolves.toBeNull();
+    if (previous) {
+      process.env.ANTHROPIC_API_KEY = previous;
+    }
+  });
+});

--- a/src/lib/agents/realtime/voice-agent/__tests__/normalize.test.ts
+++ b/src/lib/agents/realtime/voice-agent/__tests__/normalize.test.ts
@@ -1,0 +1,23 @@
+import { normalizeComponentPatch, normalizeSpecInput } from '../tool-publishing';
+
+describe('voice-agent normalize helpers', () => {
+  it('normalizes JSON spec input', () => {
+    expect(normalizeSpecInput('{"title":"Timer"}')).toEqual({ title: 'Timer' });
+    expect(normalizeSpecInput('not-json')).toEqual({});
+  });
+
+  it('normalizes duration minutes into canonical timer fields', () => {
+    const patch = normalizeComponentPatch({ durationMinutes: '7' as any }, 300);
+    expect(patch.configuredDuration).toBe(420);
+    expect(patch.initialMinutes).toBe(7);
+    expect(patch.initialSeconds).toBe(0);
+    expect(patch.timeLeft).toBe(420);
+  });
+
+  it('handles reset command', () => {
+    const patch = normalizeComponentPatch({ command: 'reset', configuredDuration: 180 as any }, 300);
+    expect(patch.isRunning).toBe(false);
+    expect(patch.isFinished).toBe(false);
+    expect(patch.timeLeft).toBe(180);
+  });
+});

--- a/src/lib/agents/realtime/voice-agent/__tests__/scorecard.test.ts
+++ b/src/lib/agents/realtime/voice-agent/__tests__/scorecard.test.ts
@@ -1,0 +1,22 @@
+import { inferScorecardTopicFromText, resolveDebatePlayerSeedFromLabels } from '../scorecard';
+
+describe('voice-agent scorecard helpers', () => {
+  it('infers scorecard topic from explicit markers', () => {
+    expect(inferScorecardTopicFromText('create a debate scorecard about: Nuclear energy policy')).toBe(
+      'Nuclear energy policy',
+    );
+    expect(inferScorecardTopicFromText('topic is "Universal basic income" for this debate')).toBe(
+      '"Universal basic income" for this debate',
+    );
+  });
+
+  it('returns undefined when debate context is missing', () => {
+    expect(inferScorecardTopicFromText('add a timer')).toBeUndefined();
+  });
+
+  it('derives AFF/NEG seeds from participant labels', () => {
+    const players = resolveDebatePlayerSeedFromLabels(['Alice', 'Bob', 'alice']);
+    expect(players[0]).toEqual({ side: 'AFF', label: 'Alice' });
+    expect(players[1]).toEqual({ side: 'NEG', label: 'Bob' });
+  });
+});

--- a/src/lib/agents/realtime/voice-agent/__tests__/tool-publishing.test.ts
+++ b/src/lib/agents/realtime/voice-agent/__tests__/tool-publishing.test.ts
@@ -1,0 +1,30 @@
+import {
+  buildToolEvent,
+  coerceComponentPatch,
+  shouldForceReliableUpdate,
+} from '../tool-publishing';
+
+describe('voice-agent tool publishing helpers', () => {
+  it('builds tool_call events with expected shape', () => {
+    const event = buildToolEvent('create_component', { type: 'RetroTimerEnhanced' }, 'room-a');
+    expect(event.type).toBe('tool_call');
+    expect(event.roomId).toBe('room-a');
+    expect(event.payload.tool).toBe('create_component');
+    expect(event.payload.params).toEqual({ type: 'RetroTimerEnhanced' });
+    expect(typeof event.id).toBe('string');
+  });
+
+  it('forces reliable update when instruction patch is present', () => {
+    expect(
+      shouldForceReliableUpdate('update_component', { patch: { instruction: 'summarize this' } } as any),
+    ).toBe(true);
+    expect(shouldForceReliableUpdate('update_component', { patch: {} } as any)).toBe(false);
+    expect(
+      shouldForceReliableUpdate('create_component', { patch: { instruction: 'x' } } as any),
+    ).toBe(false);
+  });
+
+  it('coerces string patch into instruction fallback when json is invalid', () => {
+    expect(coerceComponentPatch('set to 10 minutes')).toEqual({ instruction: 'set to 10 minutes' });
+  });
+});

--- a/src/lib/agents/realtime/voice-agent/__tests__/transcription-buffer.test.ts
+++ b/src/lib/agents/realtime/voice-agent/__tests__/transcription-buffer.test.ts
@@ -1,0 +1,25 @@
+import { TranscriptionBuffer, type PendingTranscriptionMessage } from '../transcription-buffer';
+
+const makeMessage = (text: string): PendingTranscriptionMessage => ({
+  text,
+  isManual: false,
+  isFinal: true,
+  receivedAt: Date.now(),
+});
+
+describe('TranscriptionBuffer', () => {
+  it('queues entries and drains in order when enabled', async () => {
+    const buffer = new TranscriptionBuffer(10, 30_000);
+    buffer.enqueue(makeMessage('one'));
+    buffer.enqueue(makeMessage('two'));
+    buffer.setEnabled(true);
+
+    const seen: string[] = [];
+    await buffer.drain(async (message) => {
+      seen.push(message.text);
+    });
+
+    expect(seen).toEqual(['one', 'two']);
+    expect(buffer.size()).toBe(0);
+  });
+});

--- a/src/lib/agents/realtime/voice-agent/component-ledger.ts
+++ b/src/lib/agents/realtime/voice-agent/component-ledger.ts
@@ -1,0 +1,66 @@
+export type RecentCreateFingerprint = {
+  fingerprint: string;
+  messageId: string;
+  createdAt: number;
+  turnId: number;
+  intentId: string;
+  slot?: string;
+};
+
+export class VoiceComponentLedger {
+  private readonly lastComponentByTypeByRoom = new Map<string, Map<string, string>>();
+  private readonly lastCreatedComponentIdByRoom = new Map<string, string>();
+  private readonly recentCreateFingerprintsByRoom = new Map<string, Map<string, RecentCreateFingerprint>>();
+
+  constructor(private readonly getRoomKey: () => string) {}
+
+  private getLastComponentMap() {
+    const key = this.getRoomKey();
+    let map = this.lastComponentByTypeByRoom.get(key);
+    if (!map) {
+      map = new Map<string, string>();
+      this.lastComponentByTypeByRoom.set(key, map);
+    }
+    return map;
+  }
+
+  getLastComponentForType(type: string) {
+    return this.getLastComponentMap().get(type);
+  }
+
+  setLastComponentForType(type: string, messageId: string) {
+    this.getLastComponentMap().set(type, messageId);
+  }
+
+  getLastCreatedComponentId() {
+    const key = this.getRoomKey();
+    return this.lastCreatedComponentIdByRoom.get(key) ?? null;
+  }
+
+  setLastCreatedComponentId(messageId: string | null) {
+    const key = this.getRoomKey();
+    if (!messageId) {
+      this.lastCreatedComponentIdByRoom.delete(key);
+      return;
+    }
+    this.lastCreatedComponentIdByRoom.set(key, messageId);
+  }
+
+  private getRecentCreateMap() {
+    const key = this.getRoomKey();
+    let map = this.recentCreateFingerprintsByRoom.get(key);
+    if (!map) {
+      map = new Map<string, RecentCreateFingerprint>();
+      this.recentCreateFingerprintsByRoom.set(key, map);
+    }
+    return map;
+  }
+
+  getRecentCreateFingerprint(type: string) {
+    return this.getRecentCreateMap().get(type);
+  }
+
+  setRecentCreateFingerprint(type: string, fingerprint: RecentCreateFingerprint) {
+    this.getRecentCreateMap().set(type, fingerprint);
+  }
+}

--- a/src/lib/agents/realtime/voice-agent/manual-routing.ts
+++ b/src/lib/agents/realtime/voice-agent/manual-routing.ts
@@ -1,0 +1,50 @@
+import { z } from 'zod';
+
+const routerDecisionSchema = z.object({
+  route: z.enum(['canvas', 'none']),
+  message: z.string().optional(),
+});
+
+export type ManualRouteDecision = z.infer<typeof routerDecisionSchema>;
+
+export function createManualInputRouter() {
+  let routerModelCache: any = null;
+
+  const getRouterModel = async () => {
+    if (routerModelCache) return routerModelCache;
+    const apiKey = process.env.ANTHROPIC_API_KEY;
+    if (!apiKey) return null;
+    const { createAnthropic } = await import('@ai-sdk/anthropic');
+    const modelId = (process.env.VOICE_AGENT_ROUTER_MODEL || 'claude-haiku-4-5').trim();
+    const anthropic = createAnthropic({ apiKey });
+    routerModelCache = anthropic(modelId);
+    return routerModelCache;
+  };
+
+  return async (text: string): Promise<ManualRouteDecision | null> => {
+    const model = await getRouterModel();
+    if (!model) return null;
+
+    const system = [
+      'You are a routing assistant for a real-time UI voice agent.',
+      'Decide whether the user request should be handled by the canvas agent.',
+      'Canvas requests involve drawing, layout, styling, editing, or placing shapes or visuals on the canvas.',
+      'If the request is a canvas task, return route="canvas" and a concise imperative message for the canvas agent.',
+      'Otherwise return route="none".',
+    ].join(' ');
+
+    const { generateObject } = await import('ai');
+    const { object } = await (generateObject as unknown as (args: any) => Promise<{ object: any }>)({
+      model,
+      system,
+      prompt: text,
+      schema: routerDecisionSchema,
+      temperature: 0,
+      maxOutputTokens: 120,
+    });
+
+    const parsed = routerDecisionSchema.safeParse(object);
+    if (!parsed.success) return null;
+    return parsed.data;
+  };
+}

--- a/src/lib/agents/realtime/voice-agent/scorecard.ts
+++ b/src/lib/agents/realtime/voice-agent/scorecard.ts
@@ -1,0 +1,62 @@
+const stripWrappingQuotes = (value: string) => {
+  let next = value.trim();
+  if (next.length < 2) return next;
+  const first = next[0];
+  const last = next[next.length - 1];
+  if ((first === '"' || first === "'" || first === '`') && first === last) {
+    next = next.slice(1, -1).trim();
+  }
+  return next;
+};
+
+export const inferScorecardTopicFromText = (text?: string): string | undefined => {
+  if (!text) return undefined;
+  const trimmed = text.trim();
+  if (!trimmed) return undefined;
+  const lower = trimmed.toLowerCase();
+  if (!lower.includes('debate') && !lower.includes('scorecard')) return undefined;
+
+  const markers = ['about:', 'about ', 'topic:', 'topic is', 'topic '];
+  for (const marker of markers) {
+    const idx = lower.indexOf(marker);
+    if (idx === -1) continue;
+    const candidate = stripWrappingQuotes(trimmed.slice(idx + marker.length).trim());
+    if (candidate.length >= 6 && candidate.length <= 180) {
+      return candidate;
+    }
+  }
+
+  const lastColon = trimmed.lastIndexOf(':');
+  if (lastColon !== -1) {
+    const candidate = stripWrappingQuotes(trimmed.slice(lastColon + 1).trim());
+    if (candidate.length >= 6 && candidate.length <= 180) {
+      return candidate;
+    }
+  }
+
+  if (trimmed.endsWith('?') && trimmed.length <= 180) {
+    return trimmed;
+  }
+
+  return undefined;
+};
+
+export const dedupeParticipantLabels = (labels: string[]): string[] => {
+  const seen = new Set<string>();
+  return labels.filter((label) => {
+    const key = label.trim().toLowerCase();
+    if (!key || seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+};
+
+export const resolveDebatePlayerSeedFromLabels = (labels: string[]) => {
+  const deduped = dedupeParticipantLabels(labels);
+  const affLabel = deduped[0] || 'You';
+  const negLabel = deduped[1] || (deduped[0] ? 'Opponent' : 'Opponent');
+  return [
+    { side: 'AFF' as const, label: affLabel },
+    { side: 'NEG' as const, label: negLabel },
+  ];
+};

--- a/src/lib/agents/realtime/voice-agent/tool-context.ts
+++ b/src/lib/agents/realtime/voice-agent/tool-context.ts
@@ -1,0 +1,3 @@
+import { jsonObjectSchema } from '@/lib/utils/json-schema';
+
+export const createToolParametersSchema = () => jsonObjectSchema.default({});

--- a/src/lib/agents/realtime/voice-agent/tool-publishing.ts
+++ b/src/lib/agents/realtime/voice-agent/tool-publishing.ts
@@ -1,0 +1,352 @@
+import { randomUUID } from 'crypto';
+import type { JsonObject } from '@/lib/utils/json-schema';
+
+export type ToolEvent = {
+  id: string;
+  roomId: string;
+  type: 'tool_call';
+  payload: { tool: string; params: JsonObject; context: { source: 'voice'; timestamp: number } };
+  timestamp: number;
+  source: 'voice';
+};
+
+export const buildToolEvent = (tool: string, params: JsonObject, roomId: string): ToolEvent => ({
+  id: randomUUID(),
+  roomId,
+  type: 'tool_call',
+  payload: { tool, params, context: { source: 'voice', timestamp: Date.now() } },
+  timestamp: Date.now(),
+  source: 'voice',
+});
+
+export const safeCloneJson = (value: unknown): JsonObject => {
+  if (!value || typeof value !== 'object') return {};
+  try {
+    return JSON.parse(JSON.stringify(value)) as JsonObject;
+  } catch {
+    return {};
+  }
+};
+
+export const coerceComponentPatch = (raw: unknown): JsonObject => {
+  if (!raw) return {};
+  if (typeof raw === 'string') {
+    try {
+      const parsed = JSON.parse(raw);
+      return parsed && typeof parsed === 'object' ? safeCloneJson(parsed) : { instruction: raw };
+    } catch {
+      return { instruction: raw } as JsonObject;
+    }
+  }
+  if (typeof raw === 'object') {
+    return safeCloneJson(raw);
+  }
+  return {};
+};
+
+export const normalizeSpecInput = (raw: unknown): JsonObject => {
+  if (!raw) return {};
+  if (typeof raw === 'string') {
+    try {
+      const parsed = JSON.parse(raw);
+      return parsed && typeof parsed === 'object' ? safeCloneJson(parsed) : {};
+    } catch {
+      return {};
+    }
+  }
+  if (raw && typeof raw === 'object') {
+    return safeCloneJson(raw);
+  }
+  return {};
+};
+
+export const normalizeComponentPatch = (patch: JsonObject, fallbackSeconds: number): JsonObject => {
+  const next: JsonObject = { ...patch };
+  const timestamp = Date.now();
+  next.updatedAt = typeof next.updatedAt === 'number' ? next.updatedAt : timestamp;
+
+  const coerceBoolean = (value: unknown): boolean | undefined => {
+    if (typeof value === 'boolean') return value;
+    if (typeof value === 'number') {
+      if (value === 1) return true;
+      if (value === 0) return false;
+    }
+    if (typeof value === 'string') {
+      const normalized = value.trim().toLowerCase();
+      if (!normalized) return undefined;
+      if (['true', 'yes', 'start', 'run', 'running', 'resume', 'play', 'on', '1'].includes(normalized)) {
+        return true;
+      }
+      if (['false', 'no', 'stop', 'stopped', 'pause', 'paused', 'halt', 'off', '0'].includes(normalized)) {
+        return false;
+      }
+    }
+    return undefined;
+  };
+
+  const coerceDurationValue = (value: unknown, fallbackSecondsValue: number) => {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return Math.max(1, Math.round(value));
+    }
+    if (typeof value === 'string') {
+      const cleaned = value.trim().toLowerCase();
+      if (!cleaned) return fallbackSecondsValue;
+      const parsed = Number.parseFloat(cleaned);
+      if (!Number.isFinite(parsed)) return fallbackSecondsValue;
+      const isMinutes =
+        cleaned.includes('min') ||
+        cleaned.endsWith('m') ||
+        cleaned.endsWith('minutes') ||
+        cleaned.endsWith('minute');
+      const seconds = isMinutes ? parsed * 60 : parsed;
+      return Math.max(1, Math.round(seconds));
+    }
+    return fallbackSecondsValue;
+  };
+
+  const coerceIntValue = (value: unknown, fallback: number) => {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return Math.round(value);
+    }
+    if (typeof value === 'string') {
+      const parsed = Number.parseFloat(value);
+      if (Number.isFinite(parsed)) {
+        return Math.round(parsed);
+      }
+    }
+    return fallback;
+  };
+
+  if (next.durationMinutes !== undefined) {
+    const minutesValue = coerceIntValue(
+      (next as any).durationMinutes,
+      Math.max(1, Math.round(((next as any).configuredDuration ?? fallbackSeconds) as number / 60)),
+    );
+    const durationSeconds = Math.max(1, minutesValue) * 60;
+    const seconds = durationSeconds % 60;
+    const minutes = Math.floor(durationSeconds / 60);
+    next.configuredDuration = durationSeconds;
+    if (typeof next.timeLeft !== 'number') {
+      next.timeLeft = durationSeconds;
+    }
+    next.initialMinutes = minutes;
+    next.initialSeconds = seconds;
+    delete (next as any).durationMinutes;
+  }
+
+  if (next.update && typeof (next as any).update === 'object' && !Array.isArray((next as any).update)) {
+    const update = (next as any).update as Record<string, unknown>;
+    const defaultMinutes = Math.max(0, Math.floor(fallbackSeconds / 60));
+    const defaultSeconds = fallbackSeconds % 60;
+    const minutesCandidate =
+      'minutes' in update ? coerceIntValue(update.minutes, defaultMinutes) : null;
+    const secondsCandidate =
+      'seconds' in update ? coerceIntValue(update.seconds, defaultSeconds) : null;
+    if (minutesCandidate !== null || secondsCandidate !== null) {
+      const minutes =
+        minutesCandidate !== null
+          ? Math.max(0, minutesCandidate)
+          : secondsCandidate !== null
+            ? 0
+            : defaultMinutes;
+      const seconds = secondsCandidate !== null ? Math.max(0, Math.min(59, secondsCandidate)) : defaultSeconds;
+      const durationSeconds = Math.max(1, minutes * 60 + seconds);
+      next.configuredDuration = durationSeconds;
+      next.timeLeft = durationSeconds;
+      next.initialMinutes = minutes;
+      next.initialSeconds = seconds;
+      next.isFinished = false;
+      next.isRunning = false;
+    }
+    delete (next as any).update;
+  }
+
+  if (next.duration !== undefined) {
+    const durationSeconds = coerceDurationValue(
+      next.duration,
+      Math.max(1, Math.round((next as any).configuredDuration ?? fallbackSeconds)),
+    );
+    const minutes = Math.floor(durationSeconds / 60);
+    const seconds = durationSeconds % 60;
+    next.configuredDuration = durationSeconds;
+    if (typeof next.timeLeft !== 'number') {
+      next.timeLeft = durationSeconds;
+    }
+    next.initialMinutes = minutes;
+    next.initialSeconds = seconds;
+    delete next.duration;
+  }
+  if (next.durationSeconds !== undefined) {
+    const durationSeconds = coerceDurationValue(
+      (next as any).durationSeconds,
+      Math.max(1, Math.round((next as any).configuredDuration ?? fallbackSeconds)),
+    );
+    const minutes = Math.floor(durationSeconds / 60);
+    const seconds = durationSeconds % 60;
+    next.configuredDuration = durationSeconds;
+    if (typeof next.timeLeft !== 'number') {
+      next.timeLeft = durationSeconds;
+    }
+    next.initialMinutes = minutes;
+    next.initialSeconds = seconds;
+  }
+  if (next.initialMinutes !== undefined || next.initialSeconds !== undefined) {
+    const hasMinutesField = (next as any).initialMinutes !== undefined;
+    const hasSecondsField = (next as any).initialSeconds !== undefined;
+    const defaultMinutes = Math.max(
+      0,
+      Math.floor((((next as any).configuredDuration ?? fallbackSeconds) as number) / 60),
+    );
+    const defaultSeconds = (((next as any).configuredDuration ?? fallbackSeconds) as number) % 60;
+    const minutesCandidate = hasMinutesField
+      ? coerceIntValue((next as any).initialMinutes, defaultMinutes)
+      : null;
+    const secondsCandidate = hasSecondsField
+      ? coerceIntValue((next as any).initialSeconds, defaultSeconds)
+      : null;
+    if (minutesCandidate !== null || secondsCandidate !== null) {
+      const minutes =
+        minutesCandidate !== null
+          ? Math.max(0, minutesCandidate)
+          : secondsCandidate !== null
+            ? 0
+            : defaultMinutes;
+      const seconds =
+        secondsCandidate !== null ? Math.max(0, Math.min(59, secondsCandidate)) : Math.max(0, Math.min(59, defaultSeconds));
+      const totalSeconds = Math.max(1, minutes * 60 + seconds);
+      next.configuredDuration = totalSeconds;
+      if (typeof next.timeLeft !== 'number') {
+        next.timeLeft = totalSeconds;
+      }
+      next.initialMinutes = minutes;
+      next.initialSeconds = seconds;
+    }
+  }
+
+  if (typeof (next as any).state === 'string') {
+    const stateLabel = ((next as any).state as string).trim().toLowerCase();
+    delete (next as any).state;
+    const markRunning = () => {
+      next.isRunning = true;
+      next.isFinished = false;
+      if (typeof next.timeLeft !== 'number' || next.timeLeft <= 0) {
+        const durationSeconds = typeof next.configuredDuration === 'number' ? next.configuredDuration : fallbackSeconds;
+        next.timeLeft = Math.max(1, Math.round(durationSeconds));
+      }
+    };
+    const markStopped = (finished: boolean) => {
+      next.isRunning = false;
+      if (finished) {
+        next.isFinished = true;
+        if (typeof next.timeLeft !== 'number' || next.timeLeft < 0) {
+          next.timeLeft = 0;
+        }
+      }
+    };
+    if (
+      ['run', 'running', 'start', 'started', 'resume', 'resumed', 'play', 'playing', 'active'].includes(
+        stateLabel,
+      )
+    ) {
+      markRunning();
+    } else if (
+      ['paused', 'pause', 'stop', 'stopped', 'halt', 'idle', 'ready', 'standby'].includes(stateLabel)
+    ) {
+      markStopped(false);
+    } else if (
+      ['finished', 'complete', 'completed', 'done', 'expired', "time's up", 'time up', 'timeup'].includes(
+        stateLabel,
+      )
+    ) {
+      markStopped(true);
+    }
+  }
+
+  const runningValue =
+    'running' in next ? coerceBoolean(next.running) : undefined;
+  if (runningValue !== undefined) {
+    next.isRunning = runningValue;
+    if (runningValue) {
+      next.isFinished = false;
+      if (typeof next.timeLeft !== 'number' && typeof next.configuredDuration === 'number') {
+        next.timeLeft = next.configuredDuration;
+      }
+    }
+    delete next.running;
+  }
+
+  const autoStartValue =
+    'autoStart' in next ? coerceBoolean(next.autoStart) : undefined;
+  if (autoStartValue !== undefined) {
+    next.autoStart = autoStartValue;
+    next.isRunning = autoStartValue;
+    if (autoStartValue) {
+      next.isFinished = false;
+      if (typeof next.timeLeft !== 'number' && typeof next.configuredDuration === 'number') {
+        next.timeLeft = next.configuredDuration;
+      }
+    }
+  }
+
+  const statusValue =
+    'status' in next ? coerceBoolean(next.status) : undefined;
+  if (statusValue !== undefined && next.isRunning === undefined) {
+    next.isRunning = statusValue;
+    if (statusValue) {
+      next.isFinished = false;
+      if (typeof next.timeLeft !== 'number' && typeof next.configuredDuration === 'number') {
+        next.timeLeft = next.configuredDuration;
+      }
+    }
+  }
+
+  if (typeof (next as any).action === 'string') {
+    const action = ((next as any).action as string).trim().toLowerCase();
+    delete (next as any).action;
+    if (action === 'start' || action === 'resume' || action === 'run' || action === 'play') {
+      next.isRunning = true;
+      next.isFinished = false;
+      if (typeof next.timeLeft !== 'number' || next.timeLeft <= 0) {
+        const durationSeconds = typeof next.configuredDuration === 'number' ? next.configuredDuration : fallbackSeconds;
+        next.timeLeft = Math.max(1, Math.round(durationSeconds));
+      }
+    } else if (action === 'pause' || action === 'stop' || action === 'halt') {
+      next.isRunning = false;
+    } else if (action === 'reset') {
+      const durationSeconds = typeof next.configuredDuration === 'number' ? next.configuredDuration : fallbackSeconds;
+      next.timeLeft = Math.max(1, Math.round(durationSeconds));
+      next.isRunning = false;
+      next.isFinished = false;
+    }
+  }
+
+  if (typeof (next as any).command === 'string') {
+    const command = ((next as any).command as string).trim().toLowerCase();
+    delete (next as any).command;
+    if (command === 'start' || command === 'resume' || command === 'run' || command === 'play') {
+      next.isRunning = true;
+      next.isFinished = false;
+      if (typeof next.timeLeft !== 'number' || next.timeLeft <= 0) {
+        const durationSeconds = typeof next.configuredDuration === 'number' ? next.configuredDuration : fallbackSeconds;
+        next.timeLeft = Math.max(1, Math.round(durationSeconds));
+      }
+    } else if (command === 'pause' || command === 'stop' || command === 'halt') {
+      next.isRunning = false;
+    } else if (command === 'reset') {
+      const durationSeconds = typeof next.configuredDuration === 'number' ? next.configuredDuration : fallbackSeconds;
+      next.timeLeft = Math.max(1, Math.round(durationSeconds));
+      next.isRunning = false;
+      next.isFinished = false;
+    }
+  }
+
+  return next;
+};
+
+export const shouldForceReliableUpdate = (tool: string, params: JsonObject): boolean =>
+  tool === 'update_component' &&
+  params &&
+  typeof (params as any).patch === 'object' &&
+  (params as any).patch !== null &&
+  typeof ((params as any).patch as any).instruction === 'string' &&
+  (((params as any).patch as any).instruction as string).trim().length > 0;

--- a/src/lib/agents/realtime/voice-agent/transcription-buffer.ts
+++ b/src/lib/agents/realtime/voice-agent/transcription-buffer.ts
@@ -1,0 +1,70 @@
+export type PendingTranscriptionMessage = {
+  text: string;
+  speaker?: string;
+  participantId?: string;
+  participantName?: string;
+  isManual: boolean;
+  isFinal: boolean;
+  timestamp?: number;
+  serverGenerated?: boolean;
+  receivedAt: number;
+};
+
+export class TranscriptionBuffer {
+  private readonly pending: PendingTranscriptionMessage[] = [];
+  private draining = false;
+  private enabled = false;
+
+  constructor(
+    private readonly maxItems = 64,
+    private readonly ttlMs = 30_000,
+  ) {}
+
+  setEnabled(enabled: boolean) {
+    this.enabled = enabled;
+  }
+
+  enqueue(message: PendingTranscriptionMessage) {
+    this.pending.push(message);
+    this.prune();
+  }
+
+  private prune() {
+    const now = Date.now();
+    while (this.pending.length > 0) {
+      const first = this.pending[0];
+      if (now - first.receivedAt <= this.ttlMs) break;
+      this.pending.shift();
+    }
+    if (this.pending.length > this.maxItems) {
+      this.pending.splice(0, this.pending.length - this.maxItems);
+    }
+  }
+
+  async drain(
+    handler: (message: PendingTranscriptionMessage) => Promise<void>,
+    onError?: (error: unknown) => void,
+  ) {
+    if (!this.enabled) return;
+    if (this.draining) return;
+    this.draining = true;
+    try {
+      this.prune();
+      while (this.pending.length > 0) {
+        const next = this.pending.shift();
+        if (!next) continue;
+        try {
+          await handler(next);
+        } catch (error) {
+          onError?.(error);
+        }
+      }
+    } finally {
+      this.draining = false;
+    }
+  }
+
+  size() {
+    return this.pending.length;
+  }
+}


### PR DESCRIPTION
## Summary
- split major helper responsibilities out of `voice-agent.ts` into dedicated modules:
  - `manual-routing.ts`
  - `tool-publishing.ts`
  - `transcription-buffer.ts`
  - `component-ledger.ts`
  - `scorecard.ts`
  - `tool-context.ts`
- wire `voice-agent.ts` to consume the new modules while preserving tool payload contracts
- add focused unit tests for normalization, tool publishing, buffer behavior, ledger state, manual routing fallback, and scorecard helpers

## Verification
- npm run build
- npm run lint
- npm test
