### PR TITLE
[codex] stabilize realtime e2e harness and token header policy

### DIFF
--- a/src/components/ui/livekit/hooks/utils/lk-token.test.ts
+++ b/src/components/ui/livekit/hooks/utils/lk-token.test.ts
@@ -1,0 +1,102 @@
+const getSupabaseAccessTokenMock = jest.fn();
+const resolveEdgeIngressUrlMock = jest.fn();
+
+jest.mock('@/lib/supabase/auth-headers', () => ({
+  getSupabaseAccessToken: (...args: any[]) => getSupabaseAccessTokenMock(...args),
+}));
+
+jest.mock('@/lib/edge-ingress', () => ({
+  resolveEdgeIngressUrl: (...args: any[]) => resolveEdgeIngressUrlMock(...args),
+}));
+
+import { buildLivekitTokenHeaders, fetchLivekitAccessToken } from './lk-token';
+
+describe('lk-token helpers', () => {
+  const originalFetch = global.fetch;
+  const originalCrypto = globalThis.crypto;
+  const fetchMock = jest.fn();
+  const digestMock = jest.fn(async () => new Uint8Array(32).buffer);
+
+  beforeEach(() => {
+    getSupabaseAccessTokenMock.mockReset();
+    resolveEdgeIngressUrlMock.mockReset().mockReturnValue('/api/token');
+    fetchMock.mockReset();
+    digestMock.mockClear();
+    (global as any).fetch = fetchMock;
+    Object.defineProperty(globalThis, 'crypto', {
+      configurable: true,
+      value: {
+        randomUUID: () => 'nonce-uuid',
+        subtle: {
+          digest: digestMock,
+        },
+      },
+    });
+  });
+
+  afterAll(() => {
+    (global as any).fetch = originalFetch;
+    Object.defineProperty(globalThis, 'crypto', {
+      configurable: true,
+      value: originalCrypto,
+    });
+  });
+
+  it('returns base headers when Supabase token is missing', async () => {
+    getSupabaseAccessTokenMock.mockResolvedValueOnce(null);
+
+    const headers = await buildLivekitTokenHeaders({
+      roomName: 'canvas-1',
+      identity: 'alice',
+    });
+
+    expect(headers.get('Authorization')).toBeNull();
+    expect(headers.get('x-signature')).toBeNull();
+    expect(headers.get('x-nonce')).toBeNull();
+    expect(headers.get('x-timestamp')).toBeNull();
+  });
+
+  it('adds auth and signature headers when Supabase token is present', async () => {
+    getSupabaseAccessTokenMock.mockResolvedValueOnce('supabase-token');
+
+    const headers = await buildLivekitTokenHeaders({
+      roomName: 'canvas-2',
+      identity: 'bob',
+      pathname: '/api/token',
+    });
+
+    expect(headers.get('Authorization')).toBe('Bearer supabase-token');
+    expect(typeof headers.get('x-signature')).toBe('string');
+    expect(typeof headers.get('x-nonce')).toBe('string');
+    expect(typeof headers.get('x-timestamp')).toBe('string');
+    expect(digestMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('fetches livekit token with computed headers', async () => {
+    getSupabaseAccessTokenMock.mockResolvedValueOnce('supabase-token');
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({ accessToken: 'livekit-token' }),
+    });
+
+    const signal = new AbortController().signal;
+    const token = await fetchLivekitAccessToken({
+      roomName: 'canvas-3',
+      identity: 'charlie',
+      displayName: 'Charlie',
+      metadataParam: '',
+      signal,
+    });
+
+    expect(token).toBe('livekit-token');
+    expect(resolveEdgeIngressUrlMock).toHaveBeenCalledWith('/api/token');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(String(url)).toContain('/api/token');
+    const headers = options.headers as Headers;
+    expect(headers.get('Authorization')).toBe('Bearer supabase-token');
+    expect(headers.get('x-signature')).toBeTruthy();
+  });
+});

--- a/src/components/ui/livekit/hooks/utils/lk-token.ts
+++ b/src/components/ui/livekit/hooks/utils/lk-token.ts
@@ -41,21 +41,10 @@ export async function buildLivekitTokenHeaders(args: {
   init?: HeadersInit;
 }): Promise<Headers> {
   const token = await getSupabaseAccessToken(1_500);
-  const requireAuth =
-    (process.env.NEXT_PUBLIC_TOKEN_REQUIRE_AUTH ??
-      (process.env.NODE_ENV === 'production' ? 'true' : 'false')) === 'true';
-  const requireSignedNonce =
-    (process.env.NEXT_PUBLIC_TOKEN_REQUIRE_SIGNED_NONCE ??
-      (process.env.NODE_ENV === 'production' ? 'true' : 'false')) === 'true';
-
   const headers = new Headers(args.init);
 
-  // In local/dev test lanes, token minting can run with TOKEN_REQUIRE_AUTH=false.
-  // Preserve strict behavior when auth/signed nonce is explicitly required.
+  // Server route is the source of truth for token auth/signature enforcement.
   if (!token) {
-    if (requireAuth || requireSignedNonce) {
-      throw new Error('Missing Supabase auth token for LiveKit token minting');
-    }
     return headers;
   }
 


### PR DESCRIPTION
## Summary
Follow-up to merged #88 to harden deterministic realtime test behavior and align LiveKit token header handling with server-authoritative auth policy.

This PR does two things together:
1. Stabilizes realtime multiuser Playwright setup/dispatch/failover sequencing to reduce flake windows.
2. Removes client-side strict env gating in `lk-token.ts` so `/api/token` remains the sole authority for auth/signature enforcement.

## User Impact
- Realtime E2E suite is now less timing-sensitive around readiness, room-name availability, and executor close/failover selection.
- Client no longer hard-fails token-header preflight when Supabase token is absent; server policy continues to enforce strict requirements.

## Root Cause
- Realtime suite had race windows between page readiness and room metadata availability, plus non-deterministic executor-tab closure selection.
- Token helper had duplicated policy logic on the client via `NEXT_PUBLIC_TOKEN_REQUIRE_*`, which could diverge from server enforcement and produce brittle local/test behavior.

## Why This Fix Solves Root Cause
- The test harness now waits for explicit realtime health signals and canonical room name before proceeding, and retries agent dispatch only when needed.
- Executor failover now closes the tab actually marked executor rather than a heuristic fallback.
- Header-building policy now defers strict enforcement to `/api/token`, eliminating client/server policy drift.

## Changes by Surface
### Realtime E2E harness
- File: `tests/realtime-sync-multiuser.spec.ts`
- Added `waitForRealtimeHealthy(page)` gate used by both pages in `openSharedCanvas()`.
- Added deterministic room-name resolution helper and dispatch retry loop in `ensureVoiceAgentPresent()`.
- Refactored agent-presence checks into `isVoiceAgentPresent()`.
- Updated executor failover test to resolve and close the actual executor tab.

### LiveKit token helper policy
- File: `src/components/ui/livekit/hooks/utils/lk-token.ts`
- Removed reads of `NEXT_PUBLIC_TOKEN_REQUIRE_AUTH` and `NEXT_PUBLIC_TOKEN_REQUIRE_SIGNED_NONCE`.
- Removed client-side throw on missing Supabase token.
- Missing token now returns base headers; server route remains source of truth for enforcement.

### Unit coverage
- File: `src/components/ui/livekit/hooks/utils/lk-token.test.ts`
- Added coverage for:
  - missing-token path (no auth/signature headers, no throw),
  - token-present signed-header path,
  - `fetchLivekitAccessToken` happy path.

## Backend Compatibility
- No endpoint contract changes.
- `/api/token` auth/signature enforcement semantics are unchanged.
- This is compatibility-preserving and policy-convergent (server-authoritative).

## Validation
Commands run on this branch:
- `npm run lint` (passes; existing repo warnings unchanged)
- `npm test -- --runInBand` (pass)
- `npm run build` (pass)
- `REALTIME_SYNC_E2E=1 npx playwright test tests/realtime-sync-multiuser.spec.ts --project=chromium --workers=1 --retries=0` (5/5 pass)

## Independent Review Passes
Two independent reviewer passes were executed in parallel:
- Pass A (correctness/security/perf): one P2 (over-broad identity matching) found and fixed.
- Pass B (maintainability/flakiness): same P2 found and fixed.
- Final rerun of both passes: no actionable findings.

## Merge readiness checklist
- [x] Rebased on latest `main` baseline
- [x] lint/test/build pass
- [x] Required realtime scenario tests pass
- [x] CI checks pending
- [x] Risk notes reviewed
- [x] Rollout/migration notes not applicable (no migration)
