### PR TITLE
[codex] reduce fallback drift and fix linear descriptions

### DIFF
--- a/src/components/ui/messaging/message-thread-collapsible.tsx
+++ b/src/components/ui/messaging/message-thread-collapsible.tsx
@@ -989,9 +989,7 @@ export const MessageThreadCollapsible = React.forwardRef<
   React.useEffect(() => {
     const hasAgent = storeTranscripts.some((t) => t.speaker === 'voice-agent');
     if (hasAgent) {
-      try {
-        setAgentPresent(true);
-      } catch {}
+      setAgentPresent(true);
     }
   }, [storeTranscripts, setAgentPresent]);
 

--- a/src/components/ui/productivity/linear-kanban-modal.tsx
+++ b/src/components/ui/productivity/linear-kanban-modal.tsx
@@ -31,6 +31,8 @@ export function IssueDetailModal({
   onAssigneeChange,
   onAddComment,
 }: IssueDetailModalProps) {
+  const description = issue.description?.trim();
+
   return (
     <div
       className="absolute inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
@@ -77,16 +79,11 @@ export function IssueDetailModal({
               <div>
                 <h3 className="text-sm font-semibold text-primary mb-2">Description</h3>
                 <div className="text-secondary text-sm leading-relaxed">
-                  <p>
-                    This is a placeholder description for the issue. In a real integration,
-                    this would be fetched from the Linear API. It supports <strong>markdown</strong>
-                    and other rich text features.
-                  </p>
-                  <ul className="list-disc ml-4 mt-2 space-y-1">
-                    <li>Check acceptance criteria</li>
-                    <li>Verify with design</li>
-                    <li>Update documentation</li>
-                  </ul>
+                  {description ? (
+                    <p className="whitespace-pre-wrap">{description}</p>
+                  ) : (
+                    <p>No description.</p>
+                  )}
                 </div>
               </div>
 
@@ -218,7 +215,6 @@ export function IssueDetailModal({
     </div>
   );
 }
-
 
 
 

--- a/src/components/ui/research/research-renderers.tsx
+++ b/src/components/ui/research/research-renderers.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import dynamic from 'next/dynamic';
-import { ResearchResult } from './research-panel';
+import type { ResearchResult } from './research-panel';
 import { cn } from '@/lib/utils';
 import {
   ExternalLink,

--- a/src/lib/agents/canvas-agent/server/runner.ts
+++ b/src/lib/agents/canvas-agent/server/runner.ts
@@ -752,9 +752,7 @@ function logMetrics(
   }
   onMetricEvent?.(payload);
   if (cfg.debug) {
-    try {
-      console.log('[CanvasAgent:Metrics]', JSON.stringify(payload));
-    } catch {}
+    console.log('[CanvasAgent:Metrics]', JSON.stringify(payload));
   }
 }
 

--- a/src/lib/agents/subagents/crowd-pulse-steward-fast.ts
+++ b/src/lib/agents/subagents/crowd-pulse-steward-fast.ts
@@ -1,6 +1,5 @@
 import {
   getCerebrasClient,
-  getModelForSteward,
   isFastStewardReady,
 } from '../fast-steward-config';
 import {
@@ -21,7 +20,6 @@ import {
   recordToolIoEvent,
 } from '@/lib/agents/shared/replay-telemetry';
 
-const getCrowdPulseFastModel = () => getModelForSteward('CROWD_PULSE_STEWARD_FAST_MODEL');
 let crowdPulseReplaySequence = 0;
 const nextCrowdPulseReplaySequence = () => {
   crowdPulseReplaySequence += 1;
@@ -112,7 +110,7 @@ export async function runCrowdPulseStewardFast(params: {
     stewardEnvVar: 'CROWD_PULSE_STEWARD_FAST_MODEL',
     room,
     task: 'crowd_pulse.fast',
-  }).catch(() => ({ model: getCrowdPulseFastModel() }));
+  });
   const requestId =
     typeof params.requestId === 'string' && params.requestId.trim().length > 0
       ? params.requestId.trim()

--- a/src/lib/agents/subagents/debate-steward-fast.ts
+++ b/src/lib/agents/subagents/debate-steward-fast.ts
@@ -196,7 +196,7 @@ export async function runDebateScorecardStewardFast(params: {
             stewardEnvVar: 'DEBATE_STEWARD_FAST_MODEL',
             room,
             task: 'scorecard.fast',
-          }).catch(() => ({ model: getModelForSteward('DEBATE_STEWARD_FAST_MODEL') }))
+          })
         ).model;
   const debateFastTrace = buildDebateFastTrace(resolvedDebateModel);
   const cerebrasModel = resolvedDebateModel;

--- a/src/lib/agents/subagents/flowchart-steward-fast.ts
+++ b/src/lib/agents/subagents/flowchart-steward-fast.ts
@@ -1,9 +1,7 @@
-import { getCerebrasClient, getModelForSteward, isFastStewardReady } from '../fast-steward-config';
+import { getCerebrasClient, isFastStewardReady } from '../fast-steward-config';
 import { getFlowchartDoc, getTranscriptWindow, commitFlowchartDoc, getContextDocuments, formatContextDocuments } from '../shared/supabase-context';
 import { extractFirstToolCall, parseToolArgumentsResult } from './fast-steward-response';
 import { resolveFastStewardModel } from '@/lib/agents/control-plane/fast-model';
-
-const getFlowchartFastModel = () => getModelForSteward('FLOWCHART_STEWARD_FAST_MODEL');
 
 export const flowchartStewardFastReady = isFastStewardReady();
 
@@ -99,7 +97,7 @@ export async function runFlowchartStewardFast(params: {
     stewardEnvVar: 'FLOWCHART_STEWARD_FAST_MODEL',
     room,
     task: 'flowchart.fast',
-  }).catch(() => ({ model: getFlowchartFastModel() }));
+  });
   const FLOWCHART_FAST_TRACE = flowchartFastTrace(CEREBRAS_MODEL);
   const overallStart = Date.now();
 
@@ -227,7 +225,7 @@ export async function runFlowchartInstruction(params: {
     stewardEnvVar: 'FLOWCHART_STEWARD_FAST_MODEL',
     room,
     task: 'flowchart.fast',
-  }).catch(() => ({ model: getFlowchartFastModel() }));
+  });
   const FLOWCHART_FAST_TRACE = flowchartFastTrace(CEREBRAS_MODEL);
 
   if (!isFastStewardReady()) {

--- a/src/lib/agents/subagents/linear-steward-fast.ts
+++ b/src/lib/agents/subagents/linear-steward-fast.ts
@@ -1,9 +1,7 @@
-import { getCerebrasClient, getModelForSteward, isFastStewardReady } from '../fast-steward-config';
+import { getCerebrasClient, isFastStewardReady } from '../fast-steward-config';
 import { getContextDocuments, formatContextDocuments, getTranscriptWindow } from '@/lib/agents/shared/supabase-context';
 import { extractFirstToolCall, parseToolArgumentsResult } from './fast-steward-response';
 import { resolveFastStewardModel } from '@/lib/agents/control-plane/fast-model';
-
-const getLinearFastModel = () => getModelForSteward('LINEAR_STEWARD_FAST_MODEL');
 
 const LINEAR_STEWARD_INSTRUCTIONS = `
 You are a fast, precise assistant for the Linear issue tracking system.
@@ -90,7 +88,7 @@ export async function runLinearStewardFast(params: {
     stewardEnvVar: 'LINEAR_STEWARD_FAST_MODEL',
     room,
     task: 'linear.fast',
-  }).catch(() => ({ model: getLinearFastModel() }));
+  });
 
   if (!isFastStewardReady()) {
     return {

--- a/src/lib/agents/subagents/summary-steward-fast.ts
+++ b/src/lib/agents/subagents/summary-steward-fast.ts
@@ -1,4 +1,4 @@
-import { getCerebrasClient, getModelForSteward, isFastStewardReady } from '../fast-steward-config';
+import { getCerebrasClient, isFastStewardReady } from '../fast-steward-config';
 import { getTranscriptWindow, getContextDocuments, formatContextDocuments } from '@/lib/agents/shared/supabase-context';
 import { extractFirstToolCall, parseToolArgumentsResult } from './fast-steward-response';
 import { resolveFastStewardModel } from '@/lib/agents/control-plane/fast-model';
@@ -7,7 +7,6 @@ import {
   recordToolIoEvent,
 } from '@/lib/agents/shared/replay-telemetry';
 
-const getSummaryFastModel = () => getModelForSteward('SUMMARY_STEWARD_FAST_MODEL');
 let summaryReplaySequence = 0;
 const nextSummaryReplaySequence = () => {
   summaryReplaySequence += 1;
@@ -87,7 +86,7 @@ export async function runSummaryStewardFast(params: {
     stewardEnvVar: 'SUMMARY_STEWARD_FAST_MODEL',
     room,
     task: 'summary.fast',
-  }).catch(() => ({ model: getSummaryFastModel() }));
+  });
   const requestId =
     typeof params.requestId === 'string' && params.requestId.trim().length > 0
       ? params.requestId.trim()

--- a/src/lib/agents/subagents/youtube-steward.ts
+++ b/src/lib/agents/subagents/youtube-steward.ts
@@ -1,8 +1,6 @@
-import { getCerebrasClient, getModelForSteward, isFastStewardReady } from '../fast-steward-config';
+import { getCerebrasClient, isFastStewardReady } from '../fast-steward-config';
 import { extractFirstToolCall, parseToolArgumentsResult } from './fast-steward-response';
 import { resolveFastStewardModel } from '@/lib/agents/control-plane/fast-model';
-
-const getYouTubeFastModel = () => getModelForSteward('YOUTUBE_STEWARD_FAST_MODEL');
 
 const YOUTUBE_STEWARD_INSTRUCTIONS = `
 You are a fast YouTube assistant that maps user requests to YouTube MCP tool calls.
@@ -68,7 +66,7 @@ export async function runYouTubeSteward(params: { instruction: string; context?:
     stewardEnvVar: 'YOUTUBE_STEWARD_FAST_MODEL',
     room,
     task: 'youtube.fast',
-  }).catch(() => ({ model: getYouTubeFastModel() }));
+  });
 
   // The FAST YouTube steward uses Cerebras; if it's not configured we return a best-effort heuristic
   // so the rest of the system can keep running.

--- a/src/lib/linear/normalizers.test.ts
+++ b/src/lib/linear/normalizers.test.ts
@@ -1,0 +1,33 @@
+import { normalizeIssues } from './normalizers';
+import { linearKanbanSchema } from './types';
+
+describe('normalizeIssues', () => {
+  it('preserves issue descriptions for downstream widget consumers', () => {
+    const normalized = normalizeIssues(
+      [
+        {
+          id: 'issue-1',
+          identifier: 'PRE-1',
+          title: 'Add description support',
+          description: 'Render the real issue description in the modal.',
+          status: 'Todo',
+          updatedAt: '2026-04-15T00:00:00.000Z',
+        },
+      ],
+      [],
+    );
+
+    expect(normalized).not.toBe('RATE_LIMITED');
+    expect(normalized).toEqual([
+      expect.objectContaining({
+        description: 'Render the real issue description in the modal.',
+      }),
+    ]);
+
+    expect(() =>
+      linearKanbanSchema.parse({
+        issues: normalized,
+      }),
+    ).not.toThrow();
+  });
+});

--- a/src/lib/linear/normalizers.ts
+++ b/src/lib/linear/normalizers.ts
@@ -176,6 +176,7 @@ export function normalizeIssues(
       id: i.id as string,
       identifier: i.identifier as string,
       title: i.title as string,
+      description: typeof i.description === 'string' ? i.description : undefined,
       status: statusName,
       statusId: statusId,
       updatedAt: i.updatedAt as string,
@@ -186,7 +187,6 @@ export function normalizeIssues(
     };
   });
 }
-
 
 
 

--- a/src/lib/linear/types.ts
+++ b/src/lib/linear/types.ts
@@ -47,6 +47,7 @@ export interface LinearIssue {
   id: string;
   identifier: string;
   title: string;
+  description?: string;
   status?: string;
   statusId?: string;
   updatedAt: string;
@@ -132,6 +133,7 @@ export const linearKanbanSchema = z.object({
         id: z.string(),
         identifier: z.string(),
         title: z.string(),
+        description: z.string().optional(),
         status: z.string(),
         updatedAt: z.string(),
         priority: z.object({ value: z.number(), name: z.string() }).optional(),
@@ -154,8 +156,6 @@ export interface KanbanColumn {
   title: string;
   key: string;
 }
-
-
 
 
 

--- a/src/lib/linear/use-linear-data-enricher.ts
+++ b/src/lib/linear/use-linear-data-enricher.ts
@@ -7,9 +7,8 @@ import {
   loadCacheFromStorage,
   saveCacheToStorage,
   hashApiKey,
-  normalizeTeams,
-  normalizeIssues,
-} from './index';
+} from './cache';
+import { normalizeTeams, normalizeIssues } from './normalizers';
 import type { LinearBoardData, LoadEvent, LinearStatus } from './types';
 
 interface UseLinearDataEnricherOptions {
@@ -145,7 +144,6 @@ export function useLinearDataEnricher({ apiKey, teamId, pushEvent }: UseLinearDa
     },
   }), [apiKey, teamId, pushEvent]);
 }
-
 
 
 

--- a/src/lib/tools/conductor/components/registry.tsx
+++ b/src/lib/tools/conductor/components/registry.tsx
@@ -69,8 +69,7 @@ import { InfographicWidget, infographicWidgetSchema } from '@/components/Infogra
 // Context feeder widget for document/text context injection
 import { ContextFeeder, contextFeederSchema } from '@/components/ui/documents/context-feeder';
 import { getWidgetLifecycleMetadata } from '@/lib/agents/widget-lifecycle-manifest';
-
-import { componentToolboxSchema } from '@/lib/custom';
+import { componentToolboxSchema } from '@/lib/custom-schemas';
 import type { CapabilityGroup, LifecycleOp, WidgetTier } from '@/lib/agents/capabilities';
 
 const extendedSchema = <T extends z.ZodObject<any>>(schema: T) => {


### PR DESCRIPTION
## Issue and user impact

This PR is the first `yeet-pro` cleanup wave from the code-quality swarm pass.

It addresses a set of small but real quality problems that were still present on `origin/main`:
- 7 fast-steward callers were redundantly swallowing `resolveFastStewardModel()` failures even though fallback ownership already lives in `src/lib/agents/control-plane/fast-model.ts`
- 3 first-party circular dependency edges were caused by internal modules importing back through public facades/barrels
- the Linear issue detail modal displayed fake placeholder description content instead of either real issue text or an honest empty state
- two control-path `try/catch` wrappers were suppressing failures without providing a real recovery path

User impact:
- fast steward selection becomes easier to reason about and less drift-prone
- internal module boundaries are cleaner and less cycle-prone
- the Linear issue modal no longer lies to the user with placeholder copy
- agent presence / canvas metric logging stop silently masking internal errors

## Root cause analysis

The root problem was duplicated ownership:
- fallback logic existed both in `fast-model.ts` and again at each fast-steward callsite
- public facades/barrels were imported by internal implementation files, creating first-party cycles
- the Linear modal had a UI-only placeholder instead of following the actual issue data contract
- low-value defensive catches stayed in control paths where they only hid bugs

## Why this fixes the root cause

This patch centralizes behavior instead of adding more wrappers:
- all fast-steward callers now trust `resolveFastStewardModel()` as the single fallback owner
- the 3 first-party cycles are removed by switching to type-only import / direct internal imports instead of importing back through facades
- Linear descriptions are now carried end-to-end across runtime type, normalizer, widget schema, and modal rendering
- the two pointless catches were removed instead of replaced with new fallback layers

## What changed

### Fast stewards
- removed redundant `.catch(() => ({ model }))` wrappers from:
  - `linear-steward-fast.ts`
  - `youtube-steward.ts`
  - `summary-steward-fast.ts`
  - `crowd-pulse-steward-fast.ts`
  - `flowchart-steward-fast.ts`
  - `debate-steward-fast.ts`

### First-party cycle cleanup
- made `ResearchResult` import type-only in `research-renderers.tsx`
- switched `registry.tsx` to import `componentToolboxSchema` directly from `custom-schemas`
- switched `use-linear-data-enricher.ts` from `./index` to direct `./cache` and `./normalizers` imports

### Linear modal truthfulness
- added optional `description` to `LinearIssue`
- preserved `description` in `normalizeIssues()`
- added `description` to `linearKanbanSchema` so create/update/hydrate flows do not strip it
- replaced fake placeholder issue description content in `linear-kanban-modal.tsx` with:
  - real description when present
  - `No description.` when absent
- added `src/lib/linear/normalizers.test.ts` to cover normalizer -> schema preservation of descriptions

### Control-path cleanup
- removed the pointless `try/catch` around `setAgentPresent(true)` in `message-thread-collapsible.tsx`
- removed the empty `try/catch` around canvas metrics `console.log()` while preserving `onMetricEvent` + `cfg.debug` behavior in `runner.ts`

## Backward compatibility

Verdict: backward compatible.

- no schema migrations
- no API contract removals
- no data shape breaking changes
- `LinearIssue.description` is additive and optional
- fast steward behavior remains fallback-safe because fallback ownership already exists in `fast-model.ts`

## Issue relevance evidence on `origin/main`

Verified before publish against current `origin/main`:
- 7 fast-steward caller-side fallback wrappers were still present
- the Linear modal still contained the placeholder description text
- `research-renderers.tsx` still imported from `./research-panel`
- `use-linear-data-enricher.ts` still imported from `./index`
- `message-thread-collapsible.tsx` still wrapped `setAgentPresent(true)` in `try/catch`
- `runner.ts` still wrapped canvas metrics logging in an empty `try/catch`

## Validation

Passed:
- `git diff --check`
- `npm run typecheck:app`
- `npm run typecheck:agent`
- `npx jest src/lib/linear/normalizers.test.ts --runInBand`

Known existing repo blockers outside this diff:
- `npm run typecheck` still fails in this repo because `tsconfig.reset.json` references missing reset route files
- full `npm run build` in the canonical checkout currently fails on an unrelated existing type error in `src/app/api/admin/agents/voice-sessions/route.ts:153`

## Reviewer passes

Required review lanes run:
- `reviewer_correctness`
- `reviewer_maintainability`

Resolved finding:
- both reviewers flagged that the Linear description change was only half-wired because `linearKanbanSchema` still stripped `description`
- fixed by adding `description` to the Zod issue shape and adding a focused regression test in `src/lib/linear/normalizers.test.ts`

Final reviewer status after fix:
- no remaining correctness findings in reviewed scope
- no remaining maintainability findings in reviewed scope

## UI evidence

No screenshot attached in this pass.
Reason: the only UI-visible change is a small auth-gated Linear modal copy/data-path fix; this wave is primarily internal cleanup. The modal now renders truthful data or an explicit empty state instead of placeholder content.

## Remaining risks and follow-ups

- full repo build is still blocked by the unrelated `voice-sessions` type error outside this branch
- the broader cleanup swarm still has additional high-confidence follow-up waves (for example: `useToolRunner` stub removal, context contract consolidation, larger legacy/fallback cleanup), but they are intentionally not mixed into this PR
