### PR TITLE
[codex] realtime sync hardening and executor lease convergence fixes

### DIFF
--- a/docs/migrations/005_canvas_session_executor_lease.sql
+++ b/docs/migrations/005_canvas_session_executor_lease.sql
@@ -1,0 +1,10 @@
+-- Add durable browser executor lease fields for room-scoped tool_call execution.
+alter table if exists public.canvas_sessions
+  add column if not exists tool_executor_identity text;
+
+alter table if exists public.canvas_sessions
+  add column if not exists tool_executor_lease_expires_at timestamptz;
+
+create index if not exists canvas_sessions_tool_executor_lease_idx
+  on public.canvas_sessions (room_name, tool_executor_lease_expires_at);
+

--- a/src/app/api/session/executor/claim/route.ts
+++ b/src/app/api/session/executor/claim/route.ts
@@ -1,0 +1,113 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  getServerClient,
+  parseExecutorBody,
+  readSessionLease,
+} from '../shared';
+
+export const runtime = 'nodejs';
+
+export async function POST(req: NextRequest) {
+  const authHeader = req.headers.get('Authorization');
+  const supabase = getServerClient(authHeader);
+  const { sessionId, roomName, identity, leaseTtlMs } = await parseExecutorBody(req);
+
+  if (!sessionId || !identity) {
+    return NextResponse.json(
+      { error: 'sessionId and identity are required' },
+      { status: 400 },
+    );
+  }
+
+  const now = Date.now();
+  const nowIso = new Date(now).toISOString();
+  const leaseExpiresAtIso = new Date(now + leaseTtlMs).toISOString();
+
+  const { data: current, error: readErr } = await readSessionLease(supabase, sessionId);
+  if (readErr) {
+    return NextResponse.json({ error: readErr.message }, { status: 500 });
+  }
+  if (!current) {
+    return NextResponse.json({ error: 'Session not found' }, { status: 404 });
+  }
+  if (roomName && current.room_name && current.room_name !== roomName) {
+    return NextResponse.json({ error: 'Session room mismatch' }, { status: 409 });
+  }
+
+  const currentHolder =
+    typeof current.tool_executor_identity === 'string'
+      ? current.tool_executor_identity
+      : null;
+  const currentExpiresAtMs = current.tool_executor_lease_expires_at
+    ? Date.parse(current.tool_executor_lease_expires_at)
+    : Number.NaN;
+  const leaseActive =
+    Number.isFinite(currentExpiresAtMs) && currentExpiresAtMs > now;
+
+  if (leaseActive && currentHolder && currentHolder !== identity) {
+    return NextResponse.json({
+      acquired: false,
+      sessionId,
+      executorIdentity: currentHolder,
+      leaseExpiresAt: current.tool_executor_lease_expires_at,
+    });
+  }
+
+  // Compare-and-swap update: only succeed if the lease snapshot we read is still current.
+  let updateQuery = supabase
+    .from('canvas_sessions')
+    .update({
+      tool_executor_identity: identity,
+      tool_executor_lease_expires_at: leaseExpiresAtIso,
+      updated_at: nowIso,
+    })
+    .eq('id', sessionId);
+
+  if (typeof current.updated_at === 'string' && current.updated_at.trim().length > 0) {
+    updateQuery = updateQuery.eq('updated_at', current.updated_at);
+  }
+
+  if (currentHolder) {
+    updateQuery = updateQuery.eq('tool_executor_identity', currentHolder);
+  } else {
+    updateQuery = updateQuery.is('tool_executor_identity', null);
+  }
+
+  if (typeof current.tool_executor_lease_expires_at === 'string') {
+    updateQuery = updateQuery.eq(
+      'tool_executor_lease_expires_at',
+      current.tool_executor_lease_expires_at,
+    );
+  } else {
+    updateQuery = updateQuery.is('tool_executor_lease_expires_at', null);
+  }
+
+  const { data: updated, error: updateErr } = await updateQuery
+    .select('id, tool_executor_identity, tool_executor_lease_expires_at')
+    .maybeSingle();
+
+  if (updateErr) {
+    return NextResponse.json({ error: updateErr.message }, { status: 500 });
+  }
+
+  if (!updated) {
+    // Lost a race; report current lease holder.
+    const { data: latest, error: latestErr } = await readSessionLease(supabase, sessionId);
+    if (latestErr) {
+      return NextResponse.json({ error: latestErr.message }, { status: 500 });
+    }
+    return NextResponse.json({
+      acquired: latest?.tool_executor_identity === identity,
+      sessionId,
+      executorIdentity: latest?.tool_executor_identity ?? null,
+      leaseExpiresAt: latest?.tool_executor_lease_expires_at ?? null,
+    });
+  }
+
+  return NextResponse.json({
+    acquired: updated?.tool_executor_identity === identity,
+    sessionId,
+    executorIdentity: updated?.tool_executor_identity ?? identity,
+    leaseExpiresAt: updated?.tool_executor_lease_expires_at ?? leaseExpiresAtIso,
+  });
+}

--- a/src/app/api/session/executor/heartbeat/route.ts
+++ b/src/app/api/session/executor/heartbeat/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  getServerClient,
+  parseExecutorBody,
+  readSessionLease,
+} from '../shared';
+
+export const runtime = 'nodejs';
+
+export async function POST(req: NextRequest) {
+  const authHeader = req.headers.get('Authorization');
+  const supabase = getServerClient(authHeader);
+  const { sessionId, identity, leaseTtlMs } = await parseExecutorBody(req);
+
+  if (!sessionId || !identity) {
+    return NextResponse.json(
+      { error: 'sessionId and identity are required' },
+      { status: 400 },
+    );
+  }
+
+  const { data: current, error: readErr } = await readSessionLease(supabase, sessionId);
+  if (readErr) {
+    return NextResponse.json({ error: readErr.message }, { status: 500 });
+  }
+  if (!current) {
+    return NextResponse.json({ error: 'Session not found' }, { status: 404 });
+  }
+
+  const currentHolder =
+    typeof current.tool_executor_identity === 'string'
+      ? current.tool_executor_identity
+      : null;
+  if (currentHolder !== identity) {
+    return NextResponse.json({
+      ok: false,
+      sessionId,
+      executorIdentity: currentHolder,
+      leaseExpiresAt: current.tool_executor_lease_expires_at,
+    });
+  }
+
+  const now = Date.now();
+  const leaseExpiresAtIso = new Date(now + leaseTtlMs).toISOString();
+  const { data: updated, error: updateErr } = await supabase
+    .from('canvas_sessions')
+    .update({
+      tool_executor_lease_expires_at: leaseExpiresAtIso,
+      updated_at: new Date(now).toISOString(),
+    })
+    .eq('id', sessionId)
+    .eq('tool_executor_identity', identity)
+    .select('id, tool_executor_identity, tool_executor_lease_expires_at')
+    .maybeSingle();
+
+  if (updateErr) {
+    return NextResponse.json({ error: updateErr.message }, { status: 500 });
+  }
+
+  if (!updated) {
+    const { data: latest, error: latestErr } = await readSessionLease(supabase, sessionId);
+    if (latestErr) {
+      return NextResponse.json({ error: latestErr.message }, { status: 500 });
+    }
+    return NextResponse.json({
+      ok: latest?.tool_executor_identity === identity,
+      sessionId,
+      executorIdentity: latest?.tool_executor_identity ?? null,
+      leaseExpiresAt: latest?.tool_executor_lease_expires_at ?? null,
+    });
+  }
+
+  return NextResponse.json({
+    ok: true,
+    sessionId,
+    executorIdentity: updated?.tool_executor_identity ?? identity,
+    leaseExpiresAt: updated?.tool_executor_lease_expires_at ?? leaseExpiresAtIso,
+  });
+}

--- a/src/app/api/session/executor/release/route.ts
+++ b/src/app/api/session/executor/release/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerClient, parseExecutorBody } from '../shared';
+
+export const runtime = 'nodejs';
+
+export async function POST(req: NextRequest) {
+  const authHeader = req.headers.get('Authorization');
+  const supabase = getServerClient(authHeader);
+  const { sessionId, identity } = await parseExecutorBody(req);
+
+  if (!sessionId || !identity) {
+    return NextResponse.json(
+      { error: 'sessionId and identity are required' },
+      { status: 400 },
+    );
+  }
+
+  const { data, error } = await supabase
+    .from('canvas_sessions')
+    .update({
+      tool_executor_identity: null,
+      tool_executor_lease_expires_at: null,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', sessionId)
+    .eq('tool_executor_identity', identity)
+    .select('id')
+    .maybeSingle();
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({
+    released: Boolean(data?.id),
+    sessionId,
+  });
+}
+

--- a/src/app/api/session/executor/shared.ts
+++ b/src/app/api/session/executor/shared.ts
@@ -1,0 +1,36 @@
+import { NextRequest } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+
+export function getServerClient(authHeader?: string | null) {
+  const token = authHeader?.startsWith('Bearer ') ? authHeader : undefined;
+  return createClient(url, anon, {
+    global: { headers: token ? { Authorization: token } : {} },
+  });
+}
+
+export async function parseExecutorBody(req: NextRequest) {
+  const body = await req.json().catch(() => ({}));
+  const sessionId = typeof body?.sessionId === 'string' ? body.sessionId.trim() : '';
+  const roomName = typeof body?.roomName === 'string' ? body.roomName.trim() : '';
+  const identity = typeof body?.identity === 'string' ? body.identity.trim() : '';
+  const leaseTtlMsRaw = typeof body?.leaseTtlMs === 'number' ? body.leaseTtlMs : 15_000;
+  const leaseTtlMs = Math.max(5_000, Math.min(60_000, Math.round(leaseTtlMsRaw)));
+  return { sessionId, roomName, identity, leaseTtlMs };
+}
+
+export async function readSessionLease(
+  supabase: ReturnType<typeof createClient>,
+  sessionId: string,
+) {
+  const { data, error } = await supabase
+    .from('canvas_sessions')
+    .select(
+      'id, room_name, updated_at, tool_executor_identity, tool_executor_lease_expires_at',
+    )
+    .eq('id', sessionId)
+    .maybeSingle();
+  return { data, error };
+}

--- a/src/components/tool-dispatcher/hooks/tool-call-execution-guard.ts
+++ b/src/components/tool-dispatcher/hooks/tool-call-execution-guard.ts
@@ -1,0 +1,25 @@
+export function shouldExecuteIncomingToolCall(args: {
+  isExecutor: boolean;
+  processed: Map<string, number>;
+  roomKey: string;
+  callId: string;
+  now: number;
+  ttlMs?: number;
+}): { execute: boolean; key: string; reason?: 'not_executor' | 'deduped' } {
+  const { isExecutor, processed, roomKey, callId, now, ttlMs = 120_000 } = args;
+  for (const [key, ts] of processed.entries()) {
+    if (now - ts > ttlMs) {
+      processed.delete(key);
+    }
+  }
+  if (!isExecutor) {
+    return { execute: false, key: `${roomKey}:${callId}`, reason: 'not_executor' };
+  }
+  const key = `${roomKey}:${callId}`;
+  if (processed.has(key)) {
+    return { execute: false, key, reason: 'deduped' };
+  }
+  processed.set(key, now);
+  return { execute: true, key };
+}
+

--- a/src/components/tool-dispatcher/hooks/useToolRunner.test.tsx
+++ b/src/components/tool-dispatcher/hooks/useToolRunner.test.tsx
@@ -1,0 +1,46 @@
+import { shouldExecuteIncomingToolCall } from './tool-call-execution-guard';
+
+describe('shouldExecuteIncomingToolCall', () => {
+  it('skips execution for non-executor clients', () => {
+    const processed = new Map<string, number>();
+    const result = shouldExecuteIncomingToolCall({
+      isExecutor: false,
+      processed,
+      roomKey: 'canvas-room',
+      callId: 'c1',
+      now: 1000,
+    });
+    expect(result.execute).toBe(false);
+    expect(result.reason).toBe('not_executor');
+    expect(processed.size).toBe(0);
+  });
+
+  it('dedupes already-processed call ids within ttl', () => {
+    const processed = new Map<string, number>([['canvas-room:c1', 1000]]);
+    const result = shouldExecuteIncomingToolCall({
+      isExecutor: true,
+      processed,
+      roomKey: 'canvas-room',
+      callId: 'c1',
+      now: 1500,
+      ttlMs: 120000,
+    });
+    expect(result.execute).toBe(false);
+    expect(result.reason).toBe('deduped');
+  });
+
+  it('allows execution after dedupe ttl expiry', () => {
+    const processed = new Map<string, number>([['canvas-room:c1', 1000]]);
+    const result = shouldExecuteIncomingToolCall({
+      isExecutor: true,
+      processed,
+      roomKey: 'canvas-room',
+      callId: 'c1',
+      now: 130001,
+      ttlMs: 120000,
+    });
+    expect(result.execute).toBe(true);
+    expect(result.reason).toBeUndefined();
+    expect(processed.has('canvas-room:c1')).toBe(true);
+  });
+});

--- a/src/components/ui/diagnostics/realtime-sync-health.tsx
+++ b/src/components/ui/diagnostics/realtime-sync-health.tsx
@@ -1,0 +1,183 @@
+'use client';
+
+import * as React from 'react';
+import { useRoomContext } from '@livekit/components-react';
+import { useCanvasLiveKit } from '@/components/ui/livekit/livekit-room-connector';
+import { createLiveKitBus } from '@/lib/livekit/livekit-bus';
+
+export type RealtimeSyncHealthSnapshot = {
+  contract?: any;
+  syncDiagnostics?: any;
+  sessionSync?: any;
+  executor?: any;
+  tldrawSync?: any;
+  lastProcessedToolCallId?: string | null;
+};
+
+function readWindowSnapshot(): RealtimeSyncHealthSnapshot {
+  if (typeof window === 'undefined') return {};
+  const w = (window as any).__present || {};
+  return {
+    contract: w.syncContract,
+    syncDiagnostics: w.syncDiagnostics,
+    sessionSync: w.sessionSync,
+    executor: w.executor,
+    tldrawSync: w.tldrawSync,
+    lastProcessedToolCallId:
+      typeof w.lastProcessedToolCallId === 'string' ? w.lastProcessedToolCallId : null,
+  };
+}
+
+export function RealtimeSyncHealth({ enabled = true }: { enabled?: boolean }) {
+  const room = useRoomContext();
+  const livekitCtx = useCanvasLiveKit();
+  const bus = React.useMemo(() => createLiveKitBus(room), [room]);
+  const [snapshot, setSnapshot] = React.useState<RealtimeSyncHealthSnapshot>(() => readWindowSnapshot());
+  const [probe, setProbe] = React.useState<{
+    id: string | null;
+    sentAt: number | null;
+    acks: Set<string>;
+  }>({ id: null, sentAt: null, acks: new Set() });
+  const probeIdRef = React.useRef<string | null>(null);
+
+  React.useEffect(() => {
+    if (!enabled) return;
+    const refresh = () => setSnapshot(readWindowSnapshot());
+    refresh();
+    const timer = setInterval(refresh, 1000);
+    window.addEventListener('present:sync-contract', refresh as EventListener);
+    window.addEventListener('present:sync-diagnostic', refresh as EventListener);
+    window.addEventListener('present:session-sync', refresh as EventListener);
+    window.addEventListener('present:executor-state', refresh as EventListener);
+    return () => {
+      clearInterval(timer);
+      window.removeEventListener('present:sync-contract', refresh as EventListener);
+      window.removeEventListener('present:sync-diagnostic', refresh as EventListener);
+      window.removeEventListener('present:session-sync', refresh as EventListener);
+      window.removeEventListener('present:executor-state', refresh as EventListener);
+    };
+  }, [enabled]);
+
+  React.useEffect(() => {
+    if (!enabled) return;
+    const localIdentity = room?.localParticipant?.identity || '';
+    const offProbe = bus.on('sync_probe', (message: any) => {
+      const probeId = typeof message?.probeId === 'string' ? message.probeId : null;
+      const sender = typeof message?.sender === 'string' ? message.sender : null;
+      if (!probeId || sender === localIdentity) return;
+      bus.send('sync_probe_ack', {
+        type: 'sync_probe_ack',
+        probeId,
+        from: localIdentity || 'unknown',
+        room: room?.name || '',
+        ts: Date.now(),
+      });
+    });
+    const offAck = bus.on('sync_probe_ack', (message: any) => {
+      const probeId = typeof message?.probeId === 'string' ? message.probeId : null;
+      const from = typeof message?.from === 'string' ? message.from : null;
+      if (!probeId || !from || probeIdRef.current !== probeId) return;
+      setProbe((prev) => {
+        const nextAcks = new Set(prev.acks);
+        nextAcks.add(from);
+        return { ...prev, acks: nextAcks };
+      });
+    });
+    return () => {
+      offProbe?.();
+      offAck?.();
+    };
+  }, [bus, enabled, room?.localParticipant?.identity, room?.name]);
+
+  if (!enabled) return null;
+
+  const roomName = livekitCtx?.roomName || room?.name || 'unknown';
+  const contractOk = Boolean(snapshot.syncDiagnostics?.contract?.ok);
+  const tldrawOk = Boolean(snapshot.syncDiagnostics?.tldraw?.ok);
+  const sessionOk = Boolean(snapshot.syncDiagnostics?.session?.ok);
+  const livekitConnected = Boolean(livekitCtx?.isConnected);
+  const executorIdentity =
+    typeof snapshot.executor?.executorIdentity === 'string'
+      ? snapshot.executor.executorIdentity
+      : 'none';
+  const leaseExpiry =
+    typeof snapshot.executor?.leaseExpiresAt === 'string'
+      ? snapshot.executor.leaseExpiresAt
+      : 'none';
+  const healthy = contractOk && tldrawOk && sessionOk && livekitConnected;
+  const probeLatency =
+    probe.sentAt != null ? Math.max(0, Date.now() - probe.sentAt) : null;
+  const contractCanvasId =
+    typeof snapshot.contract?.canvasId === 'string' ? snapshot.contract.canvasId : 'none';
+  const contractRoom =
+    typeof snapshot.contract?.livekitRoomName === 'string'
+      ? snapshot.contract.livekitRoomName
+      : roomName;
+  const contractTldrawRoom =
+    typeof snapshot.contract?.tldrawRoomId === 'string'
+      ? snapshot.contract.tldrawRoomId
+      : 'none';
+  const tldrawConnection =
+    typeof snapshot.tldrawSync?.connectionStatus === 'string'
+      ? snapshot.tldrawSync.connectionStatus
+      : 'unknown';
+
+  return (
+    <div className="fixed bottom-4 left-4 z-[1200] w-[360px] max-w-[calc(100vw-2rem)] rounded-xl border border-default bg-surface/95 p-3 text-xs text-primary shadow-lg backdrop-blur">
+      <div className="mb-2 flex items-center justify-between">
+        <div className="font-semibold">Realtime Sync Health</div>
+        <span
+          className={[
+            'rounded px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide',
+            healthy ? 'bg-success-surface text-success' : 'bg-danger-surface text-danger',
+          ].join(' ')}
+        >
+          {healthy ? 'healthy' : 'degraded'}
+        </span>
+      </div>
+      <div className="space-y-1 text-secondary">
+        <div>Room: <span className="font-mono text-primary">{roomName}</span></div>
+        <div>CanvasId: <span className="font-mono text-primary">{contractCanvasId}</span></div>
+        <div>Contract Room: <span className="font-mono text-primary">{contractRoom}</span></div>
+        <div>TLDraw Room: <span className="font-mono text-primary">{contractTldrawRoom}</span></div>
+        <div>Participants: <span className="font-mono text-primary">{livekitCtx?.participantCount ?? 0}</span></div>
+        <div>Contract: <span className="font-mono text-primary">{contractOk ? 'ok' : 'mismatch'}</span></div>
+        <div>TLDraw Sync: <span className="font-mono text-primary">{snapshot.tldrawSync?.status ?? 'unknown'}</span></div>
+        <div>TLDraw Conn: <span className="font-mono text-primary">{tldrawConnection}</span></div>
+        <div>Session: <span className="font-mono text-primary">{snapshot.sessionSync?.sessionId ?? 'none'}</span></div>
+        <div>Session Room: <span className="font-mono text-primary">{snapshot.syncDiagnostics?.session?.roomName ?? 'none'}</span></div>
+        <div>Executor: <span className="font-mono text-primary">{executorIdentity}</span></div>
+        <div>Lease Expiry: <span className="font-mono text-primary">{leaseExpiry}</span></div>
+        <div>Writer: <span className="font-mono text-primary">{snapshot.sessionSync?.isWriter ? 'true' : 'false'}</span></div>
+        <div>Last Tool Call: <span className="font-mono text-primary">{snapshot.lastProcessedToolCallId ?? 'none'}</span></div>
+      </div>
+      <div className="mt-3 flex items-center justify-between gap-2">
+        <button
+          type="button"
+          className="rounded border border-default bg-surface-secondary px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-primary"
+          onClick={() => {
+            const localIdentity = room?.localParticipant?.identity || 'unknown';
+            const probeId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+            probeIdRef.current = probeId;
+            setProbe({ id: probeId, sentAt: Date.now(), acks: new Set() });
+            bus.send('sync_probe', {
+              type: 'sync_probe',
+              probeId,
+              sender: localIdentity,
+              room: room?.name || '',
+              ts: Date.now(),
+            });
+          }}
+        >
+          Run Probe
+        </button>
+        <div className="text-[10px] text-secondary">
+          Probe: {probe.id ? `${probe.acks.size} ack(s)` : 'idle'}
+          {probeLatency != null ? ` • ${probeLatency}ms` : ''}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default RealtimeSyncHealth;

--- a/src/components/ui/livekit/participant/livekit-participant-tile.test.tsx
+++ b/src/components/ui/livekit/participant/livekit-participant-tile.test.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { LivekitParticipantTile } from './livekit-participant-tile';
+
+const useParticipantsMock = jest.fn();
+const useLocalParticipantMock = jest.fn();
+const useRoomContextMock = jest.fn();
+const useCanvasLiveKitMock = jest.fn();
+
+jest.mock('@livekit/components-react', () => ({
+  useParticipants: () => useParticipantsMock(),
+  useLocalParticipant: () => useLocalParticipantMock(),
+  useRoomContext: () => useRoomContextMock(),
+}));
+
+jest.mock('../livekit-room-connector', () => ({
+  useCanvasLiveKit: () => useCanvasLiveKitMock(),
+}));
+
+jest.mock('./livekit-single-participant-tile', () => ({
+  SingleParticipantTile: ({ participant }: any) => (
+    <div data-testid="single-participant-tile">{participant.identity}</div>
+  ),
+}));
+
+describe('LivekitParticipantTile', () => {
+  beforeEach(() => {
+    useCanvasLiveKitMock.mockReturnValue({
+      isConnected: true,
+      roomName: 'canvas-room',
+      participantCount: 2,
+    });
+    useRoomContextMock.mockReturnValue({});
+    useParticipantsMock.mockReturnValue([{ identity: 'bob', isLocal: false }]);
+    useLocalParticipantMock.mockReturnValue({
+      localParticipant: { identity: 'alice', isLocal: true },
+    });
+  });
+
+  it('renders explicit unassigned slot state and allows assignment', () => {
+    const onIdentityChange = jest.fn();
+    render(
+      <LivekitParticipantTile
+        slotId="slot-a"
+        assignmentStatus="unassigned"
+        onIdentityChange={onIdentityChange}
+      />,
+    );
+
+    expect(screen.getByText('Unassigned Slot')).toBeTruthy();
+    expect(screen.getByText(/slot-a/i)).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: /assign participant/i }));
+    expect(onIdentityChange).toHaveBeenCalledWith('alice');
+  });
+
+  it('renders participant tile when shared identity is assigned', () => {
+    render(
+      <LivekitParticipantTile
+        slotId="slot-b"
+        assignmentStatus="assigned"
+        participantIdentity="bob"
+      />,
+    );
+
+    expect(screen.getByTestId('single-participant-tile').textContent).toContain('bob');
+  });
+});

--- a/src/components/ui/livekit/participant/livekit-participant-tile.tsx
+++ b/src/components/ui/livekit/participant/livekit-participant-tile.tsx
@@ -15,6 +15,14 @@ import { useParticipants, useLocalParticipant, useRoomContext } from '@livekit/c
 import { LivekitParticipantTileState, SingleParticipantTile } from './livekit-single-participant-tile';
 
 export const livekitParticipantTileSchema = z.object({
+  slotId: z
+    .string()
+    .optional()
+    .describe('Stable slot identifier for this tile (defaults to component id/message id)'),
+  assignmentStatus: z
+    .enum(['unassigned', 'assigned'])
+    .optional()
+    .describe('Shared assignment status for this participant slot'),
   participantIdentity: z
     .string()
     .optional()
@@ -62,6 +70,8 @@ export const livekitParticipantTileSchema = z.object({
 export type LivekitParticipantTileProps = z.infer<typeof livekitParticipantTileSchema>;
 
 export const LivekitParticipantTile = React.memo(function LivekitParticipantTile({
+  slotId,
+  assignmentStatus,
   participantIdentity,
   showToolbar = true,
   showVideo = true,
@@ -87,6 +97,58 @@ export const LivekitParticipantTile = React.memo(function LivekitParticipantTile
   const room = useRoomContext();
   const participants = useParticipants();
   const { localParticipant } = useLocalParticipant();
+  const resolvedSlotId = slotId?.trim() || 'slot';
+  const resolvedAssignmentStatus =
+    assignmentStatus ??
+    (participantIdentity && participantIdentity.trim().length > 0 ? 'assigned' : 'unassigned');
+
+  const isAgentParticipant = React.useCallback((p: any) => {
+    try {
+      const kind = String(p?.kind ?? '').toLowerCase();
+      if (kind === 'agent') return true;
+      const identity = String(p?.identity || '').toLowerCase();
+      const metadata = String(p?.metadata || '').toLowerCase();
+      return (
+        identity.startsWith('agent-') ||
+        identity.includes('voice-agent') ||
+        identity === 'voiceagent' ||
+        metadata.includes('voice-agent') ||
+        metadata.includes('voiceagent')
+      );
+    } catch {
+      return false;
+    }
+  }, []);
+
+  const participantOptions = React.useMemo(() => {
+    const list: Array<{ identity: string; label: string }> = [];
+    if (localParticipant && !isAgentParticipant(localParticipant)) {
+      list.push({
+        identity: localParticipant.identity,
+        label: `${localParticipant.identity} (You)`,
+      });
+    }
+    participants
+      .filter((p) => !isAgentParticipant(p))
+      .sort((a, b) => String(a.identity).localeCompare(String(b.identity)))
+      .forEach((p) => {
+        if (!list.find((entry) => entry.identity === p.identity)) {
+          list.push({ identity: p.identity, label: p.identity });
+        }
+      });
+    return list;
+  }, [isAgentParticipant, localParticipant, participants]);
+  const [selectedIdentity, setSelectedIdentity] = React.useState<string>('');
+
+  React.useEffect(() => {
+    if (!participantOptions.length) {
+      setSelectedIdentity('');
+      return;
+    }
+    if (!selectedIdentity || !participantOptions.some((entry) => entry.identity === selectedIdentity)) {
+      setSelectedIdentity(participantOptions[0].identity);
+    }
+  }, [participantOptions, selectedIdentity]);
 
   React.useEffect(() => {
     if (!canvasLiveKit) {
@@ -140,79 +202,13 @@ export const LivekitParticipantTile = React.memo(function LivekitParticipantTile
     );
   }
 
-  // Robust Participant Selection Logic
-  // 1. Explicit identity via prop
-  // 2. "Waiting" state if explicit identity is missing
-  // 3. Auto-select first REMOTE participant if no identity is set
-  // 4. Fallback to LOCAL participant if no remote and no identity
-
-  let targetIdentity = participantIdentity;
-  let autoSelected = false;
-
-  // Auto-selection logic: If no identity is assigned, pick the first remote participant
-  if (!targetIdentity) {
-    const isAgentParticipant = (p: any) => {
-      try {
-        const kind = String(p?.kind ?? '').toLowerCase();
-        if (kind === 'agent') return true;
-        const identity = String(p?.identity || '').toLowerCase();
-        const metadata = String(p?.metadata || '').toLowerCase();
-        return (
-          identity.startsWith('agent-') ||
-          identity.includes('voice-agent') ||
-          identity === 'voiceagent' ||
-          metadata.includes('voice-agent') ||
-          metadata.includes('voiceagent')
-        );
-      } catch {
-        return false;
-      }
-    };
-
-    // Prefer local self-view by default.
-    if (localParticipant && !isAgentParticipant(localParticipant)) {
-      targetIdentity = localParticipant.identity;
-      autoSelected = true;
-    } else {
-      // Otherwise, prefer a non-agent remote participant.
-      const firstHumanRemote = participants.find((p: any) => !p.isLocal && !isAgentParticipant(p));
-      const firstRemote = firstHumanRemote ?? participants.find((p) => !p.isLocal);
-      if (firstHumanRemote) {
-        targetIdentity = firstHumanRemote.identity;
-        autoSelected = true;
-      } else if (firstRemote && !isAgentParticipant(firstRemote)) {
-        targetIdentity = firstRemote.identity;
-        autoSelected = true;
-      } else {
-        // Avoid briefly snapping to an agent tile before the local participant is ready.
-        return (
-          <div
-            className="relative overflow-hidden rounded-lg border border-default bg-surface-elevated text-primary"
-            style={{ width, height, borderRadius }}
-          >
-            <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 p-4">
-              <Loader2 className="h-7 w-7 animate-spin text-tertiary" />
-              <div className="text-xs text-secondary">Waiting for participants…</div>
-            </div>
-          </div>
-        );
-      }
-    }
-    if (!targetIdentity && localParticipant) {
-      targetIdentity = localParticipant.identity;
-      autoSelected = true;
-    }
-  }
+  const targetIdentity = participantIdentity?.trim() || undefined;
 
   const participant = targetIdentity
     ? (localParticipant?.identity === targetIdentity ? localParticipant : null) ||
       participants.find((p) => p.identity === targetIdentity) ||
       null
     : null;
-
-  // If we auto-selected someone, we should technically "commit" this selection to the canvas state
-  // so everyone sees the same person. But strictly controlled components shouldn't side-effect update props.
-  // For now, we'll just render them visually. Ideally, the user clicks "Pin" to save this state.
 
   if (participant) {
     return (
@@ -236,8 +232,8 @@ export const LivekitParticipantTile = React.memo(function LivekitParticipantTile
     );
   }
 
-  // WAITING STATE: Identity is set, but participant not found in room
-  if (participantIdentity && !participant) {
+  // WAITING STATE: Identity is assigned in shared state, but participant not in room.
+  if (targetIdentity && !participant) {
     return (
         <div
           className="flex flex-col items-center justify-center gap-2 rounded-lg border border-default border-dashed bg-surface-secondary p-4"
@@ -245,9 +241,12 @@ export const LivekitParticipantTile = React.memo(function LivekitParticipantTile
         >
           <Loader2 className="w-8 h-8 text-tertiary animate-spin" />
           <div className="text-center">
+            <p className="mb-1 rounded border border-default bg-surface px-2 py-1 font-mono text-[10px] uppercase tracking-wide text-tertiary">
+              {resolvedSlotId} • {resolvedAssignmentStatus}
+            </p>
             <p className="mb-1 font-medium text-secondary">Waiting for...</p>
             <p className="rounded border border-default bg-surface px-2 py-1 font-mono text-xs text-secondary">
-              {participantIdentity}
+              {targetIdentity}
             </p>
             <p className="mt-2 text-[10px] text-tertiary">Participant is not in the room yet</p>
           </div>
@@ -255,7 +254,7 @@ export const LivekitParticipantTile = React.memo(function LivekitParticipantTile
     );
   }
 
-  // EMPTY STATE: No identity set, and no participants found to auto-select
+  // UNASSIGNED STATE: Slot exists, but no participant has been assigned in shared state.
   return (
     <div
       className="flex flex-col items-center justify-center gap-2 rounded-lg border border-warning-surface bg-warning-surface p-4 text-warning"
@@ -263,18 +262,41 @@ export const LivekitParticipantTile = React.memo(function LivekitParticipantTile
     >
       <User className="w-8 h-8" />
       <div className="text-center">
-        <p className="mb-1 font-medium">No Participants</p>
-        <p className="mb-2 text-xs text-secondary">
-          Waiting for someone to join...
+        <p className="mb-1 rounded border border-default bg-surface px-2 py-1 font-mono text-[10px] uppercase tracking-wide text-tertiary">
+          {resolvedSlotId} • {resolvedAssignmentStatus}
         </p>
-        {localParticipant && (
-           <button 
-             className="mt-1 text-xs font-medium text-[var(--present-accent)] underline underline-offset-4 hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--present-accent-ring)] rounded"
-             onClick={() => onIdentityChange?.(localParticipant.identity)}
-           >
-             Show Me ({localParticipant.identity})
-           </button>
-        )}
+        <p className="mb-1 font-medium">Unassigned Slot</p>
+        <p className="mb-2 text-xs text-secondary">
+          Assign a participant to sync this tile across everyone in the room.
+        </p>
+        <div className="mt-2 flex flex-col items-center gap-2">
+          <select
+            className="w-full rounded border border-default bg-surface px-2 py-1 text-xs text-primary"
+            value={selectedIdentity}
+            onChange={(event) => setSelectedIdentity(event.target.value)}
+          >
+            {participantOptions.length === 0 ? (
+              <option value="">No participants available</option>
+            ) : (
+              participantOptions.map((option) => (
+                <option key={option.identity} value={option.identity}>
+                  {option.label}
+                </option>
+              ))
+            )}
+          </select>
+          <button
+            className="mt-1 text-xs font-medium text-[var(--present-accent)] underline underline-offset-4 hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--present-accent-ring)] rounded"
+            onClick={() => {
+              if (!selectedIdentity) return;
+              onIdentityChange?.(selectedIdentity);
+            }}
+            disabled={!selectedIdentity}
+            type="button"
+          >
+            Assign Participant
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/src/components/ui/productivity/crowd-pulse-schema.ts
+++ b/src/components/ui/productivity/crowd-pulse-schema.ts
@@ -27,6 +27,7 @@ export const crowdPulseWidgetSchema = z.object({
   questions: z.array(crowdQuestionSchema).optional(),
   scoreboard: z.array(crowdScoreSchema).optional(),
   followUps: z.array(z.string()).optional(),
+  version: z.number().optional(),
   lastUpdated: z.number().optional(),
   demoMode: z.boolean().optional(),
   sensorEnabled: z.boolean().optional(),
@@ -55,6 +56,7 @@ export type CrowdPulseState = {
   questions: CrowdQuestion[];
   scoreboard: CrowdScore[];
   followUps: string[];
+  version: number;
   lastUpdated?: number;
   demoMode: boolean;
   sensorEnabled: boolean;

--- a/src/components/ui/productivity/crowd-pulse-widget.tsx
+++ b/src/components/ui/productivity/crowd-pulse-widget.tsx
@@ -47,6 +47,7 @@ export default function CrowdPulseWidget(props: CrowdPulseWidgetProps) {
     questions: initial.questions ?? [],
     scoreboard: initial.scoreboard ?? [],
     followUps: initial.followUps ?? [],
+    version: typeof initial.version === 'number' ? initial.version : 1,
     lastUpdated: initial.lastUpdated,
     demoMode: initial.demoMode ?? false,
     sensorEnabled: initial.sensorEnabled ?? true,
@@ -83,6 +84,7 @@ export default function CrowdPulseWidget(props: CrowdPulseWidgetProps) {
       if (Array.isArray(patch.scoreboard)) next.scoreboard = patch.scoreboard as CrowdPulseState['scoreboard'];
       if (Array.isArray(patch.followUps)) next.followUps = patch.followUps as string[];
       if (typeof patch.lastUpdated === 'number') next.lastUpdated = patch.lastUpdated;
+      if (typeof patch.version === 'number') next.version = patch.version;
       if (typeof patch.demoMode === 'boolean') next.demoMode = patch.demoMode;
       if (typeof patch.sensorEnabled === 'boolean') next.sensorEnabled = patch.sensorEnabled;
       if (typeof patch.showPreview === 'boolean') next.showPreview = patch.showPreview;
@@ -103,6 +105,7 @@ export default function CrowdPulseWidget(props: CrowdPulseWidgetProps) {
       questions: state.questions,
       scoreboard: state.scoreboard,
       followUps: state.followUps,
+      version: state.version,
       lastUpdated: state.lastUpdated,
       demoMode: state.demoMode,
       sensorEnabled: state.sensorEnabled,
@@ -230,6 +233,7 @@ export default function CrowdPulseWidget(props: CrowdPulseWidgetProps) {
               next.confidence = metrics.confidence;
               next.noiseLevel = metrics.noiseLevel;
               next.lastUpdated = Date.now();
+              next.version = (prev.version ?? 0) + 1;
               if (prev.status === 'idle' && metrics.handCount > 0) {
                 next.status = 'counting';
               }

--- a/src/components/ui/productivity/debate-scorecard.tsx
+++ b/src/components/ui/productivity/debate-scorecard.tsx
@@ -1333,6 +1333,12 @@ export function DebateScorecard(props: DebateScorecardProps) {
             ...(typeof patch.status === 'string' ? { status: patch.status as any } : null),
           };
         }
+        const nextVersion =
+          typeof prev.version === 'number' && Number.isFinite(prev.version)
+            ? prev.version + 1
+            : 1;
+        next.version = nextVersion;
+        next.lastUpdated = Date.now();
         return next;
       });
 

--- a/src/hooks/use-room-executor.test.tsx
+++ b/src/hooks/use-room-executor.test.tsx
@@ -1,0 +1,209 @@
+import React from 'react';
+import { act, render, waitFor, cleanup } from '@testing-library/react';
+import { useRoomExecutor } from './use-room-executor';
+
+const fetchWithSupabaseAuthMock = jest.fn();
+
+jest.mock('@/lib/supabase/auth-headers', () => ({
+  fetchWithSupabaseAuth: (...args: any[]) => fetchWithSupabaseAuthMock(...args),
+}));
+
+type RoomLike = {
+  name: string;
+  state: string;
+  localParticipant?: { identity: string };
+};
+
+function mockJsonResponse(body: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  };
+}
+
+function HookProbe({
+  room,
+  onState,
+}: {
+  room: RoomLike;
+  onState: (state: ReturnType<typeof useRoomExecutor>) => void;
+}) {
+  const state = useRoomExecutor(room as any);
+  React.useEffect(() => onState(state), [onState, state]);
+  return null;
+}
+
+describe('useRoomExecutor', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    fetchWithSupabaseAuthMock.mockReset();
+    (window as any).__present = {
+      sessionSync: {
+        sessionId: '11111111-1111-1111-1111-111111111111',
+        roomName: 'canvas-11111111-1111-1111-1111-111111111111',
+      },
+    };
+  });
+
+  afterEach(() => {
+    cleanup();
+    jest.useRealTimers();
+  });
+
+  it('claims executor lease when available', async () => {
+    const successPayload = {
+      acquired: true,
+      executorIdentity: 'alice',
+      leaseExpiresAt: new Date(Date.now() + 15_000).toISOString(),
+    };
+    fetchWithSupabaseAuthMock.mockResolvedValueOnce(
+      mockJsonResponse(successPayload),
+    );
+    fetchWithSupabaseAuthMock.mockResolvedValueOnce(mockJsonResponse(successPayload));
+
+    let lastState: any = null;
+    render(
+      <HookProbe
+        room={{
+          name: 'canvas-11111111-1111-1111-1111-111111111111',
+          state: 'connected',
+          localParticipant: { identity: 'alice' },
+        }}
+        onState={(state) => {
+          lastState = state;
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(lastState?.isExecutor).toBe(true);
+      expect(lastState?.status).toBe('active');
+    });
+  });
+
+  it('stays standby when another executor owns the lease', async () => {
+    fetchWithSupabaseAuthMock.mockResolvedValueOnce(
+      mockJsonResponse({
+        acquired: false,
+        executorIdentity: 'bob',
+        leaseExpiresAt: new Date(Date.now() + 15_000).toISOString(),
+      }),
+    );
+
+    let lastState: any = null;
+    render(
+      <HookProbe
+        room={{
+          name: 'canvas-11111111-1111-1111-1111-111111111111',
+          state: 'connected',
+          localParticipant: { identity: 'alice' },
+        }}
+        onState={(state) => {
+          lastState = state;
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(lastState?.isExecutor).toBe(false);
+      expect(lastState?.executorIdentity).toBe('bob');
+      expect(lastState?.status).toBe('standby');
+    });
+  });
+
+  it('heartbeats when already executor', async () => {
+    const successPayload = {
+      acquired: true,
+      executorIdentity: 'alice',
+      leaseExpiresAt: new Date(Date.now() + 15_000).toISOString(),
+    };
+    fetchWithSupabaseAuthMock
+      .mockResolvedValueOnce(mockJsonResponse(successPayload))
+      .mockResolvedValueOnce(mockJsonResponse({ ...successPayload, ok: true }));
+
+    let lastState: any = null;
+    render(
+      <HookProbe
+        room={{
+          name: 'canvas-11111111-1111-1111-1111-111111111111',
+          state: 'connected',
+          localParticipant: { identity: 'alice' },
+        }}
+        onState={(state) => {
+          lastState = state;
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(lastState?.isExecutor).toBe(true);
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(5_000);
+    });
+
+    await waitFor(() => {
+      expect(fetchWithSupabaseAuthMock).toHaveBeenCalledWith(
+        '/api/session/executor/heartbeat',
+        expect.any(Object),
+      );
+    });
+  });
+
+  it('fails over to local identity after lease expiry', async () => {
+    fetchWithSupabaseAuthMock
+      .mockResolvedValueOnce(
+        mockJsonResponse({
+          acquired: false,
+          executorIdentity: 'bob',
+          leaseExpiresAt: new Date(Date.now() + 500).toISOString(),
+        }),
+      )
+      .mockResolvedValueOnce(
+        mockJsonResponse({
+          acquired: true,
+          executorIdentity: 'alice',
+          leaseExpiresAt: new Date(Date.now() + 15_000).toISOString(),
+        }),
+      )
+      .mockResolvedValueOnce(
+        mockJsonResponse({
+          ok: true,
+          executorIdentity: 'alice',
+          leaseExpiresAt: new Date(Date.now() + 15_000).toISOString(),
+        }),
+      );
+
+    let lastState: any = null;
+    render(
+      <HookProbe
+        room={{
+          name: 'canvas-11111111-1111-1111-1111-111111111111',
+          state: 'connected',
+          localParticipant: { identity: 'alice' },
+        }}
+        onState={(state) => {
+          lastState = state;
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(lastState?.status).toBe('standby');
+      expect(lastState?.executorIdentity).toBe('bob');
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(5_000);
+    });
+
+    await waitFor(() => {
+      expect(lastState?.isExecutor).toBe(true);
+      expect(lastState?.executorIdentity).toBe('alice');
+      expect(lastState?.status).toBe('active');
+    });
+  });
+});

--- a/src/hooks/use-room-executor.ts
+++ b/src/hooks/use-room-executor.ts
@@ -1,0 +1,246 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import type { Room } from 'livekit-client';
+import { fetchWithSupabaseAuth } from '@/lib/supabase/auth-headers';
+
+type SessionSyncInfo = {
+  sessionId: string | null;
+  roomName: string;
+};
+
+type ExecutorApiResponse = {
+  acquired?: boolean;
+  ok?: boolean;
+  executorIdentity?: string | null;
+  leaseExpiresAt?: string | null;
+};
+
+export type RoomExecutorState = {
+  sessionId: string | null;
+  isExecutor: boolean;
+  executorIdentity: string | null;
+  leaseExpiresAt: string | null;
+  status: 'idle' | 'claiming' | 'active' | 'standby' | 'error';
+  error: string | null;
+};
+
+const CLAIM_INTERVAL_MS = 5_000;
+const LEASE_TTL_MS = 15_000;
+
+function readSessionSyncInfo(): SessionSyncInfo {
+  if (typeof window === 'undefined') {
+    return { sessionId: null, roomName: '' };
+  }
+  const sync = (window as any)?.__present?.sessionSync;
+  return {
+    sessionId: typeof sync?.sessionId === 'string' ? sync.sessionId : null,
+    roomName: typeof sync?.roomName === 'string' ? sync.roomName : '',
+  };
+}
+
+function publishExecutorState(state: RoomExecutorState) {
+  if (typeof window === 'undefined') return;
+  try {
+    const w = window as any;
+    w.__present = w.__present || {};
+    w.__present.executor = {
+      ...state,
+      updatedAt: Date.now(),
+    };
+    window.dispatchEvent(
+      new CustomEvent('present:executor-state', {
+        detail: w.__present.executor,
+      }),
+    );
+  } catch {
+    // noop
+  }
+}
+
+async function postExecutor(
+  path: string,
+  payload: Record<string, unknown>,
+): Promise<ExecutorApiResponse> {
+  const res = await fetchWithSupabaseAuth(path, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+    keepalive: path.endsWith('/release'),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(text || `Executor request failed: ${res.status}`);
+  }
+  return (await res.json()) as ExecutorApiResponse;
+}
+
+export function useRoomExecutor(room?: Room) {
+  const [state, setState] = useState<RoomExecutorState>({
+    sessionId: null,
+    isExecutor: false,
+    executorIdentity: null,
+    leaseExpiresAt: null,
+    status: 'idle',
+    error: null,
+  });
+  const sessionRef = useRef<SessionSyncInfo>(readSessionSyncInfo());
+  const inFlightRef = useRef(false);
+  const isExecutorRef = useRef(state.isExecutor);
+  const tickRef = useRef<(() => Promise<void>) | null>(null);
+
+  useEffect(() => {
+    isExecutorRef.current = state.isExecutor;
+  }, [state.isExecutor]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const releaseLease = (sessionId: string, roomName: string, identity: string) => {
+      if (!sessionId || !identity) return;
+      void postExecutor('/api/session/executor/release', {
+        sessionId,
+        roomName,
+        identity,
+      }).catch(() => {
+        // noop
+      });
+    };
+
+    const updateSession = () => {
+      const previous = sessionRef.current;
+      const next = readSessionSyncInfo();
+      const identity = room?.localParticipant?.identity || '';
+      const previousRoomName = previous.roomName || room?.name || '';
+      if (
+        isExecutorRef.current &&
+        identity &&
+        previous.sessionId &&
+        previous.sessionId !== next.sessionId
+      ) {
+        releaseLease(previous.sessionId, previousRoomName, identity);
+      }
+      sessionRef.current = next;
+      setState((prev) => ({
+        ...prev,
+        sessionId: next.sessionId,
+      }));
+      void tickRef.current?.();
+    };
+    updateSession();
+    window.addEventListener('present:session-sync', updateSession as EventListener);
+    return () => {
+      window.removeEventListener('present:session-sync', updateSession as EventListener);
+    };
+  }, [room]);
+
+  useEffect(() => {
+    publishExecutorState(state);
+  }, [state]);
+
+  useEffect(() => {
+    if (!room) return;
+    let active = true;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const tick = async () => {
+      if (!active) return;
+      if (inFlightRef.current) {
+        timer = setTimeout(() => void tick(), CLAIM_INTERVAL_MS);
+        return;
+      }
+      const sessionId = sessionRef.current.sessionId;
+      const roomName = sessionRef.current.roomName || room.name || '';
+      const identity = room.localParticipant?.identity || '';
+      const connected = room.state === 'connected';
+
+      if (!sessionId || !roomName || !identity || !connected) {
+        setState((prev) => ({
+          ...prev,
+          sessionId: sessionId ?? null,
+          status: 'idle',
+          isExecutor: false,
+          error: null,
+        }));
+        timer = setTimeout(() => void tick(), CLAIM_INTERVAL_MS);
+        return;
+      }
+
+      inFlightRef.current = true;
+      try {
+        const endpoint = state.isExecutor
+          ? '/api/session/executor/heartbeat'
+          : '/api/session/executor/claim';
+        const response = await postExecutor(endpoint, {
+          sessionId,
+          roomName,
+          identity,
+          leaseTtlMs: LEASE_TTL_MS,
+        });
+        const executorIdentity =
+          typeof response.executorIdentity === 'string'
+            ? response.executorIdentity
+            : null;
+        const leaseExpiresAt =
+          typeof response.leaseExpiresAt === 'string'
+            ? response.leaseExpiresAt
+            : null;
+        const isExecutor =
+          Boolean(response.acquired ?? response.ok) &&
+          executorIdentity === identity;
+        setState((prev) => ({
+          ...prev,
+          sessionId,
+          isExecutor,
+          executorIdentity,
+          leaseExpiresAt,
+          status: isExecutor ? 'active' : 'standby',
+          error: null,
+        }));
+      } catch (error) {
+        setState((prev) => ({
+          ...prev,
+          sessionId,
+          isExecutor: false,
+          status: 'error',
+          error: error instanceof Error ? error.message : String(error),
+        }));
+      } finally {
+        inFlightRef.current = false;
+        if (active) timer = setTimeout(() => void tick(), CLAIM_INTERVAL_MS);
+      }
+    };
+    tickRef.current = tick;
+
+    void tick();
+
+    const release = () => {
+      const sessionId = sessionRef.current.sessionId;
+      const roomName = sessionRef.current.roomName || room.name || '';
+      const identity = room.localParticipant?.identity || '';
+      if (!sessionId || !identity) return;
+      void postExecutor('/api/session/executor/release', {
+        sessionId,
+        roomName,
+        identity,
+      }).catch(() => {
+        // noop
+      });
+    };
+
+    const onUnload = () => release();
+    window.addEventListener('beforeunload', onUnload);
+    return () => {
+      active = false;
+      if (timer) clearTimeout(timer);
+      tickRef.current = null;
+      window.removeEventListener('beforeunload', onUnload);
+      if (state.isExecutor) {
+        release();
+      }
+    };
+  }, [room, state.isExecutor]);
+
+  return state;
+}
+
+export default useRoomExecutor;

--- a/src/lib/component-registry.test.ts
+++ b/src/lib/component-registry.test.ts
@@ -1,0 +1,82 @@
+import { ComponentRegistry } from './component-registry';
+
+describe('ComponentRegistry version convergence', () => {
+  beforeEach(() => {
+    ComponentRegistry.clear();
+  });
+
+  afterEach(() => {
+    ComponentRegistry.clear();
+  });
+
+  it('accepts monotonic versions and rejects stale ones', async () => {
+    ComponentRegistry.register({
+      messageId: 'cmp-1',
+      componentType: 'TestWidget',
+      props: { value: 0, version: 0, lastUpdated: 1 },
+      contextKey: 'canvas',
+      timestamp: Date.now(),
+    });
+
+    const v1 = await ComponentRegistry.update(
+      'cmp-1',
+      { value: 1, version: 1, lastUpdated: 10 },
+      { version: 1, timestamp: 10, source: 'test' },
+    );
+    expect(v1.success).toBe(true);
+    expect((ComponentRegistry.get('cmp-1')?.props as any)?.value).toBe(1);
+
+    const stale = await ComponentRegistry.update(
+      'cmp-1',
+      { value: 999, version: 0, lastUpdated: 5 },
+      { version: 0, timestamp: 5, source: 'test' },
+    );
+    expect(stale.success).toBe(true);
+    expect((stale as any).ignored).toBe(true);
+    expect((ComponentRegistry.get('cmp-1')?.props as any)?.value).toBe(1);
+
+    const v2 = await ComponentRegistry.update(
+      'cmp-1',
+      { value: 2, version: 2, lastUpdated: 20 },
+      { version: 2, timestamp: 20, source: 'test' },
+    );
+    expect(v2.success).toBe(true);
+    expect((ComponentRegistry.get('cmp-1')?.props as any)?.value).toBe(2);
+  });
+
+  it('allows repeated updates when allowRepeat meta is provided', async () => {
+    ComponentRegistry.register({
+      messageId: 'cmp-2',
+      componentType: 'Diagnostics',
+      props: { beats: 0, version: 0, lastUpdated: 1 },
+      contextKey: 'canvas',
+      timestamp: Date.now(),
+    });
+
+    const first = await ComponentRegistry.update(
+      'cmp-2',
+      {
+        beats: 1,
+        version: 1,
+        lastUpdated: 2,
+        __meta: { allowRepeat: true },
+      } as any,
+      { version: 1, timestamp: 2, source: 'test' },
+    );
+    expect(first.success).toBe(true);
+
+    const second = await ComponentRegistry.update(
+      'cmp-2',
+      {
+        beats: 1,
+        version: 2,
+        lastUpdated: 3,
+        __meta: { allowRepeat: true },
+      } as any,
+      { version: 2, timestamp: 3, source: 'test' },
+    );
+    expect(second.success).toBe(true);
+    expect((second as any).isCircuitBreakerBlock).toBeUndefined();
+  });
+});
+

--- a/src/lib/realtime/sync-contract.ts
+++ b/src/lib/realtime/sync-contract.ts
@@ -1,0 +1,101 @@
+export type SyncContract = {
+  canvasId: string | null;
+  livekitRoomName: string;
+  tldrawRoomId: string;
+  sessionKey: string;
+  invariants: {
+    livekitMatchesTldraw: boolean;
+    roomMatchesCanvas: boolean;
+  };
+  errors: string[];
+};
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function isUuid(value: string | null | undefined): value is string {
+  if (!value) return false;
+  return UUID_RE.test(value);
+}
+
+export function buildCanvasRoomName(canvasId: string): string {
+  return `canvas-${canvasId}`;
+}
+
+export function extractCanvasIdFromRoomName(roomName: string | null | undefined): string | null {
+  if (!roomName) return null;
+  const trimmed = roomName.trim();
+  const match = trimmed.match(
+    /^canvas-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i,
+  );
+  const parsed = match?.[1] ?? null;
+  return isUuid(parsed) ? parsed : null;
+}
+
+export function getCanvasIdFromCurrentUrl(): string | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const params = new URLSearchParams(window.location.search);
+    const raw = params.get('id');
+    return isUuid(raw) ? raw : null;
+  } catch {
+    return null;
+  }
+}
+
+type BuildSyncContractInput = {
+  roomName: string;
+  canvasId?: string | null;
+  tldrawRoomId?: string | null;
+};
+
+export function buildSyncContract(input: BuildSyncContractInput): SyncContract {
+  const roomName = String(input.roomName || '').trim();
+  const derivedCanvasId = isUuid(input.canvasId) ? input.canvasId : extractCanvasIdFromRoomName(roomName);
+  const livekitRoomName = roomName;
+  const tldrawRoomId = String(input.tldrawRoomId || livekitRoomName || '').trim();
+  const expectedRoomForCanvas = derivedCanvasId ? buildCanvasRoomName(derivedCanvasId) : null;
+  const roomMatchesCanvas = expectedRoomForCanvas ? expectedRoomForCanvas === livekitRoomName : true;
+  const livekitMatchesTldraw = livekitRoomName === tldrawRoomId;
+  const errors: string[] = [];
+
+  if (!livekitMatchesTldraw) {
+    errors.push('LiveKit room does not match TLDraw room id');
+  }
+  if (!roomMatchesCanvas) {
+    errors.push('Room name does not match canonical canvas room');
+  }
+
+  return {
+    canvasId: derivedCanvasId ?? null,
+    livekitRoomName,
+    tldrawRoomId,
+    sessionKey: `${livekitRoomName}::${derivedCanvasId ?? 'none'}`,
+    invariants: {
+      livekitMatchesTldraw,
+      roomMatchesCanvas,
+    },
+    errors,
+  };
+}
+
+type SessionPair = {
+  roomName?: string | null;
+  canvasId?: string | null;
+};
+
+export function validateSessionPair(contract: SyncContract, session: SessionPair): string[] {
+  const errors: string[] = [];
+  const sessionRoom = String(session.roomName || '').trim();
+  const sessionCanvasId = isUuid(session.canvasId) ? session.canvasId : null;
+
+  if (sessionRoom && sessionRoom !== contract.livekitRoomName) {
+    errors.push('Session room does not match current LiveKit room');
+  }
+  if (contract.canvasId && sessionCanvasId && contract.canvasId !== sessionCanvasId) {
+    errors.push('Session canvas id does not match URL/room contract');
+  }
+
+  return errors;
+}
+

--- a/src/lib/tools/conductor/components/registry.tsx
+++ b/src/lib/tools/conductor/components/registry.tsx
@@ -59,18 +59,33 @@ const infographicWidgetSchema = z.object({
 function LivekitParticipantTileWrapper(props: any) {
   // In CustomShapeComponent, props.state contains the component state.
   // We fallback to top-level props if state is missing (for backward compat or direct usage).
+  const slotId =
+    props.state?.slotId ??
+    props.slotId ??
+    props.__custom_message_id ??
+    props.componentId;
   const participantIdentity = props.state?.participantIdentity ?? props.participantIdentity;
+  const assignmentStatus =
+    props.state?.assignmentStatus ??
+    props.assignmentStatus ??
+    (participantIdentity ? 'assigned' : 'unassigned');
 
   const handleIdentityChange = (id: string) => {
     // updateState is injected by CustomShapeComponent
     if (props.updateState) {
-      props.updateState({ participantIdentity: id });
+      props.updateState({
+        slotId,
+        participantIdentity: id,
+        assignmentStatus: id ? 'assigned' : 'unassigned',
+      });
     }
   };
 
   return (
     <LivekitParticipantTile
       {...props}
+      slotId={slotId}
+      assignmentStatus={assignmentStatus}
       participantIdentity={participantIdentity}
       onIdentityChange={handleIdentityChange}
     />

--- a/tests/realtime-sync-multiuser.spec.ts
+++ b/tests/realtime-sync-multiuser.spec.ts
@@ -1,0 +1,221 @@
+import { expect, test, type BrowserContext, type Page } from '@playwright/test';
+
+async function waitForCanvasReady(page: Page) {
+  await page.waitForSelector('[data-canvas-space="true"]', { timeout: 90_000 });
+  await page.waitForFunction(() => {
+    return Boolean((window as any).__present?.tldrawEditor);
+  }, null, { timeout: 90_000 });
+}
+
+async function waitForRealtimeHealthy(page: Page) {
+  await page.waitForFunction(() => {
+    const present = (window as any).__present ?? {};
+    const diag = present.syncDiagnostics ?? {};
+    return (
+      present.livekitConnected === true &&
+      diag.contract?.ok === true &&
+      diag.tldraw?.ok === true &&
+      diag.session?.ok === true
+    );
+  }, null, { timeout: 90_000 });
+}
+
+async function openSharedCanvas(
+  browser: any,
+): Promise<{ ctxA: BrowserContext; ctxB: BrowserContext; pageA: Page; pageB: Page; canvasId: string }> {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  await ctxA.addInitScript(() => {
+    window.localStorage.setItem('present:display_name', 'Alice');
+  });
+  await ctxB.addInitScript(() => {
+    window.localStorage.setItem('present:display_name', 'Bob');
+  });
+
+  const pageA = await ctxA.newPage();
+  const pageB = await ctxB.newPage();
+
+  await pageA.goto('/canvas', { waitUntil: 'domcontentloaded' });
+  await waitForCanvasReady(pageA);
+
+  const canvasId = await pageA.evaluate(() => {
+    const id = new URL(window.location.href).searchParams.get('id');
+    if (!id) {
+      throw new Error('Missing canvas id in URL');
+    }
+    return id;
+  });
+
+  await pageB.goto(`/canvas?id=${encodeURIComponent(canvasId)}`, {
+    waitUntil: 'domcontentloaded',
+  });
+  await waitForCanvasReady(pageB);
+
+  await waitForRealtimeHealthy(pageA);
+  await waitForRealtimeHealthy(pageB);
+
+  return { ctxA, ctxB, pageA, pageB, canvasId };
+}
+
+test.describe('Realtime Sync Multiuser', () => {
+  test.skip(
+    !process.env.REALTIME_SYNC_E2E,
+    'REALTIME_SYNC_E2E=1 required (live stack + dual-user environment).',
+  );
+
+  test('shared URL converges on canonical contract/session/executor view', async ({ browser }) => {
+    const { ctxA, ctxB, pageA, pageB, canvasId } = await openSharedCanvas(browser);
+    try {
+      const snapshotA = await pageA.evaluate(() => (window as any).__present);
+      const snapshotB = await pageB.evaluate(() => (window as any).__present);
+
+      expect(snapshotA?.syncContract?.canvasId).toBe(canvasId);
+      expect(snapshotB?.syncContract?.canvasId).toBe(canvasId);
+      expect(snapshotA?.syncContract?.livekitRoomName).toBe(snapshotB?.syncContract?.livekitRoomName);
+      expect(snapshotA?.syncContract?.tldrawRoomId).toBe(snapshotB?.syncContract?.tldrawRoomId);
+      expect(snapshotA?.sessionSync?.sessionId).toBe(snapshotB?.sessionSync?.sessionId);
+      expect(snapshotA?.syncDiagnostics?.contract?.ok).toBe(true);
+      expect(snapshotA?.syncDiagnostics?.session?.ok).toBe(true);
+      expect(snapshotA?.syncDiagnostics?.tldraw?.ok).toBe(true);
+      expect(snapshotB?.syncDiagnostics?.contract?.ok).toBe(true);
+      expect(snapshotB?.syncDiagnostics?.session?.ok).toBe(true);
+      expect(snapshotB?.syncDiagnostics?.tldraw?.ok).toBe(true);
+
+      await expect
+        .poll(
+          async () =>
+            pageA.evaluate(() => ({
+              executorIdentity: (window as any).__present?.executor?.executorIdentity ?? null,
+              leaseExpiresAt: (window as any).__present?.executor?.leaseExpiresAt ?? null,
+            })),
+          { timeout: 30_000 },
+        )
+        .toMatchObject({
+          executorIdentity: expect.any(String),
+          leaseExpiresAt: expect.any(String),
+        });
+    } finally {
+      await ctxA.close();
+      await ctxB.close();
+    }
+  });
+
+  test('executor lease fails over after executor tab closes', async ({ browser }) => {
+    const { ctxA, ctxB, pageA, pageB } = await openSharedCanvas(browser);
+    try {
+      const stateA = await pageA.evaluate(() => ({
+        localIdentity:
+          (window as any).__present?.livekitLocalIdentity ??
+          (window as any).__present?.executor?.executorIdentity,
+        isExecutor: Boolean((window as any).__present?.executor?.isExecutor),
+      }));
+      const stateB = await pageB.evaluate(() => ({
+        localIdentity:
+          (window as any).__present?.livekitLocalIdentity ??
+          (window as any).__present?.executor?.executorIdentity,
+        isExecutor: Boolean((window as any).__present?.executor?.isExecutor),
+      }));
+
+      const executorIsA = stateA.isExecutor || !stateB.isExecutor;
+      if (executorIsA) {
+        await ctxA.close();
+        await expect
+          .poll(
+            async () =>
+              pageB.evaluate(() => ({
+                isExecutor: Boolean((window as any).__present?.executor?.isExecutor),
+                executorIdentity: (window as any).__present?.executor?.executorIdentity ?? null,
+              })),
+            { timeout: 45_000 },
+          )
+          .toMatchObject({
+            isExecutor: true,
+            executorIdentity: expect.any(String),
+          });
+      } else {
+        await ctxB.close();
+        await expect
+          .poll(
+            async () =>
+              pageA.evaluate(() => ({
+                isExecutor: Boolean((window as any).__present?.executor?.isExecutor),
+                executorIdentity: (window as any).__present?.executor?.executorIdentity ?? null,
+              })),
+            { timeout: 45_000 },
+          )
+          .toMatchObject({
+            isExecutor: true,
+            executorIdentity: expect.any(String),
+          });
+      }
+    } finally {
+      await ctxA.close().catch(() => {});
+      await ctxB.close().catch(() => {});
+    }
+  });
+
+  test('widget state patch from user A rehydrates on user B', async ({ browser }) => {
+    const { ctxA, ctxB, pageA, pageB } = await openSharedCanvas(browser);
+    try {
+      const messageId = `e2e-crowd-pulse-${Date.now()}`;
+      const created = await pageA.evaluate(async (id) => {
+        const exec = (window as any).__presentToolDispatcherExecute;
+        if (typeof exec !== 'function') return false;
+        await exec({
+          id: `call-${id}`,
+          type: 'tool_call',
+          payload: {
+            tool: 'create_component',
+            params: {
+              componentType: 'CrowdPulseWidget',
+              componentProps: {
+                __custom_message_id: id,
+                title: 'Sync Probe',
+                handCount: 0,
+                peakCount: 0,
+                version: 1,
+                lastUpdated: Date.now(),
+              },
+            },
+          },
+          timestamp: Date.now(),
+          source: 'playwright',
+        });
+        return true;
+      }, messageId);
+
+      expect(created).toBe(true);
+
+      await expect
+        .poll(
+          async () =>
+            pageB.evaluate((id) => {
+              const editor = (window as any).__present?.tldrawEditor;
+              if (!editor?.store?.allRecords) return false;
+              const records = editor.store.allRecords();
+              return records.some((record: any) => {
+                if (record?.typeName !== 'shape') return false;
+                const props = record?.props ?? {};
+                return (
+                  (props.componentType === 'CrowdPulseWidget' || props.type === 'CrowdPulseWidget') &&
+                  (props.__custom_message_id === id || props.title === 'Sync Probe')
+                );
+              });
+            }, messageId),
+          { timeout: 30_000 },
+        )
+        .toBe(true);
+    } finally {
+      await ctxA.close();
+      await ctxB.close();
+    }
+  });
+
+  test('single tool_call creates one component (no duplicates)', async () => {
+    test.skip(true, 'Requires deterministic tool_call publish harness from LiveKit room participant API.');
+  });
+
+  test('transcript remains shared and non-duplicated across participants', async () => {
+    test.skip(true, 'Requires deterministic dual-mic or transcript fixture orchestration.');
+  });
+});


### PR DESCRIPTION
## Summary
This PR hardens realtime convergence across LiveKit room membership, TLDraw sync, component state hydration, and browser-side tool execution so two users in the same canvas room consistently see the same state and avoid duplicate tool execution.

Primary outcomes:
- Introduces a canonical sync contract (`canvasId`, `livekitRoomName`, `tldrawRoomId`, `sessionKey`) and diagnostics.
- Makes participant tile occupancy explicitly shared state (`slotId`, `participantIdentity`, `assignmentStatus`) rather than local heuristics.
- Adds a durable room-scoped executor lease for `tool_call` execution (claim/heartbeat/release).
- Enforces deterministic version-first merge semantics and stale patch rejection.
- Adds multi-layer tests and multi-user E2E scaffolding.

## User Impact / Problem
Before this change, users in the same room could diverge on:
- which participant tile showed whom,
- who executed agent `tool_call`s,
- whether widget state/transcripts converged consistently.

This caused duplicate/competing execution and inconsistent canvas hydration between participants.

## Root Cause Analysis
1. **No canonical room/canvas contract** across page/session/tldraw/livekit layers.
2. **Participant tile binding was local-first** (participant list order / local fallback), not shared authoritative state.
3. **Every client could execute `tool_call`**, causing duplicate execution races.
4. **Ingress patch normalization promoted stale updates** by force-incrementing versions.
5. **TLDraw merge dispatch occurred before acceptance checks**, allowing visual regressions from stale patches.

## Why This Fix Solves Root Cause
- Unifies room/canvas identity derivation and validates invariants at runtime.
- Moves tile occupancy decisions into shared component state with stable slot identity.
- Enforces at-most-one active executor via DB-backed lease and client gating.
- Makes registry acceptance authoritative for state application, with version-first ordering and stale rejection.
- Adds visible diagnostics and probe/ack mechanisms so contract failures are detectable rather than silent.

## What Changed
### 1) Canonical Sync Contract + Diagnostics
- Added `src/lib/realtime/sync-contract.ts`.
- Integrated into `src/app/canvas/CanvasPageClient.tsx`, `src/components/ui/tldraw/hooks/useTLDrawSync.ts`, `src/hooks/use-session-sync.ts`.
- Published diagnostics and visible panel `src/components/ui/diagnostics/realtime-sync-health.tsx`.

### 2) Participant Tile Shared Binding
- Updated `src/components/ui/livekit/participant/livekit-participant-tile.tsx` schema/behavior for explicit slot assignment.
- Updated conductor component wrapper `src/lib/tools/conductor/components/registry.tsx` to pass stable `slotId` and shared updates.

### 3) Durable Executor Lease for `tool_call`
- Added API routes:
  - `src/app/api/session/executor/claim/route.ts`
  - `src/app/api/session/executor/heartbeat/route.ts`
  - `src/app/api/session/executor/release/route.ts`
  - `src/app/api/session/executor/shared.ts`
- Added hook `src/hooks/use-room-executor.ts` and integrated in `src/components/tool-dispatcher/hooks/useToolRunner.ts`.
- Added dedupe guard `src/components/tool-dispatcher/hooks/tool-call-execution-guard.ts`.

### 4) Deterministic Convergence
- Updated `src/lib/component-registry.ts` to version-first acceptance with deterministic stale rejection.
- Updated ingress handling in:
  - `src/components/tool-dispatcher/hooks/useToolRegistry.ts`
  - `src/components/tool-dispatcher/hooks/useToolEvents.ts`
- Ensured widget patches include explicit version/timestamp (`crowd-pulse` and `debate-scorecard`).

### 5) Migration
- Added `docs/migrations/005_canvas_session_executor_lease.sql` for:
  - `tool_executor_identity`
  - `tool_executor_lease_expires_at`

## Backward Compatibility (Backend/API)
Verdict: **Compatible with current unreleased product assumptions; additive schema/API changes only.**

Details:
- `canvas_sessions` migration adds nullable columns (no destructive schema rewrite).
- New `/api/session/executor/*` endpoints are additive and scoped to new lease behavior.
- Existing flows continue unless client opts into executor gating (included in this PR).
- No data migration rewrites legacy rows; null lease fields are treated as unclaimed.

Operational requirement:
- Apply migration `docs/migrations/005_canvas_session_executor_lease.sql` before enabling lease-backed execution in shared environments.

## Validation Performed
### Automated
- `npm run lint` ✅
- `npm run build` ✅
- Targeted Jest suite ✅
  - `src/lib/component-registry.test.ts`
  - `src/hooks/use-room-executor.test.tsx`
  - `src/components/ui/livekit/participant/livekit-participant-tile.test.tsx`
  - `src/components/tool-dispatcher/hooks/useToolRunner.test.tsx`

### E2E
- Added `tests/realtime-sync-multiuser.spec.ts` scenario matrix.
- Scenarios requiring live dual-user orchestration remain env-gated (`REALTIME_SYNC_E2E=1`) with two intentionally skipped cases pending deterministic harnesses.

## Reviewer Passes (Critical)
Two independent critical reviewer passes were run.

Resolved findings included:
- Heartbeat lease-loss false-positive success.
- Stale patch version promotion and pre-acceptance merge ordering.
- Session-switch lease release gap.
- Early tool-call drop window during executor warm-up.
- `updatePropsOnly` starvation after versioned updates.

Final pass result:
- No blocking findings.
- Residual risk: full CI does not run live multi-user E2E by default; env-gated test remains required for live-room validation.

## UI Evidence
- Local artifact captured after implementation:
  - `/Users/bsteinher/.codex/worktrees/4c1a/PRESENT/docs/scrapbooks/assets/realtime-sync/after-canvas.png`
- Note: additional capture automation was intentionally limited after host instability from parallel browser/devtools process fan-out.

## Risks / Follow-ups
1. Apply DB migration before shared-environment rollout.
2. Add deterministic harness for currently skipped multi-user tool-call/transcript E2E cases.
3. Consider CI lane for `REALTIME_SYNC_E2E=1` in controlled environment.
