### PR TITLE
[codex] fix canvas toolbox naming and manual turn gating

### DIFF
--- a/src/components/ui/canvas/hooks/useCanvasEvents.ts
+++ b/src/components/ui/canvas/hooks/useCanvasEvents.ts
@@ -97,7 +97,14 @@ export function useCanvasEvents({
             lastPayloadSignatureRef.current.set(messageId, signature);
           }
         }
-        let inferredName: string | undefined = 'Rendered Component';
+        const payloadType =
+          !React.isValidElement(node) &&
+          event.detail.component &&
+          typeof event.detail.component === 'object' &&
+          typeof (event.detail.component as { type?: unknown }).type === 'string'
+            ? (event.detail.component as { type: string }).type
+            : undefined;
+        let inferredName: string | undefined = payloadType || 'Rendered Component';
         if (!editor) {
           if (!React.isValidElement(node)) {
             const maybe = event.detail.component as {

--- a/src/lib/agents/realtime/voice-agent.ts
+++ b/src/lib/agents/realtime/voice-agent.ts
@@ -1698,6 +1698,20 @@ Your only output is function calls. Never use plain text unless absolutely neces
       });
     };
 
+    const listRemoteParticipantIds = (): string[] => {
+      const ids: string[] = [];
+      try {
+        job.room.remoteParticipants.forEach((participant: any) => {
+          const candidate = String(participant?.identity || '').trim();
+          if (!candidate) return;
+          ids.push(candidate);
+        });
+      } catch {
+        /* noop */
+      }
+      return Array.from(new Set(ids));
+    };
+
     const sendScorecardSeedTask = async (payload: {
       componentId: string;
       intentId?: string;
@@ -4962,6 +4976,38 @@ Your only output is function calls. Never use plain text unless absolutely neces
               serverGenerated: true,
             });
             if (!dedupe.drop) {
+              const remoteParticipantIds = listRemoteParticipantIds();
+              const resolvedTurnMode = (() => {
+                const directResolution = resolveVoiceTurnModeForParticipant(voiceTurnModesByParticipant, {
+                  participantId:
+                    remoteParticipantIds.length === 1
+                      ? remoteParticipantIds[0]
+                      : lastRequesterParticipantId,
+                  fallbackParticipantIds: remoteParticipantIds,
+                });
+                if (
+                  directResolution !== 'auto' ||
+                  remoteParticipantIds.length < 2 ||
+                  (lastRequesterParticipantId && lastRequesterParticipantId.trim().length > 0)
+                ) {
+                  return directResolution;
+                }
+                const remoteModes = Array.from(
+                  new Set(remoteParticipantIds.map((id) => voiceTurnModesByParticipant.get(id) ?? 'auto')),
+                );
+                return remoteModes.length === 1 ? remoteModes[0] : 'auto';
+              })();
+              if (shouldSuppressAutomaticTurn(resolvedTurnMode, false)) {
+                console.log('[VoiceAgent] suppressed server transcript automatic turn for manual-mode participant', {
+                  participantId:
+                    allowSensitiveLogging &&
+                    (remoteParticipantIds.length === 1 ? remoteParticipantIds[0] : lastRequesterParticipantId)
+                      ? (remoteParticipantIds.length === 1 ? remoteParticipantIds[0] : lastRequesterParticipantId)
+                      : '[redacted]',
+                  resolvedTurnMode,
+                });
+                return;
+              }
               lastUserPrompt = trimmed;
               try {
                 await generateReplySafely();


### PR DESCRIPTION
## Issue and user impact

Two user-facing regressions remained after the earlier fixes: toolbox-created AI Image Generator widgets could still persist as "Rendered Component" and fail registry rehydration, and manual turn mode could still leak automatic replies through the server-generated transcript path in the voice agent.

## Root cause

The canvas event handler defaulted component naming to "Rendered Component" unless it could recover the wrapped React component identity, even when the authoritative component type was already present in the `custom:showComponent` payload. Separately, the voice agent had a direct `UserInputTranscribed` -> `generateReplySafely()` path that bypassed the participant-scoped manual-turn suppression logic, and its first pass used a synthetic `user` participant ID that did not match the UI-published `voice_control` identity.

## Why this fixes the root cause

The canvas hook now trusts the explicit payload type before any wrapper inference, so toolbox-created components keep their real registry name. The voice agent now applies manual-turn suppression to the server-generated transcript path too, resolving against real remote participant identities and a unanimous-mode fallback when no single participant can be identified yet.

## What changed

- Canvas registration: [useCanvasEvents.ts] now seeds `inferredName` from `event.detail.component.type` before falling back to wrapper inference.
- Voice agent gating: [voice-agent.ts] now blocks the direct server-transcript reply path when manual turn mode is active.
- Multi-participant edge case: manual suppression now falls back to a unanimous remote-participant turn mode when there is no single requester identity yet.

## Backward compatibility

No backend schema or API contract changed. These are runtime/UI correctness fixes that restore intended existing behavior.

## Validation

- Reviewer A (correctness/regression): no final findings after follow-up fixes.
- Reviewer B (maintainability/architecture): no final findings after follow-up fixes.
- npm run typecheck:app: passed.
- npm run typecheck:agent: passed.
- Repo-wide `npm run typecheck` remains blocked by the unrelated reset tsconfig baseline referencing missing `src/app/api/reset/...` files.

## Reviewer pass summary

- Initial review found the server-transcript manual-turn path was resolving against the wrong participant key (`user`).
- Follow-up review found the multi-participant first-utterance edge case when no requester identity was yet known.
- Final review reported no remaining actionable findings.

## Evidence and limitations

- The linked production behavior is still influenced by failed Railway deploys; this PR closes the remaining code-path leaks in the repo, but production verification still depends on successful deploy credentials.
