### PR TITLE
[codex] edge ingress split and cost guard hardening

### DIFF
--- a/cloudflare/ingress/src/index.ts
+++ b/cloudflare/ingress/src/index.ts
@@ -1,0 +1,160 @@
+export interface Env {
+  ORIGIN_BASE_URL: string;
+  EDGE_ALLOWED_ORIGINS?: string;
+  EDGE_INGRESS_SHARED_SECRET?: string;
+}
+
+const ALLOWED_PATHS = new Set<string>([
+  '/api/token',
+  '/api/mcp-proxy',
+  '/api/canvas-agent/ack',
+  '/api/canvas-agent/screenshot',
+  '/api/canvas-agent/viewport',
+]);
+
+const HOP_BY_HOP = new Set([
+  'connection',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade',
+  'host',
+]);
+
+function normalizeOriginList(value: string | undefined): string[] {
+  return (value || '')
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function isAllowedPath(pathname: string): boolean {
+  return ALLOWED_PATHS.has(pathname);
+}
+
+function resolveAllowedOrigin(requestOrigin: string | null, env: Env): string {
+  const allowed = normalizeOriginList(env.EDGE_ALLOWED_ORIGINS);
+  if (!requestOrigin) return '*';
+  if (allowed.length === 0) return requestOrigin;
+  if (allowed.includes('*')) return requestOrigin;
+  return allowed.includes(requestOrigin) ? requestOrigin : 'null';
+}
+
+function corsHeaders(request: Request, env: Env): Record<string, string> {
+  const origin = resolveAllowedOrigin(request.headers.get('origin'), env);
+  return {
+    'Access-Control-Allow-Origin': origin,
+    'Access-Control-Allow-Methods': 'GET,POST,PUT,PATCH,DELETE,OPTIONS',
+    'Access-Control-Allow-Headers':
+      'Authorization, Content-Type, X-Timestamp, X-Nonce, X-Signature, Last-Event-ID, MCP-Session-Id, X-MCP-Upstream-Authorization',
+    'Access-Control-Expose-Headers': 'Retry-After',
+    Vary: 'Origin',
+  };
+}
+
+function buildForwardHeaders(request: Request, env: Env): Headers {
+  const headers = new Headers();
+  for (const [key, value] of request.headers.entries()) {
+    const lower = key.toLowerCase();
+    if (HOP_BY_HOP.has(lower)) continue;
+    if (lower.startsWith('cf-')) continue;
+    headers.set(key, value);
+  }
+  if (env.EDGE_INGRESS_SHARED_SECRET) {
+    headers.set('x-edge-ingress-secret', env.EDGE_INGRESS_SHARED_SECRET);
+  }
+  return headers;
+}
+
+function mergeResponseHeaders(
+  upstream: Headers,
+  cors: Record<string, string>,
+  passthroughContentType = true,
+): Headers {
+  const headers = new Headers();
+  upstream.forEach((value, key) => {
+    const lower = key.toLowerCase();
+    if (HOP_BY_HOP.has(lower)) return;
+    if (lower === 'set-cookie') return;
+    if (!passthroughContentType && lower === 'content-type') return;
+    headers.set(key, value);
+  });
+  Object.entries(cors).forEach(([key, value]) => headers.set(key, value));
+  headers.set('Cache-Control', 'no-store');
+  headers.set('x-edge-ingress', 'cloudflare');
+  return headers;
+}
+
+function badRequest(message: string, request: Request, env: Env, status = 400) {
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+      ...corsHeaders(request, env),
+      'Cache-Control': 'no-store',
+    },
+  });
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    if (!env.ORIGIN_BASE_URL?.trim()) {
+      return badRequest('Missing ORIGIN_BASE_URL', request, env, 500);
+    }
+
+    const requestUrl = new URL(request.url);
+    if (request.method === 'OPTIONS') {
+      return new Response(null, { status: 204, headers: corsHeaders(request, env) });
+    }
+
+    if (!isAllowedPath(requestUrl.pathname)) {
+      return badRequest('Path not allowed', request, env, 404);
+    }
+
+    let originBase: URL;
+    try {
+      originBase = new URL(env.ORIGIN_BASE_URL);
+    } catch {
+      return badRequest('Invalid ORIGIN_BASE_URL', request, env, 500);
+    }
+
+    const target = new URL(`${requestUrl.pathname}${requestUrl.search}`, originBase);
+    const forwardHeaders = buildForwardHeaders(request, env);
+    const cors = corsHeaders(request, env);
+
+    try {
+      const upstream = await fetch(target.toString(), {
+        method: request.method,
+        headers: forwardHeaders,
+        body: ['GET', 'HEAD'].includes(request.method) ? undefined : request.body,
+        redirect: 'follow',
+        // @ts-expect-error duplex is required for streaming request bodies.
+        duplex: 'half',
+      });
+
+      return new Response(upstream.body, {
+        status: upstream.status,
+        headers: mergeResponseHeaders(upstream.headers, cors),
+      });
+    } catch (error) {
+      return new Response(
+        JSON.stringify({
+          error: 'Upstream proxy failure',
+          message: error instanceof Error ? error.message : 'Unknown error',
+        }),
+        {
+          status: 502,
+          headers: {
+            'Content-Type': 'application/json',
+            ...cors,
+            'Cache-Control': 'no-store',
+            'x-edge-ingress': 'cloudflare',
+          },
+        },
+      );
+    }
+  },
+};

--- a/cloudflare/ingress/wrangler.toml
+++ b/cloudflare/ingress/wrangler.toml
@@ -1,0 +1,14 @@
+name = "present-edge-ingress"
+main = "src/index.ts"
+compatibility_date = "2025-02-01"
+workers_dev = true
+preview_urls = false
+
+[observability]
+enabled = true
+
+# Required secret/config:
+# - ORIGIN_BASE_URL: Origin API base URL (e.g. https://your-app.vercel.app)
+# Optional:
+# - EDGE_ALLOWED_ORIGINS: Comma-separated origin allowlist for browser CORS
+# - EDGE_INGRESS_SHARED_SECRET: Forwarded as x-edge-ingress-secret to origin

--- a/docs/cloudflare-edge-ingress.md
+++ b/docs/cloudflare-edge-ingress.md
@@ -1,0 +1,62 @@
+# Cloudflare Edge Ingress
+
+This worker is an edge facade for high-volume stateless API paths so UI traffic can hit Cloudflare first, while keeping core application logic in Next.js.
+
+## Routed Paths
+
+- `/api/token`
+- `/api/mcp-proxy`
+- `/api/canvas-agent/ack`
+- `/api/canvas-agent/screenshot`
+- `/api/canvas-agent/viewport`
+
+All other paths return `404` from the worker.
+
+## Files
+
+- `cloudflare/ingress/wrangler.toml`
+- `cloudflare/ingress/src/index.ts`
+
+## Configure Worker Secrets / Vars
+
+Set these on the worker:
+
+- `ORIGIN_BASE_URL` (required): origin app URL (for example `https://your-app.vercel.app`)
+- `EDGE_ALLOWED_ORIGINS` (optional): comma-separated browser origins; defaults to request origin passthrough
+- `EDGE_INGRESS_SHARED_SECRET` (optional): forwarded as `x-edge-ingress-secret` to origin
+
+Example:
+
+```bash
+npx wrangler secret put ORIGIN_BASE_URL --config cloudflare/ingress/wrangler.toml
+npx wrangler secret put EDGE_INGRESS_SHARED_SECRET --config cloudflare/ingress/wrangler.toml
+```
+
+For non-secret vars:
+
+```bash
+npx wrangler deploy --config cloudflare/ingress/wrangler.toml --var EDGE_ALLOWED_ORIGINS:\"https://app.example.com\"
+```
+
+## Local Dev
+
+```bash
+npm run cf:ingress:dev
+```
+
+## Deploy
+
+```bash
+npm run cf:ingress:deploy
+```
+
+## App Wiring
+
+Set app env values:
+
+- `NEXT_PUBLIC_EDGE_INGRESS_ENABLED=true`
+- `NEXT_PUBLIC_EDGE_INGRESS_URL=https://present-edge-ingress.<subdomain>.workers.dev`
+- `EDGE_INGRESS_ENABLED=true` (for server-side callers)
+- `EDGE_INGRESS_URL=https://present-edge-ingress.<subdomain>.workers.dev`
+
+When enabled, hot-path client/server callers use the worker URL instead of same-origin API paths.

--- a/example.env.local
+++ b/example.env.local
@@ -8,6 +8,8 @@ NEXT_PUBLIC_SUBAGENT_AUTORUN=true
 NEXT_PUBLIC_custom_API_KEY=your_api_key_here                     # custom AI API key (required for generative UI)
 NEXT_PUBLIC_LK_TOKEN_ENDPOINT=/api/token                         # API route for LiveKit token generation
 NEXT_PUBLIC_LK_SERVER_URL=wss://your-livekit-url.livekit.cloud          # LiveKit websocket URL (for UI components)
+NEXT_PUBLIC_EDGE_INGRESS_ENABLED=false                           # Route hot stateless API calls through Cloudflare edge ingress
+NEXT_PUBLIC_EDGE_INGRESS_URL=                                    # e.g. https://present-edge-ingress.<subdomain>.workers.dev
 NEXT_PUBLIC_CANVAS_DEV_BYPASS=false                             # If true, bypass auth on /canvas in dev
 NEXT_PUBLIC_STEWARD_FLOWCHART_ENABLED=true                      # Enable flowchart steward routing in ToolDispatcher
 NEXT_PUBLIC_TOOL_DISPATCHER_LOGS=false                          # Verbose ToolDispatcher logs in the browser console
@@ -17,6 +19,14 @@ NEXT_PUBLIC_TOOL_DISPATCHER_METRICS=false                       # Emit tSend/tAr
 LIVEKIT_URL=wss://your-livekit-url.livekit.cloud                        # LiveKit websocket server URL (for agent)
 LIVEKIT_API_KEY=your_livekit_api_key                             # LiveKit API key (for agent)
 LIVEKIT_API_SECRET=your_livekit_api_secret                       # LiveKit API secret (for agent)
+EDGE_INGRESS_ENABLED=false                                       # Server-side edge ingress routing toggle (Node runtimes)
+EDGE_INGRESS_URL=                                                # Server-side edge ingress base URL
+TOKEN_SIGNATURE_MAX_SKEW_MS=300000                               # Max signed token request clock skew
+TOKEN_NONCE_TTL_MS=120000                                        # Reject token nonce replays inside this TTL
+TOKEN_RATE_LIMIT_PER_USER_PER_MIN=30                             # LiveKit token mints per user per minute
+TOKEN_RATE_LIMIT_PER_ROOM_PER_MIN=90                             # LiveKit token mints per room per minute
+TOKEN_REQUIRE_AUTH=false                                          # Enable in production to require authenticated token minting
+TOKEN_REQUIRE_SIGNED_NONCE=false                                  # Enable in production to require x-signature/x-timestamp/x-nonce
 
 TOGETHER_API_KEY=your-together-ai-api-key                        # Together AI API key for image generation
 
@@ -66,7 +76,11 @@ VOICE_AGENT_INPUT_TRANSCRIPTION_MODEL=                         # (Optional) Voic
 VOICE_AGENT_TRANSCRIPTION_ENABLED=false                        # (Optional) Set true to stream realtime transcripts (defaults to true when model provided)
 VOICE_AGENT_TRANSCRIPTION_LANGUAGE=en                          # (Optional) Force language hint for realtime transcription (defaults to AGENT_STT_LANGUAGE)
 VOICE_AGENT_TURN_DETECTION=                                    # (Optional) 'server_vad', 'semantic_vad', or 'none'; defaults to server VAD when transcription enabled
+VOICE_AGENT_MULTI_PARTICIPANT_TRANSCRIPTION=false              # Keep expensive multi-participant transcription off by default
 VOICE_AGENT_UPDATE_LOSSY=true                                   # If true, send update_component over lossy channel for lower latency
+VOICE_AGENT_EVENT_BUDGET_PER_SEC=24                             # Max tool_call events/sec per room before drop
+VOICE_AGENT_TOOL_DEDUPE_WINDOW_MS=1500                          # Duplicate tool_call suppression window
+VOICE_AGENT_ALLOW_INTERNAL_BYPASS=false                         # Only true for trusted server-side bypass flows
 FLOWCHART_STEWARD_VARIANT=openai                                # Set to "fast", "groq", or "cerebras" to enable StewardFAST
 FLOWCHART_STEWARD_FAST_PROVIDER=groq                            # Override provider for StewardFAST ("groq" or "cerebras")
 FLOWCHART_STEWARD_FAST_MODEL=openai/gpt-oss-20b                 # Model used when StewardFAST is active (provider-specific)
@@ -99,6 +113,9 @@ FAIRY_INTENT_DEDUPE_MAX=200                                     # Max fingerprin
 CANVAS_QUEUE_DIRECT_FALLBACK=false                              # Set true to execute the steward immediately when queue enqueue fails
 CANVAS_STEWARD_DEBUG=false                                      # Set true to log prompts/actions for canvas steward debugging
 CANVAS_AGENT_SECRET=change-me-to-strong-secret                  # Used to sign agent inbox tokens
+NEXT_PUBLIC_CANVAS_SCREENSHOT_COALESCE_MS=250                   # Coalesce screenshot bursts to first/last frame
+CANVAS_SCREENSHOT_RETENTION_MS=86400000                         # Screenshot inbox retention (24h)
+CANVAS_ACK_RETENTION_MS=86400000                                # Ack inbox retention (24h)
 # CANVAS_AGENT_DEV_ALLOW_UNAUTH=true                             # Optional dev bypass (do not enable in production)
 
 # Unified Canvas Agent Configuration (see docs/canvas-agent.md)
@@ -121,8 +138,37 @@ ANTHROPIC_CACHE_TTL=1h                                          # TTL for Anthro
 CANVAS_AGENT_MAX_FOLLOWUPS=3                                    # Legacy follow-up cap (kept for backward compatibility)
 CANVAS_AGENT_SCREENSHOT_MAX_SIZE=1024                           # Max screenshot edge length (pixels)
 CANVAS_AGENT_SHAPE_STATE_LIMIT=4096                             # Max bytes of TLDraw shape.props.state to include in prompt (truncates beyond)
+CANVAS_SCREENSHOT_COALESCE_MS=250                               # Server-side reference for screenshot coalescing windows
 SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key      # Required for Canvas Agent todos table writes
 LIVEKIT_REST_URL=https://your-livekit-url.livekit.cloud       # LiveKit REST URL for server-side data channel broadcasts
+
+# Proxy + ingestion guardrails
+MCP_PROXY_ALLOWLIST=server.smithery.ai,mcp.linear.app           # Comma-separated host allowlist for /api/mcp-proxy
+MCP_PROXY_REQUIRE_AUTH=false                                    # Require Supabase bearer auth (recommended true in production)
+MCP_PROXY_RATE_LIMIT_PER_USER_PER_MIN=120
+MCP_PROXY_MAX_CONCURRENCY_PER_USER=4
+
+TRANSCRIBE_MAX_BODY_BYTES=3000000
+TRANSCRIBE_MAX_AUDIO_BYTES=1500000
+TRANSCRIBE_RATE_LIMIT_PER_USER_PER_MIN=20
+TRANSCRIBE_REQUIRE_AUTH=false                                    # Enable in production to require authenticated transcription calls
+TRANSCRIPT_RETENTION_DAYS=30                                     # Transcript retention horizon
+
+# Queue + background controls
+SCORECARD_AUTO_FACT_CHECK=false                                 # Keep auto fact-check opt-in by default
+SCORECARD_AUTO_FACT_CHECK_MIN_INTERVAL_MS=30000
+SCORECARD_AUTO_FACT_CHECK_ROOM_MIN_INTERVAL_MS=120000
+CONDUCTOR_IDLE_BACKOFF_MAX_MS=15000
+FACT_CHECK_CACHE_TTL_SEC=900
+TASK_QUEUE_MAX_DEPTH_PER_ROOM=0                                 # 0 disables queue-depth breaker
+CONDUCTOR_ALLOW_INTERNAL_BYPASS=false                           # Only true for trusted server-side bypass flows
+
+# Cost circuit breakers
+COST_CIRCUIT_BREAKER_ENABLED=false
+COST_TOKEN_MINT_PER_MINUTE_LIMIT=300
+COST_SEARCH_PER_MINUTE_LIMIT=40
+COST_SCREENSHOT_BYTES_PER_MINUTE_LIMIT=8000000
+COST_TRANSCRIBE_AUDIO_BYTES_PER_MINUTE_LIMIT=24000000
 
 # React Profiler (set to true to enable React DevTools Profiler in development)
 NEXT_PUBLIC_REACT_APP_PROFILER=false

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "agent:conductor": "npx tsx --tsconfig tsconfig.agent.json src/lib/agents/conductor/index.ts",
     "lk:server:dev": "bash scripts/run-livekit-dev.sh",
     "sync:dev": "npx tsx scripts/tldraw-sync-server/server.ts",
+    "cf:ingress:dev": "npx wrangler dev --config cloudflare/ingress/wrangler.toml",
+    "cf:ingress:deploy": "npx wrangler deploy --config cloudflare/ingress/wrangler.toml",
     "stack:start": "bash scripts/start-dev-stack.sh",
     "stack:stop": "bash scripts/stop-dev-stack.sh",
     "stack:restart": "bash scripts/restart-dev-stack.sh",

--- a/src/app/api/agent/enqueue/route.ts
+++ b/src/app/api/agent/enqueue/route.ts
@@ -10,6 +10,7 @@ const requestSchema = z.object({
   resourceKeys: z.array(z.string()).optional(),
   priority: z.number().int().min(0).default(0),
   runAt: z.coerce.date().optional(),
+  coalesceByResource: z.boolean().optional(),
 });
 
 export async function POST(request: Request) {

--- a/src/app/api/canvas-agent/screenshot/route.ts
+++ b/src/app/api/canvas-agent/screenshot/route.ts
@@ -1,8 +1,22 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { storeScreenshot } from '@/server/inboxes/screenshot';
 import { verifyAgentToken } from '@/lib/agents/canvas-agent/server/auth/agentTokens';
+import { consumeBudget, isCostCircuitBreakerEnabled } from '@/lib/server/traffic-guards';
 
 const REQUIRE_AGENT_TOKEN = process.env.CANVAS_AGENT_REQUIRE_TOKEN === 'true';
+const SCREENSHOT_BUDGET_BYTES_PER_MIN = Math.max(
+  200_000,
+  Number(process.env.COST_SCREENSHOT_BYTES_PER_MINUTE_LIMIT ?? 8_000_000),
+);
+
+function estimateDataUrlBytes(dataUrl: unknown): number {
+  if (typeof dataUrl !== 'string' || !dataUrl) return 0;
+  const commaIndex = dataUrl.indexOf(',');
+  const base64Payload = (commaIndex >= 0 ? dataUrl.slice(commaIndex + 1) : dataUrl).replace(/\s+/g, '');
+  if (!base64Payload) return 0;
+  const padding = base64Payload.endsWith('==') ? 2 : base64Payload.endsWith('=') ? 1 : 0;
+  return Math.max(0, Math.floor((base64Payload.length * 3) / 4) - padding);
+}
 
 export async function POST(req: NextRequest) {
   try {
@@ -24,6 +38,25 @@ export async function POST(req: NextRequest) {
     }
     if (token && !verifyAgentToken(token, { sessionId, roomId, requestId })) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    const claimedImageBytes =
+      typeof body?.image?.bytes === 'number' && Number.isFinite(body.image.bytes)
+        ? Math.max(0, Math.floor(body.image.bytes))
+        : 0;
+    const derivedImageBytes = estimateDataUrlBytes(body?.image?.dataUrl);
+    const imageBytes = Math.max(claimedImageBytes, derivedImageBytes);
+    if (isCostCircuitBreakerEnabled()) {
+      const metricKey = roomId ? `screenshot-bytes:room:${roomId}` : `screenshot-bytes:session:${sessionId}`;
+      const budget = consumeBudget(metricKey, imageBytes, SCREENSHOT_BUDGET_BYTES_PER_MIN, 60_000);
+      if (!budget.ok) {
+        return NextResponse.json(
+          { error: 'Screenshot budget exceeded', retryAfterSec: budget.retryAfterSec },
+          { status: 429, headers: { 'Retry-After': String(budget.retryAfterSec) } },
+        );
+      }
+    }
+    if (body?.image && typeof body.image === 'object') {
+      body.image.bytes = imageBytes;
     }
     storeScreenshot(body as any);
     return NextResponse.json({ ok: true });

--- a/src/app/api/mcp-proxy/route.ts
+++ b/src/app/api/mcp-proxy/route.ts
@@ -1,113 +1,289 @@
-import { NextRequest } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
+import { getRequestUserId } from '@/lib/supabase/server/request-user';
+import { acquireConcurrencySlot, consumeWindowedLimit } from '@/lib/server/traffic-guards';
 
-// --- Simple streaming proxy for MCP servers --------------------------------
-// Browsers block direct fetches to many public MCP servers because they do not
-// include an `Access-Control-Allow-Origin` header. We work around this by
-// proxying the request through our own Next.js server (same origin as the
-// frontend).
-// Usage from the browser:
-//   fetch(`/api/mcp-proxy?target=${encodeURIComponent('https://server.smithery.ai/exa/mcp?api_key=xxx')}`)
-// The proxy forwards the request, streams back the response body (important
-// for SSE connections) and appends permissive CORS headers.
-// ---------------------------------------------------------------------------
+export const runtime = 'edge';
 
-export const runtime = 'edge'; // Enable edge runtime for lower latency streams
+const DEFAULT_MAX_CONCURRENCY = Math.max(1, Number(process.env.MCP_PROXY_MAX_CONCURRENCY_PER_USER ?? 4));
+const DEFAULT_MAX_RPM = Math.max(1, Number(process.env.MCP_PROXY_RATE_LIMIT_PER_USER_PER_MIN ?? 120));
+const REQUIRE_AUTH =
+  (process.env.MCP_PROXY_REQUIRE_AUTH ??
+    (process.env.NODE_ENV === 'production' ? 'true' : 'false')) === 'true';
 
-const CORS_HEADERS = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Methods': 'GET,POST,PUT,DELETE,OPTIONS',
-  'Access-Control-Allow-Headers': '*',
+const HOP_BY_HOP_HEADERS = new Set([
+  'connection',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade',
+  'host',
+]);
+
+const SENSITIVE_HEADERS = new Set([
+  'authorization',
+  'cookie',
+  'set-cookie',
+  'x-forwarded-for',
+  'x-forwarded-host',
+  'x-forwarded-proto',
+  'x-real-ip',
+  'cf-connecting-ip',
+  'cf-ipcountry',
+  'cf-ray',
+]);
+
+const ALLOWED_FORWARD_HEADERS = new Set([
+  'accept',
+  'accept-language',
+  'cache-control',
+  'content-type',
+  'last-event-id',
+  'mcp-session-id',
+  'mcp-protocol-version',
+  'pragma',
+  'user-agent',
+  'x-request-id',
+  'x-mcp-upstream-authorization',
+]);
+
+const parseAllowlist = () => {
+  const configured = (process.env.MCP_PROXY_ALLOWLIST || '')
+    .split(',')
+    .map((entry) => entry.trim().toLowerCase())
+    .filter(Boolean);
+  if (configured.length > 0) return configured;
+  return ['mcp.linear.app', 'server.smithery.ai', 'localhost', '127.0.0.1'];
 };
 
-async function forward(request: NextRequest, targetUrl: string): Promise<Response> {
-  try {
-    // Parse the target URL to preserve query parameters
-    const url = new URL(targetUrl);
+const isLocalDevelopmentHost = (url: URL) =>
+  ['localhost', '127.0.0.1', '::1'].includes(url.hostname.toLowerCase());
 
-    // Merge any additional query params from the proxy request
-    // (but don't override params already in the target URL)
+function isAllowlistedTarget(url: URL, allowlist: string[]): boolean {
+  if (!allowlist.length) return false;
+  const host = url.host.toLowerCase();
+  const hostname = url.hostname.toLowerCase();
+  for (const rule of allowlist) {
+    if (rule === host || rule === hostname) return true;
+    if (rule.startsWith('*.')) {
+      const suffix = rule.slice(1);
+      if (hostname.endsWith(suffix)) return true;
+    }
+  }
+  return false;
+}
+
+function getCorsHeaders(request: NextRequest) {
+  const origin = request.headers.get('origin') || '*';
+  return {
+    'Access-Control-Allow-Origin': origin,
+    'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+    'Access-Control-Allow-Headers':
+      'Content-Type, Authorization, Last-Event-ID, MCP-Session-Id, X-MCP-Upstream-Authorization',
+    Vary: 'Origin',
+  };
+}
+
+function buildForwardHeaders(req: NextRequest): Headers {
+  const headers = new Headers();
+  for (const [key, value] of req.headers.entries()) {
+    const lower = key.toLowerCase();
+    if (HOP_BY_HOP_HEADERS.has(lower)) continue;
+    if (SENSITIVE_HEADERS.has(lower) && lower !== 'x-mcp-upstream-authorization') continue;
+    if (!ALLOWED_FORWARD_HEADERS.has(lower)) continue;
+    if (lower === 'x-mcp-upstream-authorization') {
+      headers.set('Authorization', value);
+      continue;
+    }
+    headers.set(key, value);
+  }
+  return headers;
+}
+
+function sanitizeUpstreamResponseHeaders(upstream: Response, corsHeaders: Record<string, string>) {
+  const headers = new Headers();
+  upstream.headers.forEach((value, key) => {
+    const lower = key.toLowerCase();
+    if (HOP_BY_HOP_HEADERS.has(lower)) return;
+    if (lower === 'set-cookie') return;
+    headers.set(key, value);
+  });
+  Object.entries(corsHeaders).forEach(([key, value]) => headers.set(key, value));
+  headers.set('Cache-Control', 'no-store');
+  return headers;
+}
+
+async function authorize(req: NextRequest) {
+  if (!REQUIRE_AUTH) {
+    const forwarded = req.headers.get('x-forwarded-for') || '';
+    const ip = forwarded.split(',')[0]?.trim() || 'unknown-ip';
+    const ua = req.headers.get('user-agent') || 'unknown-ua';
+    const raw = new TextEncoder().encode(`${ip}|${ua}`);
+    const digest = await crypto.subtle.digest('SHA-1', raw);
+    const anonHash = Array.from(new Uint8Array(digest))
+      .slice(0, 8)
+      .map((value) => value.toString(16).padStart(2, '0'))
+      .join('');
+    return `anonymous:${anonHash}`;
+  }
+  const auth = await getRequestUserId(req);
+  if (!auth.ok) {
+    if (auth.error === 'misconfigured') {
+      return NextResponse.json({ error: 'Auth configuration missing' }, { status: 500 });
+    }
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  return auth.userId;
+}
+
+async function forward(request: NextRequest, targetUrl: URL, userId: string): Promise<Response> {
+  const corsHeaders = getCorsHeaders(request);
+  const maxConcurrency = DEFAULT_MAX_CONCURRENCY;
+  const maxRpm = DEFAULT_MAX_RPM;
+
+  const rate = consumeWindowedLimit(`mcp:user:${userId}`, maxRpm, 60_000);
+  if (!rate.ok) {
+    return NextResponse.json(
+      { error: 'Rate limit exceeded', retryAfterSec: rate.retryAfterSec },
+      {
+        status: 429,
+        headers: { ...corsHeaders, 'Retry-After': String(rate.retryAfterSec) },
+      },
+    );
+  }
+
+  const slot = acquireConcurrencySlot(`mcp:user:${userId}`, maxConcurrency);
+  if (!slot.ok) {
+    return NextResponse.json(
+      {
+        error: 'Too many concurrent MCP streams',
+        inFlight: slot.inFlight,
+        maxConcurrency: slot.limit,
+      },
+      { status: 429, headers: corsHeaders },
+    );
+  }
+
+  let released = false;
+  const releaseSlot = () => {
+    if (!released) {
+      released = true;
+      slot.release();
+    }
+  };
+
+  try {
     request.nextUrl.searchParams.forEach((value, key) => {
-      if (key !== 'target' && !url.searchParams.has(key)) {
-        url.searchParams.set(key, value);
+      if (key !== 'target' && !targetUrl.searchParams.has(key)) {
+        targetUrl.searchParams.set(key, value);
       }
     });
 
     const init: RequestInit = {
       method: request.method,
-      // Forward headers except Host so the upstream sees correct origin
-      headers: Object.fromEntries(
-        [...request.headers.entries()].filter(([key]) => key.toLowerCase() !== 'host'),
-      ),
-      // For non-GET methods pass the body through
+      headers: buildForwardHeaders(request),
       body: ['GET', 'HEAD'].includes(request.method) ? undefined : request.body,
       redirect: 'follow',
-      cache: 'no-store', // Disable caching for SSE/API proxy
-      // @ts-expect-error - duplex is required for streaming bodies in some environments but not in all TS definitions
+      cache: 'no-store',
+      // @ts-expect-error duplex is required for streaming POST bodies in some runtimes.
       duplex: 'half',
     };
 
-    console.log('[MCP Proxy] Forwarding to:', url.toString());
-    const upstream = await fetch(url.toString(), init);
-    console.log('[MCP Proxy] Upstream status:', upstream.status);
+    const upstream = await fetch(targetUrl.toString(), init);
+    const headers = sanitizeUpstreamResponseHeaders(upstream, corsHeaders);
+    if (!upstream.body) {
+      releaseSlot();
+      return new Response(null, {
+        status: upstream.status,
+        headers,
+      });
+    }
 
-    // Stream the body directly so we support Server-Sent Events (text/event-stream)
-    return new Response(upstream.body, {
-      status: upstream.status,
-      headers: {
-        ...Object.fromEntries(upstream.headers.entries()),
-        ...CORS_HEADERS,
+    const reader = upstream.body.getReader();
+    const proxiedBody = new ReadableStream<Uint8Array>({
+      async pull(controller) {
+        try {
+          const { done, value } = await reader.read();
+          if (done) {
+            releaseSlot();
+            controller.close();
+            return;
+          }
+          if (value) controller.enqueue(value);
+        } catch (error) {
+          releaseSlot();
+          controller.error(error);
+        }
+      },
+      async cancel(reason) {
+        releaseSlot();
+        await reader.cancel(reason);
       },
     });
+
+    return new Response(proxiedBody, {
+      status: upstream.status,
+      headers,
+    });
   } catch (error) {
-    console.error('[MCP Proxy] Error forwarding request:', error);
-    return new Response(
-      JSON.stringify({
+    releaseSlot();
+    return NextResponse.json(
+      {
         error: 'Proxy error',
         message: error instanceof Error ? error.message : 'Unknown error',
-      }),
-      {
-        status: 500,
-        headers: {
-          'Content-Type': 'application/json',
-          ...CORS_HEADERS,
-        },
       },
+      { status: 502, headers: corsHeaders },
     );
   }
 }
 
-export async function OPTIONS() {
-  return new Response(null, { status: 200, headers: CORS_HEADERS });
+async function handleProxy(req: NextRequest) {
+  const corsHeaders = getCorsHeaders(req);
+  const target = req.nextUrl.searchParams.get('target');
+  if (!target) {
+    return new Response('Missing "target" query parameter', { status: 400, headers: corsHeaders });
+  }
+
+  let targetUrl: URL;
+  try {
+    targetUrl = new URL(target);
+  } catch {
+    return new Response('Invalid target URL', { status: 400, headers: corsHeaders });
+  }
+
+  const allowlist = parseAllowlist();
+  if (!allowlist.length) {
+    return NextResponse.json(
+      { error: 'Server misconfigured: MCP_PROXY_ALLOWLIST is required' },
+      { status: 500, headers: corsHeaders },
+    );
+  }
+
+  if (targetUrl.protocol !== 'https:' && !(process.env.NODE_ENV !== 'production' && isLocalDevelopmentHost(targetUrl) && targetUrl.protocol === 'http:')) {
+    return new Response('Only HTTPS targets are allowed', { status: 400, headers: corsHeaders });
+  }
+
+  if (!isAllowlistedTarget(targetUrl, allowlist)) {
+    return new Response('Target host is not allowlisted', { status: 403, headers: corsHeaders });
+  }
+
+  const auth = await authorize(req);
+  if (auth instanceof NextResponse) {
+    return auth;
+  }
+  return forward(req, targetUrl, auth);
+}
+
+export async function OPTIONS(req: NextRequest) {
+  return new Response(null, { status: 204, headers: getCorsHeaders(req) });
 }
 
 export async function GET(req: NextRequest) {
-  const target = req.nextUrl.searchParams.get('target');
-  if (!target) {
-    return new Response('Missing "target" query parameter', { status: 400, headers: CORS_HEADERS });
-  }
-
-  // Validate the target URL
-  try {
-    new URL(target);
-  } catch {
-    return new Response('Invalid target URL', { status: 400, headers: CORS_HEADERS });
-  }
-
-  return forward(req, target);
+  return handleProxy(req);
 }
 
 export async function POST(req: NextRequest) {
-  const target = req.nextUrl.searchParams.get('target');
-  if (!target) {
-    return new Response('Missing "target" query parameter', { status: 400, headers: CORS_HEADERS });
-  }
-
-  // Validate the target URL
-  try {
-    new URL(target);
-  } catch {
-    return new Response('Invalid target URL', { status: 400, headers: CORS_HEADERS });
-  }
-
-  return forward(req, target);
+  return handleProxy(req);
 }

--- a/src/app/api/session-transcripts/route.ts
+++ b/src/app/api/session-transcripts/route.ts
@@ -8,6 +8,10 @@ import { getBooleanFlag } from '@/lib/feature-flags';
 export const runtime = 'nodejs';
 
 const DEMO_MODE_ENABLED = getBooleanFlag(process.env.NEXT_PUBLIC_CANVAS_DEMO_MODE, false);
+const TRANSCRIPT_RETENTION_DAYS = Math.max(
+  1,
+  Number(process.env.TRANSCRIPT_RETENTION_DAYS ?? 30),
+);
 
 const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
 const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
@@ -95,11 +99,13 @@ export async function GET(req: NextRequest) {
   }
 
   const { sessionId, limit } = parsed.data;
+  const retentionCutoff = Date.now() - TRANSCRIPT_RETENTION_DAYS * 24 * 60 * 60 * 1000;
 
   const { data, error } = await supabase
     .from('canvas_session_transcripts')
     .select('event_id, participant_id, participant_name, text, ts, manual')
     .eq('session_id', sessionId)
+    .gte('ts', retentionCutoff)
     .order('ts', { ascending: false })
     .limit(limit);
 
@@ -139,6 +145,7 @@ export async function POST(req: NextRequest) {
   }
 
   const { sessionId, entries } = parsed.data;
+  const retentionCutoff = Date.now() - TRANSCRIPT_RETENTION_DAYS * 24 * 60 * 60 * 1000;
 
   const { data: session, error: sessionErr } = await supabase
     .from('canvas_sessions')
@@ -166,9 +173,21 @@ export async function POST(req: NextRequest) {
     manual: entry.manual ?? false,
   }));
 
+  const freshRows = rows.filter((row) => Number.isFinite(row.ts) && row.ts >= retentionCutoff);
+  if (freshRows.length === 0) {
+    return NextResponse.json({ ok: true, skipped: true });
+  }
+
+  // Opportunistic cleanup keeps transcript storage bounded without a dedicated cron.
+  void supabase
+    .from('canvas_session_transcripts')
+    .delete()
+    .eq('session_id', sessionId)
+    .lt('ts', retentionCutoff);
+
   const { error } = await supabase
     .from('canvas_session_transcripts')
-    .upsert(rows, { onConflict: 'event_id', ignoreDuplicates: true });
+    .upsert(freshRows, { onConflict: 'event_id', ignoreDuplicates: true });
 
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });

--- a/src/app/api/steward/runCanvas/route.ts
+++ b/src/app/api/steward/runCanvas/route.ts
@@ -53,12 +53,17 @@ export async function POST(req: NextRequest) {
     try {
       // Lazily instantiate so `next build` doesn't require Supabase env vars.
       const queue = new AgentTaskQueue();
+      const normalizedResourceKeys =
+        normalizedTask === 'canvas.agent_prompt' || normalizedTask === 'fairy.intent'
+          ? [`room:${trimmedRoom}`, 'canvas:intent']
+          : [`room:${trimmedRoom}`];
       const enqueueResult = await queue.enqueueTask({
         room: trimmedRoom,
         task: normalizedTask,
         params: normalizedParams,
         requestId,
-        resourceKeys: [`room:${trimmedRoom}`],
+        resourceKeys: normalizedResourceKeys,
+        coalesceByResource: normalizedTask === 'canvas.agent_prompt' || normalizedTask === 'fairy.intent',
       });
       if (normalizedTask === 'canvas.agent_prompt') {
         try {

--- a/src/app/api/token/route.ts
+++ b/src/app/api/token/route.ts
@@ -1,55 +1,104 @@
+import { createHash, timingSafeEqual } from 'crypto';
 import type { AccessTokenOptions, VideoGrant } from 'livekit-server-sdk';
 import { AccessToken } from 'livekit-server-sdk';
 import { NextRequest, NextResponse } from 'next/server';
+import { getRequestUserId } from '@/lib/supabase/server/request-user';
+import {
+  consumeBudget,
+  consumeWindowedLimit,
+  isCostCircuitBreakerEnabled,
+} from '@/lib/server/traffic-guards';
+
 export const runtime = 'nodejs';
-
-/**
- * GET /api/token?roomName=ROOM&username=NAME
- *
- * Generates a signed LiveKit JWT that allows the client to join the requested room.
- *
- * Expects the following environment variables to be set (see `.env.local.example`):
- *   LIVEKIT_API_KEY
- *   LIVEKIT_API_SECRET
- *   LIVEKIT_URL (optional – returned so the client knows which URL to connect to)
- */
-
-// Do not cache endpoint result
 export const revalidate = 0;
 
 const apiKey = process.env.LIVEKIT_API_KEY;
 const apiSecret = process.env.LIVEKIT_API_SECRET;
+const signatureSkewMs = Math.max(30_000, Number(process.env.TOKEN_SIGNATURE_MAX_SKEW_MS ?? 300_000));
+const userRatePerMinute = Math.max(1, Number(process.env.TOKEN_RATE_LIMIT_PER_USER_PER_MIN ?? 30));
+const roomRatePerMinute = Math.max(1, Number(process.env.TOKEN_RATE_LIMIT_PER_ROOM_PER_MIN ?? 90));
+const nonceTtlMs = Math.max(60_000, Number(process.env.TOKEN_NONCE_TTL_MS ?? 120_000));
+const tokenBudgetPerMinute = Math.max(1, Number(process.env.COST_TOKEN_MINT_PER_MINUTE_LIMIT ?? 300));
+const REQUIRE_AUTH =
+  (process.env.TOKEN_REQUIRE_AUTH ?? (process.env.NODE_ENV === 'production' ? 'true' : 'false')) ===
+  'true';
+const REQUIRE_SIGNED_NONCE =
+  (process.env.TOKEN_REQUIRE_SIGNED_NONCE ??
+    (process.env.NODE_ENV === 'production' ? 'true' : 'false')) === 'true';
+
+const nonceLedger = new Map<string, number>();
 
 const createToken = async (userInfo: AccessTokenOptions, grant: VideoGrant) => {
   if (!apiKey) {
     throw new Error('Server misconfigured: missing LIVEKIT_API_KEY');
   }
-
   if (!apiSecret) {
     throw new Error('Server misconfigured: missing LIVEKIT_API_SECRET');
   }
 
-  try {
-    const at = new AccessToken(apiKey, apiSecret, userInfo);
-    at.addGrant(grant);
-    return await at.toJwt();
-  } catch (error) {
-    console.error('Token creation error:', error);
-    throw new Error(`Failed to create token: ${(error as Error).message}`);
-  }
+  const at = new AccessToken(apiKey, apiSecret, userInfo);
+  at.addGrant(grant);
+  return await at.toJwt();
 };
+
+const readBearerToken = (req: NextRequest): string | null => {
+  const header = req.headers.get('authorization') || req.headers.get('Authorization');
+  if (!header) return null;
+  const match = header.match(/^Bearer\s+(.+)$/i);
+  return match?.[1]?.trim() || null;
+};
+
+const getTestUserId = (): string | null => {
+  if (process.env.NODE_ENV !== 'test') return null;
+  const raw = process.env.TEST_USER_ID?.trim();
+  return raw || null;
+};
+
+const resolveUserId = async (req: NextRequest) => {
+  const testUser = getTestUserId();
+  if (testUser) return { ok: true as const, userId: testUser };
+  return getRequestUserId(req);
+};
+
+const safeEqual = (left: string, right: string) => {
+  const a = Buffer.from(left);
+  const b = Buffer.from(right);
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+};
+
+function pruneNonceLedger(now: number) {
+  if (nonceLedger.size < 1_000) return;
+  for (const [key, ts] of nonceLedger) {
+    if (now - ts > nonceTtlMs) {
+      nonceLedger.delete(key);
+    }
+  }
+}
+
+function buildSignaturePayload(
+  req: NextRequest,
+  roomName: string,
+  identity: string,
+  timestamp: string,
+  nonce: string,
+) {
+  return [
+    req.method.toUpperCase(),
+    req.nextUrl.pathname,
+    roomName,
+    identity,
+    timestamp,
+    nonce,
+  ].join('.');
+}
+
+function computeSignature(payload: string, bearerToken: string): string {
+  return createHash('sha256').update(`${bearerToken}.${payload}`).digest('hex');
+}
 
 export async function GET(req: NextRequest) {
   try {
-    // Add debug logging
-    console.log('Token request params:', Object.fromEntries(req.nextUrl.searchParams));
-    console.log('Environment check:', {
-      hasApiKey: !!apiKey,
-      hasApiSecret: !!apiSecret,
-      hasLivekitUrl: !!process.env.LIVEKIT_URL,
-    });
-
-    // Update parameter names to match what's being sent by useToken
     const roomName =
       req.nextUrl.searchParams.get('roomName') || req.nextUrl.searchParams.get('room');
     const identity =
@@ -74,15 +123,102 @@ export async function GET(req: NextRequest) {
     const wsUrl = process.env.LIVEKIT_URL;
     if (!wsUrl) {
       return NextResponse.json(
-        {
-          error: 'Server misconfigured: missing LIVEKIT_URL environment variable',
-        },
+        { error: 'Server misconfigured: missing LIVEKIT_URL environment variable' },
         { status: 500 },
       );
     }
 
+    const auth = REQUIRE_AUTH
+      ? await resolveUserId(req)
+      : ({ ok: true, userId: getTestUserId() || 'anonymous-dev' } as const);
+    if (!auth.ok) {
+      if (auth.error === 'misconfigured') {
+        return NextResponse.json({ error: 'Auth configuration missing' }, { status: 500 });
+      }
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const bearerToken = readBearerToken(req);
+    if (REQUIRE_AUTH && !bearerToken && process.env.NODE_ENV !== 'test') {
+      return NextResponse.json({ error: 'Missing bearer token' }, { status: 401 });
+    }
+    if (REQUIRE_SIGNED_NONCE && !bearerToken && process.env.NODE_ENV !== 'test') {
+      return NextResponse.json({ error: 'Missing bearer token for signed request' }, { status: 401 });
+    }
+
+    const timestamp = req.headers.get('x-timestamp')?.trim() || '';
+    const signature = req.headers.get('x-signature')?.trim() || '';
+    const nonce = req.headers.get('x-nonce')?.trim() || '';
+    if (REQUIRE_SIGNED_NONCE && (!timestamp || !signature || !nonce) && process.env.NODE_ENV !== 'test') {
+      return NextResponse.json(
+        { error: 'Missing required signed nonce headers: x-timestamp, x-signature, x-nonce' },
+        { status: 401 },
+      );
+    }
+
+    if (REQUIRE_SIGNED_NONCE && timestamp && signature && nonce && bearerToken) {
+      const now = Date.now();
+      const ts = Number(timestamp);
+      if (!Number.isFinite(ts) || Math.abs(now - ts) > signatureSkewMs) {
+        return NextResponse.json({ error: 'Signature timestamp expired' }, { status: 401 });
+      }
+
+      pruneNonceLedger(now);
+      const nonceKey = `${auth.userId}:${nonce}`;
+      const usedAt = nonceLedger.get(nonceKey);
+      if (typeof usedAt === 'number' && now - usedAt < nonceTtlMs) {
+        return NextResponse.json({ error: 'Nonce already used' }, { status: 409 });
+      }
+
+      const payload = buildSignaturePayload(req, roomName.trim(), identity.trim(), timestamp, nonce);
+      const expected = computeSignature(payload, bearerToken);
+      if (!safeEqual(expected, signature)) {
+        return NextResponse.json({ error: 'Invalid signature' }, { status: 401 });
+      }
+      nonceLedger.set(nonceKey, now);
+    }
+
+    const userRate = consumeWindowedLimit(
+      `token:user:${auth.userId}`,
+      userRatePerMinute,
+      60_000,
+    );
+    if (!userRate.ok) {
+      return NextResponse.json(
+        { error: 'Rate limit exceeded', retryAfterSec: userRate.retryAfterSec },
+        {
+          status: 429,
+          headers: { 'Retry-After': String(userRate.retryAfterSec) },
+        },
+      );
+    }
+
+    const roomRate = consumeWindowedLimit(`token:room:${roomName.trim()}`, roomRatePerMinute, 60_000);
+    if (!roomRate.ok) {
+      return NextResponse.json(
+        { error: 'Room rate limit exceeded', retryAfterSec: roomRate.retryAfterSec },
+        {
+          status: 429,
+          headers: { 'Retry-After': String(roomRate.retryAfterSec) },
+        },
+      );
+    }
+
+    if (isCostCircuitBreakerEnabled()) {
+      const budget = consumeBudget('token-mints', 1, tokenBudgetPerMinute, 60_000);
+      if (!budget.ok) {
+        return NextResponse.json(
+          { error: 'Token budget exceeded', retryAfterSec: budget.retryAfterSec },
+          {
+            status: 429,
+            headers: { 'Retry-After': String(budget.retryAfterSec) },
+          },
+        );
+      }
+    }
+
     const grant: VideoGrant = {
-      room: roomName,
+      room: roomName.trim(),
       roomJoin: true,
       canPublish: true,
       canPublishData: true,
@@ -90,31 +226,24 @@ export async function GET(req: NextRequest) {
       canUpdateOwnMetadata: true,
     };
 
-    // Create token for the participant
     const token = await createToken(
       {
-        identity,
+        identity: identity.trim(),
         name: name || undefined,
         metadata: metadata || undefined,
       },
       grant,
     );
 
-    console.log(`✅ Token created for ${identity} in room ${roomName}`);
-    console.log('🤖 Agent will automatically join via automatic dispatch');
-
     return NextResponse.json(
-      {
-        identity,
-        accessToken: token,
-      },
+      { identity: identity.trim(), accessToken: token },
       { headers: { 'Cache-Control': 'no-store' } },
     );
   } catch (e) {
-    console.error('Token generation error:', e);
+    console.error('[token] generation error', e instanceof Error ? e.message : e);
     return NextResponse.json(
       {
-        error: (e as Error).message,
+        error: e instanceof Error ? e.message : 'Failed to create token',
         stack: process.env.NODE_ENV === 'development' ? (e as Error).stack : undefined,
       },
       { status: 500 },

--- a/src/components/tool-dispatcher/tool-dispatcher.tsx
+++ b/src/components/tool-dispatcher/tool-dispatcher.tsx
@@ -5,6 +5,7 @@ import { useRoomContext } from '@livekit/components-react';
 import type { DispatcherContext } from './utils';
 import { useToolEvents, useToolRunner } from './hooks';
 import { fetchWithSupabaseAuth } from '@/lib/supabase/auth-headers';
+import { resolveEdgeIngressUrl } from '@/lib/edge-ingress';
 
 // Exported so fixture routes (e.g. /showcase/ui) can provide a no-op dispatcher
 // without pulling in LiveKit room context.
@@ -98,7 +99,7 @@ export function ToolDispatcher({
           try {
             const clientId = room?.localParticipant?.identity || 'unknown';
             const roomId = room?.name || '';
-            await fetchWithSupabaseAuth('/api/canvas-agent/ack', {
+            await fetchWithSupabaseAuth(resolveEdgeIngressUrl('/api/canvas-agent/ack'), {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
               body: JSON.stringify({

--- a/src/components/ui/canvas/hooks/useScreenshotRequestHandler.ts
+++ b/src/components/ui/canvas/hooks/useScreenshotRequestHandler.ts
@@ -4,119 +4,232 @@ import { useEffect } from 'react';
 import { Box, type Editor } from '@tldraw/tldraw';
 import type { Room } from 'livekit-client';
 import { createLiveKitBus } from '@/lib/livekit/livekit-bus';
+import { resolveEdgeIngressUrl } from '@/lib/edge-ingress';
+
+type ScreenshotRequest = {
+  type: 'agent:screenshot_request';
+  sessionId: string;
+  requestId: string;
+  bounds?: { x: number; y: number; w: number; h: number };
+  maxSize?: { w: number; h: number };
+  token?: string;
+  roomId?: string;
+};
+
+type BurstState = {
+  firstRequestId: string;
+  firstSceneHash: string;
+  latestMessage?: ScreenshotRequest;
+  latestSceneHash?: string;
+  timer?: ReturnType<typeof setTimeout>;
+};
+
+const resolveCoalesceWindowMs = () =>
+  Math.max(75, Number(process.env.NEXT_PUBLIC_CANVAS_SCREENSHOT_COALESCE_MS ?? 250));
 
 export function useScreenshotRequestHandler(editor: Editor | undefined, room: Room | undefined) {
   useEffect(() => {
     if (!editor || !room) return;
+
     const bus = createLiveKitBus(room);
-    const off = bus.on('agent:screenshot_request', async (message: any) => {
-      try {
-        if (!message || message.type !== 'agent:screenshot_request') return;
-        const { sessionId, requestId, bounds, maxSize, token: requestToken, roomId: messageRoomId } = message;
-        const isDev = process.env.NODE_ENV !== 'production';
+    const isDev = process.env.NODE_ENV !== 'production';
+    const coalesceWindowMs = resolveCoalesceWindowMs();
+    const burstStateByKey = new Map<string, BurstState>();
+    const uploadedRequestAt = new Map<string, number>();
+    const requestUploadDedupeTtlMs = 5 * 60_000;
+
+    const computeSceneHash = (
+      sessionId: string,
+      rawTarget: { x: number; y: number; w: number; h: number },
+      viewport: { x: number; y: number; w: number; h: number },
+      selection: string[],
+      docVersion: string,
+      shapeCount: number,
+    ) =>
+      [
+        sessionId,
+        docVersion,
+        `${Math.round(rawTarget.x)}:${Math.round(rawTarget.y)}:${Math.round(rawTarget.w)}:${Math.round(rawTarget.h)}`,
+        `${Math.round(viewport.x)}:${Math.round(viewport.y)}:${Math.round(viewport.w)}:${Math.round(viewport.h)}`,
+        selection.slice().sort().join(','),
+        shapeCount,
+      ].join('|');
+
+    const toBurstKey = (sessionId: string, rawTarget: { x: number; y: number; w: number; h: number }) =>
+      `${sessionId}:${Math.round(rawTarget.x)}:${Math.round(rawTarget.y)}:${Math.round(rawTarget.w)}:${Math.round(rawTarget.h)}`;
+
+    const captureAndUpload = async (message: ScreenshotRequest, sceneHash: string, attempt = 0) => {
+      const { sessionId, requestId, bounds, maxSize, token: requestToken, roomId: messageRoomId } = message;
+      const requestKey = `${sessionId}:${requestId}`;
+      const uploadedAt = uploadedRequestAt.get(requestKey);
+      if (typeof uploadedAt === 'number' && Date.now() - uploadedAt < requestUploadDedupeTtlMs) {
         if (isDev) {
-          console.log('[ScreenshotHandler] request received', {
-            sessionId,
-            requestId,
-            bounds,
-            maxSize,
-            roomId: messageRoomId,
-          });
+          console.log('[ScreenshotHandler] skipped duplicate request', { sessionId, requestId });
         }
-        const viewBounds = editor.getViewportPageBounds();
-        const rawTarget = bounds || { x: viewBounds.x, y: viewBounds.y, w: viewBounds.w, h: viewBounds.h };
-        const targetBox = Box.From(rawTarget);
-        const size = maxSize || { w: 800, h: 800 };
-        const longestTargetSide = Math.max(targetBox?.w ?? 0, targetBox?.h ?? 0) || 1;
-        const desiredLongestSide = Math.max(size?.w ?? 0, size?.h ?? 0, 1);
-        const exportScale = Math.min(4, Math.max(0.25, desiredLongestSide / longestTargetSide));
-        const shapes = editor.getCurrentPageShapesSorted().filter((shape: any) => {
-          const shapeBounds = editor.getShapeMaskedPageBounds(shape);
-          if (!shapeBounds) return false;
-          const intersectsHorizontally = shapeBounds.x + shapeBounds.w >= rawTarget.x && shapeBounds.x <= rawTarget.x + rawTarget.w;
-          const intersectsVertically = shapeBounds.y + shapeBounds.h >= rawTarget.y && shapeBounds.y <= rawTarget.y + rawTarget.h;
-          return intersectsHorizontally && intersectsVertically;
+        return;
+      }
+      const viewBounds = editor.getViewportPageBounds();
+      const rawTarget = bounds || { x: viewBounds.x, y: viewBounds.y, w: viewBounds.w, h: viewBounds.h };
+
+      const targetBox = Box.From(rawTarget);
+      const size = maxSize || { w: 800, h: 800 };
+      const longestTargetSide = Math.max(targetBox?.w ?? 0, targetBox?.h ?? 0) || 1;
+      const desiredLongestSide = Math.max(size?.w ?? 0, size?.h ?? 0, 1);
+      const exportScale = Math.min(4, Math.max(0.25, desiredLongestSide / longestTargetSide));
+      const shapes = editor.getCurrentPageShapesSorted().filter((shape: any) => {
+        const shapeBounds = editor.getShapeMaskedPageBounds(shape);
+        if (!shapeBounds) return false;
+        const intersectsHorizontally =
+          shapeBounds.x + shapeBounds.w >= rawTarget.x && shapeBounds.x <= rawTarget.x + rawTarget.w;
+        const intersectsVertically =
+          shapeBounds.y + shapeBounds.h >= rawTarget.y && shapeBounds.y <= rawTarget.y + rawTarget.h;
+        return intersectsHorizontally && intersectsVertically;
+      });
+
+      let dataUrl: string | undefined;
+      let width = 0;
+      let height = 0;
+      const startedAt = Date.now();
+
+      if (shapes.length === 0) {
+        const canvas = document.createElement('canvas');
+        width = Math.max(1, Math.round(size.w));
+        height = Math.max(1, Math.round(size.h));
+        canvas.width = width;
+        canvas.height = height;
+        const ctx = canvas.getContext('2d');
+        if (ctx) {
+          ctx.fillStyle = '#0b0b0b';
+          ctx.fillRect(0, 0, width, height);
+        }
+        dataUrl = canvas.toDataURL('image/png');
+      } else {
+        const image = await editor.toImage(shapes, {
+          format: 'png',
+          background: false,
+          bounds: targetBox,
+          padding: 0,
+          scale: exportScale,
         });
-        if (isDev) {
-          console.log('[ScreenshotHandler] shapes in bounds', shapes.length, { targetProto: targetBox?.constructor?.name });
+        const blob: Blob | undefined = (image as any)?.blob;
+        if (blob) {
+          dataUrl = await blobToDataUrl(blob);
         }
-        let dataUrl: string | undefined;
-        let width = 0;
-        let height = 0;
-        const startedAt = Date.now();
-        if (shapes.length === 0) {
-          const canvas = document.createElement('canvas');
-          width = Math.max(1, Math.round(size.w));
-          height = Math.max(1, Math.round(size.h));
-          canvas.width = width;
-          canvas.height = height;
-          const ctx = canvas.getContext('2d');
-          if (ctx) {
-            ctx.fillStyle = '#0b0b0b';
-            ctx.fillRect(0, 0, width, height);
-          }
-          dataUrl = canvas.toDataURL('image/png');
-        } else {
-          const image = await editor
-            .toImage(shapes, {
-              format: 'png',
-              background: false,
-              bounds: targetBox,
-              padding: 0,
-              scale: exportScale,
-            })
-            .catch((error: unknown) => {
-              const detail = error instanceof Error ? error.message : String(error);
-              console.warn('[ScreenshotHandler] toImage failed', detail);
-              throw error;
-            });
-          const blob: Blob | undefined = (image as any)?.blob;
-          if (blob) {
-            dataUrl = await blobToDataUrl(blob);
-          }
-          width = (image as any)?.width || 0;
-          height = (image as any)?.height || 0;
+        width = (image as any)?.width || 0;
+        height = (image as any)?.height || 0;
+      }
+
+      const bytes = typeof dataUrl === 'string' ? Math.ceil((dataUrl.length * 3) / 4) : 0;
+      const viewport = editor.getViewportPageBounds();
+      const selection = editor.getSelectedShapeIds();
+      const docVersion = String((window as any).__present_tldraw_doc_version || 0);
+
+      const fallbackToken = (window as any).__presentCanvasAgentToken as string | undefined;
+      const token = typeof requestToken === 'string' ? requestToken : fallbackToken;
+      const roomId = typeof messageRoomId === 'string' && messageRoomId ? messageRoomId : room?.name || '';
+      const response = await fetch(resolveEdgeIngressUrl('/api/canvas-agent/screenshot'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          sessionId,
+          requestId,
+          roomId,
+          token,
+          image: { mime: 'image/png', dataUrl, bytes, width, height },
+          bounds: { x: rawTarget.x, y: rawTarget.y, w: rawTarget.w, h: rawTarget.h },
+          viewport: { x: viewport.x, y: viewport.y, w: viewport.w, h: viewport.h },
+          selection,
+          docVersion,
+        }),
+      });
+      if (response.status === 429 && attempt < 1) {
+        const retryAfterSec = Number(response.headers.get('retry-after') || '1');
+        const retryDelayMs = Math.max(250, Number.isFinite(retryAfterSec) ? retryAfterSec * 1000 : 1000);
+        await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+        return captureAndUpload(message, sceneHash, attempt + 1);
+      }
+      if (!response.ok) {
+        throw new Error(`Screenshot upload failed: ${response.status}`);
+      }
+
+      uploadedRequestAt.set(requestKey, Date.now());
+      if (uploadedRequestAt.size > 2500) {
+        const cutoff = Date.now() - requestUploadDedupeTtlMs;
+        for (const [key, timestamp] of uploadedRequestAt) {
+          if (timestamp < cutoff) uploadedRequestAt.delete(key);
         }
-        const bytes = typeof dataUrl === 'string' ? Math.ceil((dataUrl.length * 3) / 4) : 0;
-        if (isDev) {
-          console.log('[ScreenshotHandler] capture duration ms', Date.now() - startedAt);
-        }
+      }
+      if (isDev) {
+        console.log('[ScreenshotHandler] uploaded', {
+          sessionId,
+          requestId,
+          sceneHash,
+          bytes,
+          durationMs: Date.now() - startedAt,
+        });
+      }
+    };
+
+    const off = bus.on('agent:screenshot_request', async (message: unknown) => {
+      try {
+        if (!message || typeof message !== 'object') return;
+        const request = message as ScreenshotRequest;
+        if (request.type !== 'agent:screenshot_request') return;
+
+        const sessionId = String(request.sessionId || '').trim();
+        const requestId = String(request.requestId || '').trim();
+        if (!sessionId || !requestId) return;
+
         const viewport = editor.getViewportPageBounds();
+        const rawTarget =
+          request.bounds || { x: viewport.x, y: viewport.y, w: viewport.w, h: viewport.h };
         const selection = editor.getSelectedShapeIds();
         const docVersion = String((window as any).__present_tldraw_doc_version || 0);
-        try {
-          const fallbackToken = (window as any).__presentCanvasAgentToken as string | undefined;
-          const token = typeof requestToken === 'string' ? requestToken : fallbackToken;
-          const roomId = typeof messageRoomId === 'string' && messageRoomId ? messageRoomId : room?.name || '';
-          await fetch('/api/canvas-agent/screenshot', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              sessionId,
-              requestId,
-              roomId,
-              token,
-              image: { mime: 'image/png', dataUrl, bytes, width, height },
-              bounds: { x: rawTarget.x, y: rawTarget.y, w: rawTarget.w, h: rawTarget.h },
-              viewport: { x: viewport.x, y: viewport.y, w: viewport.w, h: viewport.h },
-              selection,
-              docVersion,
-            }),
-          })
-            .then(() => {
-              if (process.env.NODE_ENV !== 'production') {
-                console.log('[ScreenshotHandler] uploaded', { sessionId, requestId, bytes });
-              }
-            })
-            .catch((error) => {
-              console.warn('[ScreenshotHandler] upload failed', error);
-            });
-        } catch (error) {
-          console.warn('[ScreenshotHandler] unable to capture screenshot', error);
+        const shapeCount = editor.getCurrentPageShapesSorted().length;
+        const sceneHash = computeSceneHash(sessionId, rawTarget, viewport, selection, docVersion, shapeCount);
+        const burstKey = toBurstKey(sessionId, rawTarget);
+
+        const existingBurst = burstStateByKey.get(burstKey);
+        if (!existingBurst) {
+          const burst: BurstState = { firstRequestId: requestId, firstSceneHash: sceneHash };
+          burstStateByKey.set(burstKey, burst);
+          await captureAndUpload(request, sceneHash).catch((error) => {
+            if (isDev) console.warn('[ScreenshotHandler] upload failed', error);
+          });
+          burst.timer = setTimeout(() => {
+            const snapshot = burstStateByKey.get(burstKey);
+            if (!snapshot) return;
+            const trailingMessage = snapshot.latestMessage;
+            const trailingHash = snapshot.latestSceneHash;
+            burstStateByKey.delete(burstKey);
+            if (
+              trailingMessage &&
+              trailingHash &&
+              (trailingHash !== snapshot.firstSceneHash ||
+                trailingMessage.requestId !== snapshot.firstRequestId)
+            ) {
+              void captureAndUpload(trailingMessage, trailingHash).catch((error) => {
+                if (isDev) console.warn('[ScreenshotHandler] trailing upload failed', error);
+              });
+            }
+          }, coalesceWindowMs);
+          return;
         }
-      } catch {}
+
+        existingBurst.latestMessage = request;
+        existingBurst.latestSceneHash = sceneHash;
+      } catch (error) {
+        if (isDev) console.warn('[ScreenshotHandler] request handling failed', error);
+      }
     });
-    return () => { off?.(); };
+
+    return () => {
+      off?.();
+      burstStateByKey.forEach((state) => {
+        if (state.timer) clearTimeout(state.timer);
+      });
+      burstStateByKey.clear();
+    };
   }, [editor, room]);
 }
 

--- a/src/components/ui/livekit/hooks/utils/lk-token.ts
+++ b/src/components/ui/livekit/hooks/utils/lk-token.ts
@@ -1,4 +1,6 @@
 import type { User } from '@supabase/supabase-js';
+import { getSupabaseAccessToken } from '@/lib/supabase/auth-headers';
+import { resolveEdgeIngressUrl } from '@/lib/edge-ingress';
 
 interface FetchTokenParams {
   roomName: string;
@@ -18,6 +20,45 @@ export function buildMetadataParam(displayName: string, user: User | null | unde
   return `&metadata=${encodeURIComponent(JSON.stringify(metadataPayload))}`;
 }
 
+function randomNonce() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+async function sha256Hex(input: string): Promise<string> {
+  const buffer = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(input));
+  return Array.from(new Uint8Array(buffer))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+export async function buildLivekitTokenHeaders(args: {
+  roomName: string;
+  identity: string;
+  pathname?: string;
+  init?: HeadersInit;
+}): Promise<Headers> {
+  const token = await getSupabaseAccessToken(1_500);
+  if (!token) {
+    throw new Error('Missing Supabase auth token for LiveKit token minting');
+  }
+
+  const timestamp = Date.now().toString();
+  const nonce = randomNonce();
+  const pathname = args.pathname || '/api/token';
+  const payload = ['GET', pathname, args.roomName, args.identity, timestamp, nonce].join('.');
+  const signature = await sha256Hex(`${token}.${payload}`);
+
+  const headers = new Headers(args.init);
+  headers.set('Authorization', `Bearer ${token}`);
+  headers.set('x-timestamp', timestamp);
+  headers.set('x-nonce', nonce);
+  headers.set('x-signature', signature);
+  return headers;
+}
+
 export async function fetchLivekitAccessToken({
   roomName,
   identity,
@@ -25,10 +66,11 @@ export async function fetchLivekitAccessToken({
   metadataParam,
   signal,
 }: FetchTokenParams): Promise<string> {
-  const response = await fetch(
-    `/api/token?roomName=${encodeURIComponent(roomName)}&identity=${encodeURIComponent(identity)}&username=${encodeURIComponent(displayName)}&name=${encodeURIComponent(displayName)}${metadataParam}`,
-    { signal },
-  );
+  const headers = await buildLivekitTokenHeaders({ roomName, identity, pathname: '/api/token' });
+  const endpoint = resolveEdgeIngressUrl('/api/token');
+  const separator = endpoint.includes('?') ? '&' : '?';
+  const tokenUrl = `${endpoint}${separator}roomName=${encodeURIComponent(roomName)}&identity=${encodeURIComponent(identity)}&username=${encodeURIComponent(displayName)}&name=${encodeURIComponent(displayName)}${metadataParam}`;
+  const response = await fetch(tokenUrl, { signal, headers });
 
   if (!response.ok) {
     throw new Error(`Token fetch failed: ${response.status} ${response.statusText}`);

--- a/src/components/ui/message-thread-collapsible.tsx
+++ b/src/components/ui/message-thread-collapsible.tsx
@@ -17,6 +17,8 @@ import { supabase } from '@/lib/supabase';
 import { CanvasLiveKitContext } from './livekit/livekit-room-connector';
 import { useAuth } from '@/hooks/use-auth';
 import { useAllTranscripts, useTranscriptStore, type Transcript as StoreTranscript } from '@/lib/stores/transcript-store';
+import { buildLivekitTokenHeaders } from '@/components/ui/livekit/hooks/utils/lk-token';
+import { resolveEdgeIngressUrl } from '@/lib/edge-ingress';
 
 /**
  * Props for the MessageThreadCollapsible component
@@ -235,7 +237,7 @@ export const MessageThreadCollapsible = React.forwardRef<
       }
       // Prefer configured token endpoint; fall back to /api/token
       const tokenEndpoint =
-        process.env.NEXT_PUBLIC_LK_TOKEN_ENDPOINT || '/api/token';
+        process.env.NEXT_PUBLIC_LK_TOKEN_ENDPOINT || resolveEdgeIngressUrl('/api/token');
       // Build absolute URL to avoid basePath/iframe pitfalls
       const base = typeof window !== 'undefined' ? window.location.origin : '';
       const tokenUrl = new URL(tokenEndpoint, base);
@@ -245,7 +247,12 @@ export const MessageThreadCollapsible = React.forwardRef<
 
       let data: any | null = null;
       try {
-        const res = await fetch(tokenUrl.toString(), { cache: 'no-store' });
+        const headers = await buildLivekitTokenHeaders({
+          roomName: livekitCtx.roomName,
+          identity: identity!,
+          pathname: tokenUrl.pathname,
+        });
+        const res = await fetch(tokenUrl.toString(), { cache: 'no-store', headers });
         if (!res.ok) throw new Error(`Token fetch failed: ${res.status}`);
         data = await res.json();
       } catch (err) {

--- a/src/components/ui/messaging/message-thread-collapsible.tsx
+++ b/src/components/ui/messaging/message-thread-collapsible.tsx
@@ -17,6 +17,8 @@ import { supabase } from '@/lib/supabase';
 import { CanvasLiveKitContext } from '../livekit/livekit-room-connector';
 import { useAuth } from '@/hooks/use-auth';
 import { useAllTranscripts, useTranscriptStore, type Transcript as StoreTranscript } from '@/lib/stores/transcript-store';
+import { buildLivekitTokenHeaders } from '@/components/ui/livekit/hooks/utils/lk-token';
+import { resolveEdgeIngressUrl } from '@/lib/edge-ingress';
 
 /**
  * Props for the MessageThreadCollapsible component
@@ -350,7 +352,7 @@ export const MessageThreadCollapsible = React.forwardRef<
       }
       // Prefer configured token endpoint; fall back to /api/token
       const tokenEndpoint =
-        process.env.NEXT_PUBLIC_LK_TOKEN_ENDPOINT || '/api/token';
+        process.env.NEXT_PUBLIC_LK_TOKEN_ENDPOINT || resolveEdgeIngressUrl('/api/token');
       // Build absolute URL to avoid basePath/iframe pitfalls
       const base = typeof window !== 'undefined' ? window.location.origin : '';
       const tokenUrl = new URL(tokenEndpoint, base);
@@ -363,7 +365,12 @@ export const MessageThreadCollapsible = React.forwardRef<
 
       let data: any | null = null;
       try {
-        const res = await fetch(tokenUrl.toString(), { cache: 'no-store' });
+        const headers = await buildLivekitTokenHeaders({
+          roomName: livekitCtx.roomName,
+          identity: identity!,
+          pathname: tokenUrl.pathname,
+        });
+        const res = await fetch(tokenUrl.toString(), { cache: 'no-store', headers });
         if (!res.ok) throw new Error(`Token fetch failed: ${res.status}`);
         data = await res.json();
       } catch (err) {

--- a/src/lib/edge-ingress.ts
+++ b/src/lib/edge-ingress.ts
@@ -1,0 +1,39 @@
+const normalizePath = (path: string) => {
+  if (!path) return '/';
+  return path.startsWith('/') ? path : `/${path}`;
+};
+
+const normalizeBase = (value: string): string | null => {
+  const raw = value.trim();
+  if (!raw) return null;
+  try {
+    return new URL(raw).toString();
+  } catch {
+    return null;
+  }
+};
+
+export function isEdgeIngressEnabled(): boolean {
+  if (typeof window !== 'undefined') {
+    return (process.env.NEXT_PUBLIC_EDGE_INGRESS_ENABLED ?? 'false') === 'true';
+  }
+  return (
+    (process.env.EDGE_INGRESS_ENABLED ?? process.env.NEXT_PUBLIC_EDGE_INGRESS_ENABLED ?? 'false') ===
+    'true'
+  );
+}
+
+export function getEdgeIngressBaseUrl(): string | null {
+  if (typeof window !== 'undefined') {
+    return normalizeBase(process.env.NEXT_PUBLIC_EDGE_INGRESS_URL || '');
+  }
+  return normalizeBase(process.env.EDGE_INGRESS_URL || process.env.NEXT_PUBLIC_EDGE_INGRESS_URL || '');
+}
+
+export function resolveEdgeIngressUrl(path: string): string {
+  const normalizedPath = normalizePath(path);
+  if (!isEdgeIngressEnabled()) return normalizedPath;
+  const base = getEdgeIngressBaseUrl();
+  if (!base) return normalizedPath;
+  return new URL(normalizedPath, base).toString();
+}

--- a/src/lib/mcp-utils.ts
+++ b/src/lib/mcp-utils.ts
@@ -2,6 +2,7 @@
  * Type for MCP Server entries
  */
 import { createLogger } from '@/lib/utils';
+import { resolveEdgeIngressUrl } from '@/lib/edge-ingress';
 
 export type McpServer =
   | string
@@ -205,7 +206,8 @@ export function loadMcpServers(): McpServer[] {
           }
 
           // Update the URL to use our proxy
-          const proxiedUrl = `/api/mcp-proxy?target=${encodeURIComponent(url)}`;
+          const proxyBase = resolveEdgeIngressUrl('/api/mcp-proxy');
+          const proxiedUrl = `${proxyBase}?target=${encodeURIComponent(url)}`;
 
           if (typeof processedServer === 'string') {
             processedServer = proxiedUrl;

--- a/src/lib/server/traffic-guards.test.ts
+++ b/src/lib/server/traffic-guards.test.ts
@@ -1,0 +1,51 @@
+import { acquireConcurrencySlot, consumeBudget, consumeWindowedLimit } from '@/lib/server/traffic-guards';
+
+describe('traffic guards', () => {
+  it('enforces windowed request limits and reports retry-after', () => {
+    const start = 1_000_000;
+    const k = 'test:window';
+    const first = consumeWindowedLimit(k, 2, 1_000, start);
+    const second = consumeWindowedLimit(k, 2, 1_000, start + 50);
+    const third = consumeWindowedLimit(k, 2, 1_000, start + 100);
+
+    expect(first.ok).toBe(true);
+    expect(second.ok).toBe(true);
+    expect(third.ok).toBe(false);
+    expect(third.retryAfterSec).toBeGreaterThan(0);
+
+    const afterWindow = consumeWindowedLimit(k, 2, 1_000, start + 1_500);
+    expect(afterWindow.ok).toBe(true);
+    expect(afterWindow.current).toBe(1);
+  });
+
+  it('enforces concurrency slots with explicit release', () => {
+    const key = 'test:concurrency';
+    const slot1 = acquireConcurrencySlot(key, 2);
+    const slot2 = acquireConcurrencySlot(key, 2);
+    const slot3 = acquireConcurrencySlot(key, 2);
+
+    expect(slot1.ok).toBe(true);
+    expect(slot2.ok).toBe(true);
+    expect(slot3.ok).toBe(false);
+
+    if (slot1.ok) slot1.release();
+    const slot4 = acquireConcurrencySlot(key, 2);
+    expect(slot4.ok).toBe(true);
+
+    if (slot2.ok) slot2.release();
+    if (slot4.ok) slot4.release();
+  });
+
+  it('enforces budget ceilings per window', () => {
+    const start = 5_000_000;
+    const k = 'test:budget';
+    const a = consumeBudget(k, 4, 10, 1_000, start);
+    const b = consumeBudget(k, 5, 10, 1_000, start + 100);
+    const c = consumeBudget(k, 3, 10, 1_000, start + 200);
+
+    expect(a.ok).toBe(true);
+    expect(b.ok).toBe(true);
+    expect(c.ok).toBe(false);
+    expect(c.retryAfterSec).toBeGreaterThan(0);
+  });
+});

--- a/src/lib/server/traffic-guards.ts
+++ b/src/lib/server/traffic-guards.ts
@@ -1,0 +1,151 @@
+type WindowCounter = {
+  windowStart: number;
+  count: number;
+};
+
+type BudgetCounter = {
+  windowStart: number;
+  used: number;
+};
+
+const windowCounters = new Map<string, WindowCounter>();
+const budgetCounters = new Map<string, BudgetCounter>();
+const concurrencyCounters = new Map<string, number>();
+
+const MAX_WINDOW_COUNTERS = 20_000;
+const MAX_BUDGET_COUNTERS = 20_000;
+
+type WindowLimitResult = {
+  ok: boolean;
+  remaining: number;
+  retryAfterSec: number;
+  current: number;
+  limit: number;
+};
+
+type BudgetLimitResult = {
+  ok: boolean;
+  retryAfterSec: number;
+  used: number;
+  limit: number;
+};
+
+function pruneWindowCounters(now: number) {
+  if (windowCounters.size <= MAX_WINDOW_COUNTERS) return;
+  for (const [key, value] of windowCounters) {
+    if (now - value.windowStart > 5 * 60_000) {
+      windowCounters.delete(key);
+    }
+  }
+}
+
+function pruneBudgetCounters(now: number) {
+  if (budgetCounters.size <= MAX_BUDGET_COUNTERS) return;
+  for (const [key, value] of budgetCounters) {
+    if (now - value.windowStart > 5 * 60_000) {
+      budgetCounters.delete(key);
+    }
+  }
+}
+
+export function consumeWindowedLimit(
+  key: string,
+  limit: number,
+  windowMs: number,
+  now = Date.now(),
+): WindowLimitResult {
+  const safeLimit = Math.max(1, Math.floor(limit));
+  const safeWindowMs = Math.max(250, Math.floor(windowMs));
+  const bucket = windowCounters.get(key);
+
+  if (!bucket || now - bucket.windowStart >= safeWindowMs) {
+    windowCounters.set(key, { windowStart: now, count: 1 });
+    pruneWindowCounters(now);
+    return {
+      ok: true,
+      remaining: Math.max(0, safeLimit - 1),
+      retryAfterSec: 0,
+      current: 1,
+      limit: safeLimit,
+    };
+  }
+
+  bucket.count += 1;
+  const ok = bucket.count <= safeLimit;
+  const remaining = Math.max(0, safeLimit - bucket.count);
+  const retryAfterSec = ok
+    ? 0
+    : Math.max(1, Math.ceil((bucket.windowStart + safeWindowMs - now) / 1000));
+  return {
+    ok,
+    remaining,
+    retryAfterSec,
+    current: bucket.count,
+    limit: safeLimit,
+  };
+}
+
+export function acquireConcurrencySlot(
+  key: string,
+  limit: number,
+): { ok: true; release: () => void; inFlight: number } | { ok: false; inFlight: number; limit: number } {
+  const safeLimit = Math.max(1, Math.floor(limit));
+  const inFlight = concurrencyCounters.get(key) ?? 0;
+  if (inFlight >= safeLimit) {
+    return { ok: false, inFlight, limit: safeLimit };
+  }
+  const next = inFlight + 1;
+  concurrencyCounters.set(key, next);
+  let released = false;
+  return {
+    ok: true,
+    inFlight: next,
+    release: () => {
+      if (released) return;
+      released = true;
+      const current = concurrencyCounters.get(key) ?? 0;
+      if (current <= 1) {
+        concurrencyCounters.delete(key);
+      } else {
+        concurrencyCounters.set(key, current - 1);
+      }
+    },
+  };
+}
+
+export function consumeBudget(
+  metric: string,
+  amount: number,
+  limit: number,
+  windowMs = 60_000,
+  now = Date.now(),
+): BudgetLimitResult {
+  const safeLimit = Math.max(1, Math.floor(limit));
+  const safeWindowMs = Math.max(1_000, Math.floor(windowMs));
+  const safeAmount = Math.max(0, Math.ceil(amount));
+  const key = `${metric}:${Math.floor(now / safeWindowMs)}`;
+  const bucket = budgetCounters.get(key);
+  if (!bucket) {
+    budgetCounters.set(key, { windowStart: now, used: safeAmount });
+    pruneBudgetCounters(now);
+    return {
+      ok: safeAmount <= safeLimit,
+      retryAfterSec: safeAmount <= safeLimit ? 0 : Math.max(1, Math.ceil(safeWindowMs / 1000)),
+      used: safeAmount,
+      limit: safeLimit,
+    };
+  }
+
+  bucket.used += safeAmount;
+  const ok = bucket.used <= safeLimit;
+  return {
+    ok,
+    retryAfterSec: ok ? 0 : Math.max(1, Math.ceil((bucket.windowStart + safeWindowMs - now) / 1000)),
+    used: bucket.used,
+    limit: safeLimit,
+  };
+}
+
+export function isCostCircuitBreakerEnabled(): boolean {
+  return (process.env.COST_CIRCUIT_BREAKER_ENABLED ?? 'false').toLowerCase() === 'true';
+}

--- a/src/server/inboxes/ack.ts
+++ b/src/server/inboxes/ack.ts
@@ -1,4 +1,5 @@
-import { mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from 'fs';
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync } from 'fs';
+import { writeFile } from 'fs/promises';
 import { join } from 'path';
 
 type AckRecord = {
@@ -7,8 +8,18 @@ type AckRecord = {
   ts: number;
 };
 
-const inbox = new Map<string, Map<number, AckRecord>>();
+type AckEnvelope = {
+  record: AckRecord;
+  storedAt: number;
+};
+
+const inbox = new Map<string, Map<number, AckEnvelope>>();
 const ACK_ROOT = process.env.CANVAS_AGENT_ACK_DIR || join(process.cwd(), '.present', 'acks');
+const ACK_TTL_MS = Math.max(
+  60_000,
+  Number(process.env.CANVAS_ACK_RETENTION_MS ?? 24 * 60 * 60 * 1000),
+);
+let lastCleanupAt = 0;
 
 function sanitizeSegment(segment: string) {
   return segment.replace(/[^a-zA-Z0-9_-]/g, '_');
@@ -20,27 +31,33 @@ function ensureAckDir(sessionId?: string) {
     if (sessionId) {
       mkdirSync(join(ACK_ROOT, sanitizeSegment(sessionId)), { recursive: true });
     }
-  } catch {
-    // best-effort; fall back to in-memory cache if mkdir fails
-  }
+  } catch {}
 }
 
-function persistAck(sessionId: string, seq: number, record: AckRecord) {
+function filePath(sessionId: string, seq: number) {
+  return join(ACK_ROOT, sanitizeSegment(sessionId), `${seq}.json`);
+}
+
+function isExpired(storedAt: number, now = Date.now()) {
+  return now - storedAt > ACK_TTL_MS;
+}
+
+function persistAck(sessionId: string, seq: number, envelope: AckEnvelope) {
   ensureAckDir(sessionId);
-  try {
-    const file = join(ACK_ROOT, sanitizeSegment(sessionId), `${seq}.json`);
-    writeFileSync(file, JSON.stringify(record));
-  } catch {
-    // Ignore disk errors; we still retain the ack in-memory for this process
-  }
+  void writeFile(filePath(sessionId, seq), JSON.stringify(envelope)).catch(() => {
+    // in-memory ack stays available if disk write fails
+  });
 }
 
-function readPersistedAck(sessionId: string, seq: number): AckRecord | null {
-  const file = join(ACK_ROOT, sanitizeSegment(sessionId), `${seq}.json`);
+function readPersistedAck(sessionId: string, seq: number): AckEnvelope | null {
+  const file = filePath(sessionId, seq);
   if (!existsSync(file)) return null;
   try {
-    const parsed = JSON.parse(readFileSync(file, 'utf8')) as AckRecord;
-    return parsed;
+    const parsed = JSON.parse(readFileSync(file, 'utf8')) as AckEnvelope | AckRecord;
+    if ('record' in parsed && parsed.record && typeof parsed.storedAt === 'number') {
+      return parsed as AckEnvelope;
+    }
+    return { record: parsed as AckRecord, storedAt: Date.now() };
   } catch {
     return null;
   } finally {
@@ -50,29 +67,81 @@ function readPersistedAck(sessionId: string, seq: number): AckRecord | null {
   }
 }
 
-export function recordAck(sessionId: string, seq: number, clientId: string, ts: number) {
-  const session = inbox.get(sessionId) ?? new Map<number, AckRecord>();
-  if (!session.has(seq)) {
-    const record: AckRecord = { seq, clientId, ts };
-    session.set(seq, record);
-    inbox.set(sessionId, session);
-    persistAck(sessionId, seq, record);
+function pruneInMemory(now = Date.now()) {
+  for (const [sessionId, entries] of inbox) {
+    for (const [seq, envelope] of entries) {
+      if (isExpired(envelope.storedAt, now)) {
+        entries.delete(seq);
+      }
+    }
+    if (entries.size === 0) {
+      inbox.delete(sessionId);
+    }
   }
 }
 
+function prunePersisted(now = Date.now()) {
+  if (!existsSync(ACK_ROOT)) return;
+  try {
+    const sessions = readdirSync(ACK_ROOT);
+    for (const sessionDir of sessions) {
+      const dirPath = join(ACK_ROOT, sessionDir);
+      const files = readdirSync(dirPath);
+      for (const file of files) {
+        const path = join(dirPath, file);
+        try {
+          const stats = statSync(path);
+          if (isExpired(stats.mtimeMs, now)) {
+            rmSync(path, { force: true });
+          }
+        } catch {}
+      }
+    }
+  } catch {}
+}
+
+function maybeCleanup() {
+  const now = Date.now();
+  if (now - lastCleanupAt < 60_000) return;
+  lastCleanupAt = now;
+  pruneInMemory(now);
+  prunePersisted(now);
+}
+
+export function recordAck(sessionId: string, seq: number, clientId: string, ts: number) {
+  const envelope: AckEnvelope = {
+    record: { seq, clientId, ts },
+    storedAt: Date.now(),
+  };
+  const session = inbox.get(sessionId) ?? new Map<number, AckEnvelope>();
+  if (!session.has(seq)) {
+    session.set(seq, envelope);
+    inbox.set(sessionId, session);
+    persistAck(sessionId, seq, envelope);
+  }
+  maybeCleanup();
+}
+
 export function getAck(sessionId: string, seq: number): AckRecord | null {
+  maybeCleanup();
   const session = inbox.get(sessionId);
-  if (session?.has(seq)) {
-    return session.get(seq) ?? null;
+  const inMemory = session?.get(seq);
+  if (inMemory) {
+    if (isExpired(inMemory.storedAt)) {
+      session?.delete(seq);
+      return null;
+    }
+    return inMemory.record;
   }
+
   const persisted = readPersistedAck(sessionId, seq);
-  if (persisted) {
-    const nextSession = session ?? new Map<number, AckRecord>();
-    nextSession.set(seq, persisted);
-    inbox.set(sessionId, nextSession);
-    return persisted;
+  if (!persisted || isExpired(persisted.storedAt)) {
+    return null;
   }
-  return null;
+  const nextSession = session ?? new Map<number, AckEnvelope>();
+  nextSession.set(seq, persisted);
+  inbox.set(sessionId, nextSession);
+  return persisted.record;
 }
 
 export function clearAcks() {
@@ -81,6 +150,3 @@ export function clearAcks() {
     rmSync(ACK_ROOT, { recursive: true, force: true });
   } catch {}
 }
-
-
-

--- a/src/server/inboxes/screenshot.ts
+++ b/src/server/inboxes/screenshot.ts
@@ -1,4 +1,5 @@
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync } from 'fs';
+import { writeFile } from 'fs/promises';
 import { join } from 'path';
 
 export type ScreenshotPayload = {
@@ -11,8 +12,19 @@ export type ScreenshotPayload = {
   docVersion: string;
 };
 
-const inbox = new Map<string, ScreenshotPayload>();
-const SCREENSHOT_ROOT = process.env.CANVAS_AGENT_SCREENSHOT_DIR || join(process.cwd(), '.present', 'screenshots');
+type ScreenshotRecord = {
+  payload: ScreenshotPayload;
+  storedAt: number;
+};
+
+const inbox = new Map<string, ScreenshotRecord>();
+const SCREENSHOT_ROOT =
+  process.env.CANVAS_AGENT_SCREENSHOT_DIR || join(process.cwd(), '.present', 'screenshots');
+const SCREENSHOT_TTL_MS = Math.max(
+  60_000,
+  Number(process.env.CANVAS_SCREENSHOT_RETENTION_MS ?? 24 * 60 * 60 * 1000),
+);
+let lastCleanupAt = 0;
 
 function sanitize(segment: string) {
   return segment.replace(/[^a-zA-Z0-9_-]/g, '_');
@@ -24,31 +36,36 @@ function ensureDir(sessionId?: string) {
     if (sessionId) {
       mkdirSync(join(SCREENSHOT_ROOT, sanitize(sessionId)), { recursive: true });
     }
-  } catch {
-    // best-effort; if mkdir fails we still keep the in-memory entry
-  }
+  } catch {}
 }
 
 function filePath(sessionId: string, requestId: string) {
   return join(SCREENSHOT_ROOT, sanitize(sessionId), `${sanitize(requestId)}.json`);
 }
 
-function persist(payload: ScreenshotPayload) {
-  if (!payload.sessionId || !payload.requestId) return;
-  ensureDir(payload.sessionId);
-  try {
-    writeFileSync(filePath(payload.sessionId, payload.requestId), JSON.stringify(payload));
-  } catch {
-    // ignore disk errors; in-memory cache still works for this process
-  }
+function persist(record: ScreenshotRecord) {
+  if (!record.payload.sessionId || !record.payload.requestId) return;
+  ensureDir(record.payload.sessionId);
+  void writeFile(filePath(record.payload.sessionId, record.payload.requestId), JSON.stringify(record)).catch(
+    () => {
+      // in-memory record remains available even if disk write fails
+    },
+  );
 }
 
-function readPersisted(sessionId: string, requestId: string): ScreenshotPayload | null {
+function isExpired(storedAt: number, now = Date.now()) {
+  return now - storedAt > SCREENSHOT_TTL_MS;
+}
+
+function readPersisted(sessionId: string, requestId: string): ScreenshotRecord | null {
   const file = filePath(sessionId, requestId);
   if (!existsSync(file)) return null;
   try {
-    const parsed = JSON.parse(readFileSync(file, 'utf8')) as ScreenshotPayload;
-    return parsed;
+    const parsed = JSON.parse(readFileSync(file, 'utf8')) as ScreenshotRecord | ScreenshotPayload;
+    if ('payload' in parsed && parsed.payload && typeof parsed.storedAt === 'number') {
+      return parsed as ScreenshotRecord;
+    }
+    return { payload: parsed as ScreenshotPayload, storedAt: Date.now() };
   } catch {
     return null;
   } finally {
@@ -58,21 +75,64 @@ function readPersisted(sessionId: string, requestId: string): ScreenshotPayload 
   }
 }
 
+function pruneInMemory(now = Date.now()) {
+  for (const [key, record] of inbox) {
+    if (isExpired(record.storedAt, now)) {
+      inbox.delete(key);
+    }
+  }
+}
+
+function prunePersisted(now = Date.now()) {
+  if (!existsSync(SCREENSHOT_ROOT)) return;
+  try {
+    const sessions = readdirSync(SCREENSHOT_ROOT);
+    for (const sessionDir of sessions) {
+      const dirPath = join(SCREENSHOT_ROOT, sessionDir);
+      const files = readdirSync(dirPath);
+      for (const file of files) {
+        const path = join(dirPath, file);
+        try {
+          const stats = statSync(path);
+          if (isExpired(stats.mtimeMs, now)) {
+            rmSync(path, { force: true });
+          }
+        } catch {}
+      }
+    }
+  } catch {}
+}
+
+function maybeCleanup() {
+  const now = Date.now();
+  if (now - lastCleanupAt < 60_000) return;
+  lastCleanupAt = now;
+  pruneInMemory(now);
+  prunePersisted(now);
+}
+
 export function storeScreenshot(payload: ScreenshotPayload) {
   const key = `${payload.sessionId}::${payload.requestId}`;
-  inbox.set(key, payload);
-  persist(payload);
+  const record: ScreenshotRecord = { payload, storedAt: Date.now() };
+  inbox.set(key, record);
+  persist(record);
+  maybeCleanup();
 }
 
 export function takeScreenshot(sessionId: string, requestId: string): ScreenshotPayload | null {
+  maybeCleanup();
   const key = `${sessionId}::${requestId}`;
-  const payload = inbox.get(key);
-  if (payload) {
+  const record = inbox.get(key);
+  if (record) {
     inbox.delete(key);
-    return payload;
+    if (isExpired(record.storedAt)) return null;
+    return record.payload;
   }
+
   const persisted = readPersisted(sessionId, requestId);
-  return persisted;
+  if (!persisted) return null;
+  if (isExpired(persisted.storedAt)) return null;
+  return persisted.payload;
 }
 
 export function clearScreenshots() {
@@ -81,5 +141,3 @@ export function clearScreenshots() {
     rmSync(SCREENSHOT_ROOT, { recursive: true, force: true });
   } catch {}
 }
-
-


### PR DESCRIPTION
## Issue and User Impact

This change addresses cost leakage and abuse-exposed hot paths while preserving full feature availability and low latency.

Primary user-facing risks before this change:
- Unauthorized or high-volume ingress could trigger runaway spend (token minting, MCP proxying, transcription, screenshot ingestion).
- Expensive background loops (fact-check/search/screenshot churn) could run more often than needed.
- Stateless high-volume API traffic was not prepared for low-cost edge ingress routing.

## Root Cause Analysis

The cost profile was driven by root causes in request admission and repeated execution, not isolated endpoint bugs:
- Weak ingress hardening on high-cost endpoints (auth/signature/rate/concurrency gaps).
- Upstream calls and streams being allowed before deterministic budget/limit checks.
- Duplicate/redundant operations across screenshot and steward workflows.
- Platform mismatch for stateless high-volume paths (not edge-routed by default).
- Incomplete data minimization and retention guardrails for high-volume artifacts.

## Why This Fix Solves Root Cause

This PR adds layered controls before expensive execution starts and routes stateless hot paths through a Cloudflare edge ingress option:
- Admission control: auth/signature/rate/concurrency checks block abuse and over-budget paths early.
- Deterministic gating/dedupe: room/event/request-level dedupe and budget controls suppress waste loops.
- Edge routing abstraction: hot stateless calls can be moved to Cloudflare without changing product behavior.
- Automatic fallback behavior: controlled 429/Retry-After responses and retry logic avoid runaway retries.

## What Changed (by subsystem)

### Ingress Security & Cost Guardrails
- Hardened `/api/token` with signed request verification and safer logging.
- Hardened `/api/mcp-proxy` with auth requirement, allowlist enforcement, header sanitization, per-user rate/concurrency limits, and stream-safe concurrency slot lifecycle.
- Hardened `/api/transcribe` with payload and rate limits before upstream model call.
- Added shared traffic guard utilities and tests.

### Agent/Conductor/Queue Efficiency
- Added deterministic dispatch gating and event-budget protection in realtime/conductor flows.
- Added queue coalescing behavior to cancel superseded queued work by resource/task scope.
- Added idle backoff and additional execution guardrails in conductor paths.

### Canvas/Scorecard Waste Suppression
- Added screenshot request coalescing and per-request dedupe guarantees.
- Added screenshot budget accounting hardening (server-derived bytes, not client-trusted only).
- Added inbox TTL/cleanup patterns for ack/screenshot ephemeral traffic.
- Added fact-check/web search caching improvements and safer cache keying.

### Platform Fit (Phase 5)
- Added Cloudflare ingress worker scaffold and wrangler config:
  - `cloudflare/ingress/src/index.ts`
  - `cloudflare/ingress/wrangler.toml`
- Added edge ingress URL resolver and wired hot-path callers:
  - token fetch paths
  - MCP proxy callers
  - canvas ack/screenshot ingress paths
- Added deploy scripts and docs:
  - `npm run cf:ingress:dev`
  - `npm run cf:ingress:deploy`
  - `docs/cloudflare-edge-ingress.md`

## Backward Compatibility Analysis (Backend/API)

This PR intentionally introduces stricter contracts and may impact older clients that are not updated:
- `/api/token`: now expects authenticated context and signed request metadata.
- `/api/mcp-proxy`: now enforces host allowlist + auth + limits.
- `/api/transcribe`: now enforces explicit payload/rate constraints and returns budget/rate 429 responses.

Compatibility verdict:
- **Backward compatible for updated first-party clients in this repo** (all active call sites were updated).
- **Potentially breaking for stale/third-party callers** that bypass the updated request contracts.

## Validation Performed

- `npm install`
- `npm run lint` (Biome): pass
- `npm test -- src/lib/server/traffic-guards.test.ts src/lib/agents/canvas-agent/server/wire.test.ts src/lib/linear-mcp-client.test.ts --runInBand`: pass

## Reviewer Passes (2 independent critical reviewers)

Reviewer A (correctness/security/performance) initially flagged:
- MCP proxy stream concurrency slot released too early.
- Screenshot dedupe could drop valid new request IDs.
- Linear MCP client Node compatibility regression (relative proxy URL).

Reviewer B (hygiene/architecture) initially flagged:
- Screenshot budget bypass via client-controlled byte counts.
- `coalesceByResource` scope mismatch for non-hardcoded tasks.
- Web-search evidence cache key missing output-shaping fields.

All meaningful findings above were implemented and re-reviewed. Final re-review from both reviewers reported no unresolved/new meaningful findings.

## UI Evidence

No user-visible visual UI redesign/behavioral UI flow change was introduced in this PR; changes are primarily API/agent/ingress/runtime wiring.

## Remaining Risks / Follow-ups

- Full e2e latency benchmark and cost trend measurement should be run in production-like load after rollout.
- Optional follow-up: add integration tests for Cloudflare ingress route matrix and stream lifecycle behavior.
