### PR TITLE
fix: prevent DO duration burn from anonymous singleton stream routing

### DIFF
--- a/vendor/tldraw-agent-template/worker/do/AgentDurableObject.ts
+++ b/vendor/tldraw-agent-template/worker/do/AgentDurableObject.ts
@@ -6,6 +6,19 @@ import { Streaming } from '../../shared/types/Streaming'
 import { Environment } from '../environment'
 import { AgentService } from './AgentService'
 
+const DEFAULT_IDLE_TIMEOUT_MS = 30_000
+const DEFAULT_MAX_DURATION_MS = 180_000
+const MIN_IDLE_TIMEOUT_MS = 5_000
+const MIN_MAX_DURATION_MS = 30_000
+const MAX_TIMEOUT_MS = 900_000
+
+type StreamCloseReason =
+	| 'complete'
+	| 'client_disconnected'
+	| 'idle_timeout'
+	| 'max_duration'
+	| 'error'
+
 export class AgentDurableObject extends DurableObject<Environment> {
 	service: AgentService
 
@@ -36,31 +49,94 @@ export class AgentDurableObject extends DurableObject<Environment> {
 		const encoder = new TextEncoder()
 		const { readable, writable } = new TransformStream()
 		const writer = writable.getWriter()
+		const startedAt = Date.now()
+		const idleTimeoutMs = parseTimeoutMs(
+			this.env.AGENT_STREAM_IDLE_TIMEOUT_MS,
+			DEFAULT_IDLE_TIMEOUT_MS,
+			MIN_IDLE_TIMEOUT_MS
+		)
+		const maxDurationMs = parseTimeoutMs(
+			this.env.AGENT_STREAM_MAX_DURATION_MS,
+			DEFAULT_MAX_DURATION_MS,
+			MIN_MAX_DURATION_MS
+		)
 
 		const response: { changes: Streaming<AgentAction>[] } = { changes: [] }
+		let closeReason: StreamCloseReason = 'complete'
+		let stopRequested = false
+		let streamClosed = false
+		const abortController = new AbortController()
+		let idleTimer: ReturnType<typeof setTimeout> | null = null
+		const maxTimer = setTimeout(() => stop('max_duration'), maxDurationMs)
+
+		const closeStream = async () => {
+			if (streamClosed) return
+			streamClosed = true
+			try {
+				await writer.close()
+			} catch (closeError) {
+				try {
+					await writer.abort(closeError)
+				} catch {}
+			}
+		}
+
+		const stop = (reason: StreamCloseReason) => {
+			if (stopRequested) return
+			stopRequested = true
+			closeReason = reason
+			abortController.abort(reason)
+		}
+
+		const resetIdleTimer = () => {
+			if (idleTimer) clearTimeout(idleTimer)
+			idleTimer = setTimeout(() => stop('idle_timeout'), idleTimeoutMs)
+		}
+
+		const onClientAbort = () => stop('client_disconnected')
+		request.signal.addEventListener('abort', onClientAbort, { once: true })
+		resetIdleTimer()
 
 		;(async () => {
 			try {
 				const prompt = (await request.json()) as AgentPrompt
 
-				for await (const change of this.service.stream(prompt)) {
+				for await (const change of this.service.stream(prompt, abortController.signal)) {
+					if (stopRequested) break
+					resetIdleTimer()
 					response.changes.push(change)
 					const data = `data: ${JSON.stringify(change)}\n\n`
 					await writer.write(encoder.encode(data))
 					await writer.ready
 				}
-				await writer.close()
+				await closeStream()
 			} catch (error: any) {
+				if (stopRequested) {
+					await closeStream()
+					return
+				}
+
+				closeReason = 'error'
 				console.error('Stream error:', error)
 
 				// Send error through the stream
 				const errorData = `data: ${JSON.stringify({ error: error.message })}\n\n`
 				try {
 					await writer.write(encoder.encode(errorData))
-					await writer.close()
+					await closeStream()
 				} catch (writeError) {
 					await writer.abort(writeError)
 				}
+			} finally {
+				if (idleTimer) clearTimeout(idleTimer)
+				clearTimeout(maxTimer)
+				request.signal.removeEventListener('abort', onClientAbort)
+				console.info('[AgentDurableObject] stream closed', {
+					reason: closeReason,
+					durationMs: Date.now() - startedAt,
+					idleTimeoutMs,
+					maxDurationMs,
+				})
 			}
 		})()
 
@@ -77,4 +153,11 @@ export class AgentDurableObject extends DurableObject<Environment> {
 			},
 		})
 	}
+}
+
+function parseTimeoutMs(rawValue: string | undefined, fallback: number, min: number) {
+	if (!rawValue) return fallback
+	const parsed = Number.parseInt(rawValue, 10)
+	if (!Number.isFinite(parsed)) return fallback
+	return Math.max(min, Math.min(MAX_TIMEOUT_MS, parsed))
 }

--- a/vendor/tldraw-agent-template/worker/environment.ts
+++ b/vendor/tldraw-agent-template/worker/environment.ts
@@ -3,4 +3,6 @@ export interface Environment {
 	OPENAI_API_KEY: string
 	ANTHROPIC_API_KEY: string
 	GOOGLE_API_KEY: string
+	AGENT_STREAM_IDLE_TIMEOUT_MS?: string
+	AGENT_STREAM_MAX_DURATION_MS?: string
 }


### PR DESCRIPTION
## Summary
- replace singleton Durable Object routing (`idFromName('anonymous')`) with a scoped key derived from request session identity (`X-Tldraw-Agent-Id` / query fallback)
- send a stable per-agent-session id from the client stream caller so separate browser sessions do not collapse onto one DO instance
- add server-side stream lifetime guards in the Durable Object path:
  - idle timeout abort
  - max-duration abort
  - client-disconnect abort
- plumb optional env knobs for timeout tuning:
  - `AGENT_STREAM_IDLE_TIMEOUT_MS`
  - `AGENT_STREAM_MAX_DURATION_MS`
- pass `AbortSignal` through `AgentService` to `streamText` so DO timeout/disconnect actually terminates model streaming

## Why
Cloudflare DO duration overrun was duration-heavy (not request-volume-heavy), with concentrated object IDs and long-lived stream behavior. This patch removes the shared anonymous singleton routing pattern and bounds stream lifetimes.

## Files
- `vendor/tldraw-agent-template/client/agent/TldrawAgent.ts`
- `vendor/tldraw-agent-template/worker/routes/stream.ts`
- `vendor/tldraw-agent-template/worker/do/AgentDurableObject.ts`
- `vendor/tldraw-agent-template/worker/do/AgentService.ts`
- `vendor/tldraw-agent-template/worker/environment.ts`

## Validation
- Ran `npm exec -- tsc --noEmit`.
- Result: fails with many pre-existing repo-wide TypeScript issues unrelated to this patch; no focused clean-slate project check is currently available in this worktree.

## Notes
- This PR is intentionally conservative and low-blast-radius.
- No merge performed.
