### PR TITLE
[codex] canonicalize legacy canvas routes

### DIFF
--- a/src/app/canvas/CanvasPageClient.tsx
+++ b/src/app/canvas/CanvasPageClient.tsx
@@ -41,6 +41,7 @@ import {
   buildSyncContract,
   getCanvasIdFromCurrentUrl,
 } from '@/lib/realtime/sync-contract';
+import { canonicalizeLegacyCanvasHref } from '@/lib/legacy-canvas-route';
 
 // Suppress development warnings for cleaner console
 suppressDevelopmentWarnings();
@@ -153,6 +154,17 @@ export function CanvasPageClient() {
       // noop
     }
   }, [canvasId, roomName]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      const canonicalHref = canonicalizeLegacyCanvasHref(window.location.href);
+      if (!canonicalHref || canonicalHref === window.location.href) return;
+      window.history.replaceState({}, '', canonicalHref);
+    } catch {
+      // noop
+    }
+  }, []);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;

--- a/src/components/ui/livekit/hooks/useLivekitConnection.ts
+++ b/src/components/ui/livekit/hooks/useLivekitConnection.ts
@@ -13,6 +13,7 @@ import { useLkAutoConnect } from './useLkAutoConnect';
 import { useLkAgentRequest } from './useLkAgentRequest';
 import { useLkRoomHandlers } from './useLkRoomHandlers';
 import { useLkIdentity } from './useLkIdentity';
+import { buildLegacyCanvasInviteLink } from '@/lib/legacy-canvas-route';
 
 export interface UseLivekitConnectionOptions {
   roomName?: string;
@@ -191,7 +192,7 @@ export function useLivekitConnection(options: UseLivekitConnectionOptions): Live
       return;
     }
 
-    const link = `${window.location.origin}/?room=${encodeURIComponent(providedRoomName)}`;
+    const link = buildLegacyCanvasInviteLink(window.location.origin, providedRoomName);
 
     try {
       await navigator.clipboard.writeText(link);

--- a/src/lib/legacy-canvas-route.test.ts
+++ b/src/lib/legacy-canvas-route.test.ts
@@ -1,0 +1,30 @@
+import {
+  buildLegacyCanvasInviteLink,
+  canonicalizeLegacyCanvasHref,
+} from './legacy-canvas-route';
+
+describe('legacy canvas route helpers', () => {
+  it('builds invite links against /canvas', () => {
+    expect(buildLegacyCanvasInviteLink('https://present.best', 'canvas-demo-room')).toBe(
+      'https://present.best/canvas?room=canvas-demo-room',
+    );
+  });
+
+  it('canonicalizes root urls onto /canvas while preserving params and hash', () => {
+    expect(
+      canonicalizeLegacyCanvasHref(
+        'https://present.best/?room=canvas-demo-room&id=a642d151-05cc-484f-b62f-c9a52a81a345&share=1#focus',
+      ),
+    ).toBe(
+      'https://present.best/canvas?room=canvas-demo-room&id=a642d151-05cc-484f-b62f-c9a52a81a345&share=1#focus',
+    );
+  });
+
+  it('does not rewrite urls that are already on /canvas', () => {
+    expect(
+      canonicalizeLegacyCanvasHref(
+        'https://present.best/canvas?room=canvas-demo-room&id=a642d151-05cc-484f-b62f-c9a52a81a345',
+      ),
+    ).toBeNull();
+  });
+});

--- a/src/lib/legacy-canvas-route.ts
+++ b/src/lib/legacy-canvas-route.ts
@@ -1,0 +1,17 @@
+const LEGACY_CANVAS_PATHNAME = '/canvas';
+
+export function buildLegacyCanvasInviteLink(origin: string, roomName: string): string {
+  const url = new URL(LEGACY_CANVAS_PATHNAME, origin);
+  url.searchParams.set('room', roomName);
+  return url.toString();
+}
+
+export function canonicalizeLegacyCanvasHref(href: string): string | null {
+  const url = new URL(href);
+  if (url.pathname !== '/') {
+    return null;
+  }
+
+  url.pathname = LEGACY_CANVAS_PATHNAME;
+  return url.toString();
+}


### PR DESCRIPTION
## Summary

This fixes a legacy-canvas routing regression that is still user-visible on `present.best`.

The merged `/canvas` rollback restored the legacy TLDraw canvas route, but legacy invite/share flows were still generating root-path links like `/?room=...`. When the legacy canvas booted from root, `CanvasPageClient` preserved the current pathname and appended `id` in place, which produced URLs like `/?id=<canvas-id>` instead of canonicalizing to `/canvas?id=<canvas-id>`.

On live prod this is still observable today: both `https://present.best/` and `https://present.best/canvas` render the legacy join screen, and the root-path entrypoint can drift into root-scoped `?id=` URLs.

## Root cause

Two issues combined:

1. `useLivekitConnection.copyInviteLink()` built invite links against `/` instead of `/canvas`.
2. `CanvasPageClient` had no pathname canonicalization step, so if the legacy canvas mounted on `/`, all subsequent `room` / `id` mutations stayed on `/`.

That meant the rollback restored the canvas route, but not the route contract.

## What changed

### Legacy route helpers
- Added `src/lib/legacy-canvas-route.ts` to centralize:
  - building invite links against `/canvas`
  - canonicalizing legacy-canvas root URLs onto `/canvas` while preserving query params and hash

### Invite-link generation
- Updated `src/components/ui/livekit/hooks/useLivekitConnection.ts` so copied invite links are now always `/canvas?room=...`

### Legacy canvas bootstrap
- Updated `src/app/canvas/CanvasPageClient.tsx` to canonicalize any root-mounted legacy-canvas URL onto `/canvas` before the existing `room` / `id` bootstrap logic mutates the URL

## Why this fixes the root problem

This fixes both entry directions:
- newly generated invite/share links now target the correct route
- stale/root legacy-canvas sessions self-heal onto `/canvas` instead of continuing to mutate `/?id=...`

So the route contract becomes stable again even if a user lands on the wrong pathname first.

## Compatibility

Backend compatibility: safe.

This is a frontend-only route/canonicalization fix. There are no API, schema, data, or job behavior changes.

## Validation

Issue relevance proof:
- `origin/main` still generated invite links via `/?room=...`
- live `https://present.best/` and `https://present.best/canvas` both still rendered the legacy join flow during this fix pass

Checks run:
- `npx jest --runInBand --runTestsByPath src/lib/legacy-canvas-route.test.ts src/app/canvas/page.test.tsx`
- `npm run typecheck:app`
- `npx biome lint src/app/canvas/CanvasPageClient.tsx src/components/ui/livekit/hooks/useLivekitConnection.ts src/lib/legacy-canvas-route.ts src/lib/legacy-canvas-route.test.ts`
  - reported only pre-existing warnings in the legacy canvas files; no new blocker introduced by this diff

## Review passes

Correctness review:
- confirmed the issue is still live on prod and still present on `origin/main`
- verified both the generation path and the bootstrap path are covered
- no blocker findings remained after the helper-based patch

Maintainability review:
- helper extraction keeps route-string handling out of the hook/component call sites
- scope stayed limited to 4 files with direct regression coverage
- no maintainability blocker findings remained
