### PR TITLE
[codex] restore legacy canvas route

### DIFF
--- a/src/app/canvas/page.test.tsx
+++ b/src/app/canvas/page.test.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from 'react';
+import { render, screen } from '@testing-library/react';
+import CanvasPage from './page';
+
+jest.mock('./CanvasPageClient', () => ({
+  __esModule: true,
+  default: () => <div data-testid="canvas-page-client">canvas-page-client</div>,
+}));
+
+jest.mock('@/components/ErrorBoundary', () => ({
+  ErrorBoundary: ({ children }: { children: ReactNode }) => <div data-testid="error-boundary">{children}</div>,
+}));
+
+describe('/canvas route', () => {
+  it('renders the legacy canvas client directly', () => {
+    render(<CanvasPage />);
+
+    expect(screen.getByTestId('error-boundary')).toBeTruthy();
+    expect(screen.getByTestId('canvas-page-client')).toBeTruthy();
+    expect(document.querySelector('.legacy-canvas-shell')).toBeNull();
+    expect(document.querySelector('.legacy-canvas-shell__banner')).toBeNull();
+  });
+});

--- a/src/app/canvas/page.tsx
+++ b/src/app/canvas/page.tsx
@@ -1,42 +1,13 @@
 import CanvasPageClient from './CanvasPageClient';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
-import { LegacyArchiveNotice } from '@/components/ui/reset/legacy-archive-notice';
 
 export const dynamic = 'force-dynamic';
 
-export default async function Canvas({
-  searchParams,
-}: {
-  searchParams: Promise<Record<string, string | string[] | undefined>>;
-}) {
-  const params = await searchParams;
-  const legacyEnabled = params.legacy === '1';
-
-  if (!legacyEnabled) {
-    return (
-      <LegacyArchiveNotice
-        eyebrow="Legacy Canvas"
-        title="The standalone canvas is archived."
-        summary="PRESENT now opens in the reset workspace shell. The old TLDraw and LiveKit runtime is still reachable, but it is no longer the main product entry."
-        detail="Use the reset shell for the primary mission-control flow, or launch the legacy canvas explicitly when you need the old room surface."
-        primaryHref="/"
-        primaryLabel="Open Reset Workspace"
-        secondaryHref="/canvas?legacy=1"
-        secondaryLabel="Launch Legacy Canvas"
-      />
-    );
-  }
-
+export default function Canvas() {
   try {
     return (
       <ErrorBoundary>
-        <div className="legacy-canvas-shell">
-          <div className="legacy-canvas-shell__banner">
-            <span>Legacy Runtime</span>
-            <strong>This canvas is archived. The reset workspace at `/` is now the primary surface.</strong>
-          </div>
-          <CanvasPageClient />
-        </div>
+        <CanvasPageClient />
       </ErrorBoundary>
     );
   } catch (error) {


### PR DESCRIPTION
## Issue and user impact

`/canvas` no longer behaved like the stable legacy TLDraw surface. On `origin/main`, the route was archive-gated unless `?legacy=1` was present, and even the gated path wrapped the canvas in archive-era messaging. That breaks the expectation that the old reliable canvas remains directly reachable for existing TLDraw, LiveKit, component, and agent workflows.

## Root cause

The route entrypoint in `src/app/canvas/page.tsx` had been converted into an archive shell:

- it read `searchParams`
- it required `legacy=1` to render the legacy client at all
- otherwise it returned `LegacyArchiveNotice`
- even when enabled, it still wrapped `CanvasPageClient` in `legacy-canvas-shell` / banner markup that framed the route as archived

So the regression was at the route contract itself, not inside TLDraw or the legacy canvas client.

## Why this fixes the root cause

This patch removes the archive gate and restores `/canvas` to directly mount `CanvasPageClient` under `ErrorBoundary` again. That fixes the exact route-level regression rather than patching around symptoms.

The branch intentionally does **not** pull in any reset-runtime or experimental canvas-OS work. It is scoped to restoring the existing shipped legacy canvas path on top of `origin/main`.

## What changed

### Route surface
- `src/app/canvas/page.tsx`
  - removed the `searchParams`-driven `legacy=1` gate
  - removed `LegacyArchiveNotice` from `/canvas`
  - removed the archive wrapper/banner shell
  - restored direct `CanvasPageClient` rendering

### Regression coverage
- `src/app/canvas/page.test.tsx`
  - added a smoke test that verifies `/canvas` renders the legacy client directly under `ErrorBoundary`
  - asserts the archive wrapper/banner structure is absent

## Backward compatibility

Backend/API/data compatibility: safe.

- No schema changes
- No API contract changes
- No queue/worker changes
- No agent behavior changes
- No persistence changes

This is a frontend route rollback only.

## Validation

Issue relevance and proof:
- `origin/main:src/app/canvas/page.tsx` archive-gates `/canvas` and only renders the legacy client behind `?legacy=1`
- live route probe on `https://present.best/canvas` still shows `legacy-canvas-shell` in the returned HTML, confirming the route is not currently a clean direct legacy canvas entry

Checks run:
- `npm run typecheck:app`
- `npx jest --runInBand --runTestsByPath src/app/canvas/page.test.tsx`
- `npm run lint -- src/app/canvas/page.tsx src/app/canvas/page.test.tsx`

Lint note:
- the repo lint script still reports the existing global warning backlog because it scans `src` broadly
- no new lint blocker was introduced by this patch

## Reviewer passes

### Correctness review
- reviewer lane found no concrete correctness findings in the narrowed diff
- one earlier low-severity test-contract note was resolved by asserting the old archive wrapper/banner markup is absent

### Maintainability review
- reviewer lane found no maintainability or architecture-fit findings in the narrowed diff
- review agreed the scope is disciplined because it restores `/canvas` only and does not revive broader archived legacy surfaces

## UI evidence

Before:
- `/tmp/present-pr-artifacts/legacy-canvas-before.png`

After:
- `/tmp/present-pr-artifacts/legacy-canvas-after.png`

## Remaining risks / follow-ups

Accepted non-blocking residual risk:
- Some stale references outside this diff may still mention `/canvas?legacy=1` or archive-era wording. That does not break this fix because `/canvas?legacy=1` still resolves to the restored page, but it is follow-up cleanup rather than part of this rollback.
