### PR TITLE
[codex] harden fairy and canvas startup configuration (rebased r2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,17 +6,17 @@ WORKDIR /app
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 
-# Install dependencies
+# Install dependencies (including build-time deps for Next.js)
 COPY package.json package-lock.json ./
 # `npm ci` is strict about lockfile peer resolution and can fail depending on npm version.
 # For Railway we prefer a tolerant install that matches Vercel's build behavior.
-RUN npm install --omit=dev
+RUN npm install
 
 # Copy source code
 COPY . .
 
-# Build (if necessary, though agents are tsx)
-# RUN npm run build 
+# Build Next.js artifacts so web deployments always serve the current image commit.
+RUN npm run build
 
 # Railway uses SERVICE_TYPE to select the entrypoint in scripts/start-service.sh
 CMD ["sh", "scripts/start-service.sh"]

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -14,6 +14,8 @@ module.exports = {
   moduleNameMapper: {
     '^@/components/TO BE REFACTORED/tool-dispatcher$': '<rootDir>/tests/__mocks__/virtual-tool-dispatcher.ts',
     '^@tldraw/tldraw$': '<rootDir>/tests/__mocks__/tldraw-stub.ts',
+    '^@tldraw/fairy-shared$': '<rootDir>/src/vendor/tldraw-fairy/fairy-shared/index.ts',
+    '^@tldraw/fairy-shared/(.*)$': '<rootDir>/src/vendor/tldraw-fairy/fairy-shared/$1',
     '^@custom-ai/react$': '<rootDir>/tests/__mocks__/custom-ai-react.ts',
     '^react-markdown$': '<rootDir>/tests/__mocks__/react-markdown.tsx',
     '^nanoid$': '<rootDir>/tests/__mocks__/nanoid-stub.ts',

--- a/src/app/api/agent/stream/route.ts
+++ b/src/app/api/agent/stream/route.ts
@@ -7,7 +7,6 @@ import { getCanvasAgentService } from '@/lib/agents/subagents/canvas-agent-servi
 import { resolveCanvasModelName } from '@/lib/agents/subagents/canvas-models'
 
 const isDevEnv = process.env.NODE_ENV !== 'production'
-const service = getCanvasAgentService()
 const CANVAS_STEWARD_DEBUG = process.env.CANVAS_STEWARD_DEBUG === 'true'
 const debugLog = (...args: unknown[]) => {
 	if (CANVAS_STEWARD_DEBUG) {
@@ -39,6 +38,13 @@ export async function POST(req: NextRequest) {
 
 	if (!Array.isArray(messages) || messages.length === 0) {
 		return jsonError('messages must be a non-empty array', 400)
+	}
+
+	let service
+	try {
+		service = getCanvasAgentService()
+	} catch (error: any) {
+		return jsonError(error?.message ?? 'Canvas agent service is not configured', 503)
 	}
 
 	const requestedDefinition = getAgentModelDefinition(modelName)

--- a/src/app/api/fairy/stream-actions/route.ts
+++ b/src/app/api/fairy/stream-actions/route.ts
@@ -1,5 +1,9 @@
 import { AgentService } from '@/lib/fairy-worker/agent-service';
-import type { FairyWorkerEnv, FairyUserStub } from '@/lib/fairy-worker/environment';
+import {
+  type FairyWorkerEnv,
+  type FairyUserStub,
+  getFairyConfigurationError,
+} from '@/lib/fairy-worker/environment';
 import type { AgentPrompt } from '@/lib/fairy-worker/types';
 import { NextRequest } from 'next/server';
 import { getRequestUserId } from '@/lib/supabase/server/request-user';
@@ -27,6 +31,14 @@ export async function POST(request: NextRequest) {
     FAIRY_MODEL: process.env.FAIRY_MODEL,
     IS_LOCAL: process.env.NODE_ENV === 'production' ? 'false' : 'true',
   };
+
+  const configError = getFairyConfigurationError(env);
+  if (configError) {
+    return new Response(JSON.stringify({ error: configError }), {
+      status: 503,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
 
   const service = new AgentService(env);
   const encoder = new TextEncoder();

--- a/src/app/api/steward/runCanvas/route.ts
+++ b/src/app/api/steward/runCanvas/route.ts
@@ -12,12 +12,13 @@ import {
   stewardRunCanvasRequestSchema,
 } from '@/lib/agents/shared/schemas';
 import type { JsonObject } from '@/lib/utils/json-schema';
+import { getBooleanFlag, isFairyClientAgentEnabled } from '@/lib/feature-flags';
 
 export const runtime = 'nodejs';
 
 const QUEUE_DIRECT_FALLBACK_ENABLED = process.env.CANVAS_QUEUE_DIRECT_FALLBACK === 'true';
-const CLIENT_CANVAS_AGENT_ENABLED = process.env.NEXT_PUBLIC_CANVAS_AGENT_CLIENT_ENABLED === 'true';
-const FAIRY_CLIENT_AGENT_ENABLED = process.env.NEXT_PUBLIC_FAIRY_CLIENT_AGENT_ENABLED === 'true';
+const CLIENT_CANVAS_AGENT_ENABLED = getBooleanFlag(process.env.NEXT_PUBLIC_CANVAS_AGENT_CLIENT_ENABLED, false);
+const FAIRY_CLIENT_AGENT_ENABLED = isFairyClientAgentEnabled(process.env.NEXT_PUBLIC_FAIRY_CLIENT_AGENT_ENABLED);
 const CANVAS_STEWARD_ENABLED = (process.env.CANVAS_STEWARD_SERVER_EXECUTION ?? 'true') === 'true';
 const SERVER_CANVAS_AGENT_ENABLED =
   CANVAS_STEWARD_ENABLED && !CLIENT_CANVAS_AGENT_ENABLED && !FAIRY_CLIENT_AGENT_ENABLED;

--- a/src/components/ui/tldraw/fairy/fairy-livekit-bridge.tsx
+++ b/src/components/ui/tldraw/fairy/fairy-livekit-bridge.tsx
@@ -10,7 +10,7 @@ import { createLiveKitBus } from '@/lib/livekit/livekit-bus';
 import { useFairyApp } from '@/vendor/tldraw-fairy/fairy/fairy-app/FairyAppProvider';
 import type { FairyAgent } from '@/vendor/tldraw-fairy/fairy/fairy-agent/FairyAgent';
 import { useFairyPromptData } from './fairy-prompt-data';
-import { getBooleanFlag } from '@/lib/feature-flags';
+import { isFairyClientAgentEnabled } from '@/lib/feature-flags';
 
 interface FairyLiveKitBridgeProps {
   room?: Room;
@@ -21,7 +21,7 @@ interface AgentHostState {
   hostId: string | null;
 }
 
-const FAIRY_CLIENT_AGENT_ENABLED = getBooleanFlag(process.env.NEXT_PUBLIC_FAIRY_CLIENT_AGENT_ENABLED, true);
+const FAIRY_CLIENT_AGENT_ENABLED = isFairyClientAgentEnabled(process.env.NEXT_PUBLIC_FAIRY_CLIENT_AGENT_ENABLED);
 
 function useIsAgentHost(room?: Room) {
   const [hostState, setHostState] = useState<AgentHostState>({ isHost: false, hostId: null });

--- a/src/lib/agents/subagents/canvas-agent-service.test.ts
+++ b/src/lib/agents/subagents/canvas-agent-service.test.ts
@@ -1,0 +1,25 @@
+import { CanvasAgentService } from './canvas-agent-service';
+
+describe('CanvasAgentService provider validation', () => {
+  it('throws a clear error when no providers are configured', () => {
+    const service = new CanvasAgentService({
+      OPENAI_API_KEY: '',
+      ANTHROPIC_API_KEY: '',
+      GOOGLE_API_KEY: '',
+    });
+    expect(() => service.getModelForStreaming('gpt-5')).toThrow(
+      'No canvas model providers configured.',
+    );
+  });
+
+  it('falls back to an available provider when preferred provider is missing', () => {
+    const service = new CanvasAgentService({
+      OPENAI_API_KEY: 'test-key',
+      ANTHROPIC_API_KEY: '',
+      GOOGLE_API_KEY: '',
+    });
+    const result = service.getModelForStreaming('claude-sonnet-4-5');
+    expect(result.modelDefinition.name).toBe('gpt-5');
+    expect(result.modelDefinition.provider).toBe('openai');
+  });
+});

--- a/src/lib/fairy-worker/environment.test.ts
+++ b/src/lib/fairy-worker/environment.test.ts
@@ -1,0 +1,33 @@
+import {
+  getFairyConfigurationError,
+  getRequiredProviderEnvKey,
+  type FairyWorkerEnv,
+} from './environment';
+
+describe('fairy worker environment validation', () => {
+  it('maps model provider to required key', () => {
+    expect(getRequiredProviderEnvKey('gpt-5.1')).toBe('OPENAI_API_KEY');
+    expect(getRequiredProviderEnvKey('claude-sonnet-4-5')).toBe('ANTHROPIC_API_KEY');
+    expect(getRequiredProviderEnvKey('gemini-3-pro-preview')).toBe('GOOGLE_API_KEY');
+  });
+
+  it('reports missing key for configured FAIRY_MODEL', () => {
+    const env: FairyWorkerEnv = {
+      FAIRY_MODEL: 'gpt-5.1',
+      OPENAI_API_KEY: '',
+      ANTHROPIC_API_KEY: 'set',
+      GOOGLE_API_KEY: 'set',
+    };
+    expect(getFairyConfigurationError(env)).toContain('OPENAI_API_KEY');
+  });
+
+  it('passes when the configured model key is available', () => {
+    const env: FairyWorkerEnv = {
+      FAIRY_MODEL: 'claude-sonnet-4-5',
+      OPENAI_API_KEY: 'set',
+      ANTHROPIC_API_KEY: 'set',
+      GOOGLE_API_KEY: '',
+    };
+    expect(getFairyConfigurationError(env)).toBeNull();
+  });
+});

--- a/src/lib/fairy-worker/environment.ts
+++ b/src/lib/fairy-worker/environment.ts
@@ -1,3 +1,6 @@
+import { getDefaultModelName, type AgentModelName } from '@tldraw/fairy-shared/models';
+import { getAgentModelDefinition } from './models';
+
 export interface FairyUserStub {
   fetch: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
 }
@@ -8,4 +11,30 @@ export interface FairyWorkerEnv {
   GOOGLE_API_KEY?: string;
   FAIRY_MODEL?: string;
   IS_LOCAL?: string;
+}
+
+type FairyProvider = 'openai' | 'anthropic' | 'google';
+
+const PROVIDER_ENV_KEYS: Record<FairyProvider, keyof FairyWorkerEnv> = {
+  openai: 'OPENAI_API_KEY',
+  anthropic: 'ANTHROPIC_API_KEY',
+  google: 'GOOGLE_API_KEY',
+};
+
+export function getRequiredProviderEnvKey(modelName: AgentModelName): keyof FairyWorkerEnv {
+  const provider = getAgentModelDefinition(modelName).provider as FairyProvider;
+  return PROVIDER_ENV_KEYS[provider];
+}
+
+export function getFairyConfigurationError(
+  env: FairyWorkerEnv,
+  modelName?: AgentModelName,
+): string | null {
+  const resolvedModel = modelName ?? getDefaultModelName({ FAIRY_MODEL: env.FAIRY_MODEL });
+  const requiredKey = getRequiredProviderEnvKey(resolvedModel);
+  const value = env[requiredKey];
+  if (typeof value === 'string' && value.trim().length > 0) {
+    return null;
+  }
+  return `Fairy model "${resolvedModel}" requires ${requiredKey} to be configured.`;
 }

--- a/src/lib/feature-flags.test.ts
+++ b/src/lib/feature-flags.test.ts
@@ -1,0 +1,17 @@
+import { getBooleanFlag, isFairyClientAgentEnabled } from './feature-flags';
+
+describe('feature flags', () => {
+  it('parses quoted booleans', () => {
+    expect(getBooleanFlag('"true"', false)).toBe(true);
+    expect(getBooleanFlag('"false"', true)).toBe(false);
+  });
+
+  it('defaults fairy client agent flag to false when unset', () => {
+    expect(isFairyClientAgentEnabled(undefined)).toBe(false);
+  });
+
+  it('respects explicit fairy client agent flag values', () => {
+    expect(isFairyClientAgentEnabled('true')).toBe(true);
+    expect(isFairyClientAgentEnabled('false')).toBe(false);
+  });
+});

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -8,6 +8,10 @@ export function getBooleanFlag(envVar: string | undefined, defaultValue: boolean
   return defaultValue;
 }
 
+export function isFairyClientAgentEnabled(envVar: string | undefined): boolean {
+  return getBooleanFlag(envVar, false);
+}
+
 export const flags = {
   localToolRoutingEnabled: getBooleanFlag(process.env.NEXT_PUBLIC_LOCAL_TOOL_ROUTING_ENABLED, true),
   mcpEarlyInitEnabled: getBooleanFlag(process.env.NEXT_PUBLIC_MCP_EARLY_INIT_ENABLED, true),

--- a/tests/jest.setup.ts
+++ b/tests/jest.setup.ts
@@ -1,6 +1,10 @@
 import { TextEncoder, TextDecoder } from 'util';
+import { ReadableStream, TransformStream, WritableStream } from 'stream/web';
 (global as any).TextEncoder = TextEncoder;
 (global as any).TextDecoder = TextDecoder as any;
+(global as any).ReadableStream = (global as any).ReadableStream || ReadableStream;
+(global as any).TransformStream = (global as any).TransformStream || TransformStream;
+(global as any).WritableStream = (global as any).WritableStream || WritableStream;
 
 if (typeof window !== 'undefined') {
   if (!window.requestAnimationFrame) {
@@ -15,4 +19,3 @@ if (typeof window !== 'undefined') {
 
 process.env.NEXT_PUBLIC_SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL || 'http://localhost/supabase';
 process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'test-key';
-


### PR DESCRIPTION
## Summary
Supersedes #73 with the same startup/config hardening rebased on latest `main`.

This PR hardens runtime configuration validation for Fairy and Canvas agent execution paths so provider/key misconfiguration fails fast at startup/entry instead of failing mid-stream during user requests.

## Issue and user impact
When `FAIRY_MODEL` (or canvas model selection) required a provider key that was unset, failures surfaced late during request execution/streaming. This degraded reliability, made incidents harder to triage, and could drop/stall canvas/fairy flows under some default-flag combinations.

## Root cause
1. Fairy worker constructed provider clients directly from environment and deferred provider availability failures to runtime model resolution.
2. `NEXT_PUBLIC_FAIRY_CLIENT_AGENT_ENABLED` default handling diverged across runtime boundaries.
3. Canvas provider availability checks happened only when executing request paths.
4. Service startup routing behavior was brittle for deployments without explicit `SERVICE_TYPE`.
5. Docker web runtime did not guarantee current Next build artifacts in image.

## Why this solves the root cause
- Adds explicit provider/key validation primitives and uses them before streaming starts.
- Unifies fairy client-flag parsing with a shared helper defaulting to `false`.
- Asserts canvas model/provider configuration on service access and returns explicit 503s for config errors.
- Hardens service startup entrypoint modes and defaults unset deployments to web while still failing fast on invalid explicit values.
- Builds Next artifacts in Docker image build stage to avoid stale runtime artifacts.

## What changed by subsystem
### Fairy worker / API
- Added provider-key resolution and fail-fast validation in `src/lib/fairy-worker/environment.ts`.
- Updated fairy `AgentService` to validate on construction and guard provider lookup with explicit key-required errors.
- Added preflight config check in `/api/fairy/stream-actions` route to return `503` on misconfiguration.

### Canvas/conductor flag and config behavior
- Added `isFairyClientAgentEnabled()` in `src/lib/feature-flags.ts` (default `false`).
- Updated conductor, runCanvas route, and fairy livekit bridge to use consistent parsing.
- Added explicit provider checks and clearer fallback errors in `canvas-agent-service`.
- Updated `/api/agent/stream` to lazily initialize canvas service and return `503` for config failures.

### Deployment/runtime entrypoints
- Updated `scripts/start-service.sh` to support `web|present|app` and route correctly by `SERVICE_TYPE`.
- Preserved fast failure for invalid explicit `SERVICE_TYPE` values.
- Defaulted missing `SERVICE_TYPE` to `web` to avoid startup regressions in environments that do not inject it.
- Updated `Dockerfile` to build Next artifacts during image build.

### Tests / harness
- Added focused tests:
  - `src/lib/feature-flags.test.ts`
  - `src/lib/fairy-worker/environment.test.ts`
  - `src/lib/agents/subagents/canvas-agent-service.test.ts`
- Updated Jest config/setup for vendor alias resolution and Web Streams globals.

## Backward compatibility (backend/API/schema)
- No API contract changes.
- No DB/schema/migration changes.
- Error behavior for misconfiguration is now earlier and explicit (`503`/startup failure where appropriate), which is an operational improvement and backward-compatible for correctly configured environments.

## Validation performed
- `npm run lint`
- `npm test`
- `npm run build`

All commands passed on rebased head.

## Supersedence
- supersedes #73
