### PR TITLE
[codex] remove fake exa fallback results

### DIFF
--- a/src/components/tool-dispatcher/hooks/useToolRunner.test.tsx
+++ b/src/components/tool-dispatcher/hooks/useToolRunner.test.tsx
@@ -1,4 +1,90 @@
+import React from 'react';
+import { act, cleanup, render, waitFor } from '@testing-library/react';
 import { shouldDeferToolCallWhenNotExecutor, shouldExecuteIncomingToolCall } from './tool-call-execution-guard';
+import { useToolRunner } from './useToolRunner';
+import type { ToolCall, ToolRunResult } from '../utils/toolTypes';
+import { ComponentRegistry } from '@/lib/component-registry';
+
+const queueApiMock = {
+  state: { jobs: [] },
+  enqueue: jest.fn(),
+  markStarted: jest.fn(),
+  markComplete: jest.fn(),
+  markError: jest.fn(),
+  reset: jest.fn(),
+};
+
+const registryApiMock = {
+  getHandler: jest.fn(),
+  listTools: jest.fn(() => []),
+};
+
+jest.mock('./useToolQueue', () => ({
+  useToolQueue: () => queueApiMock,
+}));
+
+jest.mock('./useToolRegistry', () => ({
+  useToolRegistry: () => registryApiMock,
+}));
+
+jest.mock('@/hooks/use-room-executor', () => ({
+  useRoomExecutor: () => ({
+    sessionId: null,
+    isExecutor: true,
+    executorIdentity: null,
+    leaseExpiresAt: null,
+    status: 'idle',
+    error: null,
+  }),
+}));
+
+jest.mock('@/lib/journey-logger', () => ({
+  logJourneyEvent: jest.fn(),
+}));
+
+jest.mock('@/lib/logging', () => ({
+  createLogger: () => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  }),
+}));
+
+type RunnerProbeProps = {
+  onReady: (api: ReturnType<typeof useToolRunner>) => void;
+  events?: Partial<{
+    emitRequest: jest.Mock;
+    emitDone: jest.Mock;
+    emitError: jest.Mock;
+    emitEditorAction: jest.Mock;
+    log: jest.Mock;
+    bus: { on: jest.Mock; send: jest.Mock };
+  }>;
+};
+
+function RunnerProbe({ onReady, events }: RunnerProbeProps) {
+  const api = useToolRunner({
+    stewardEnabled: false,
+    events: {
+      emitRequest: jest.fn(),
+      emitDone: jest.fn(),
+      emitError: jest.fn(),
+      emitEditorAction: jest.fn(),
+      log: jest.fn(),
+      bus: {
+        on: jest.fn(() => () => {}),
+        send: jest.fn(),
+      },
+      ...events,
+    } as any,
+  });
+
+  React.useEffect(() => {
+    onReady(api);
+  }, [api, onReady]);
+
+  return null;
+}
 
 describe('shouldExecuteIncomingToolCall', () => {
   it('skips execution for non-executor clients', () => {
@@ -42,6 +128,93 @@ describe('shouldExecuteIncomingToolCall', () => {
     expect(result.execute).toBe(true);
     expect(result.reason).toBeUndefined();
     expect(processed.has('canvas-room:c1')).toBe(true);
+  });
+});
+
+describe('useToolRunner', () => {
+  beforeEach(() => {
+    cleanup();
+    jest.clearAllMocks();
+    registryApiMock.getHandler.mockReturnValue(undefined);
+    ComponentRegistry.clear();
+    (window as any).__custom_mcp_tools = {};
+    (window as any).callMcpTool = jest.fn();
+  });
+
+  afterEach(() => {
+    cleanup();
+    ComponentRegistry.clear();
+    delete (window as any).__custom_mcp_tools;
+    delete (window as any).callMcpTool;
+  });
+
+  it('surfaces exa MCP unavailability as an error without fake scorecard updates', async () => {
+    const emitRequest = jest.fn();
+    const emitDone = jest.fn();
+    const emitError = jest.fn();
+    const callMcpTool = jest.fn().mockResolvedValue(undefined);
+    (window as any).callMcpTool = callMcpTool;
+
+    let runnerApi: ReturnType<typeof useToolRunner> | null = null;
+    const onReady = jest.fn((api: ReturnType<typeof useToolRunner>) => {
+      runnerApi = api;
+    });
+
+    const updateSpy = jest.spyOn(ComponentRegistry, 'update');
+
+    render(
+      <RunnerProbe
+        onReady={onReady}
+        events={{
+          emitRequest,
+          emitDone,
+          emitError,
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(runnerApi).not.toBeNull();
+    });
+
+    const call: ToolCall = {
+      id: 'call-exa-1',
+      type: 'tool_call',
+      payload: {
+        tool: 'mcp_exa',
+        params: {
+          query: 'ai agents',
+        },
+      },
+    };
+
+    let result: ToolRunResult | undefined;
+    await act(async () => {
+      result = await runnerApi!.executeToolCall(call);
+    });
+
+    expect(callMcpTool).toHaveBeenCalledWith('exa', { query: 'ai agents' });
+    expect(result).toEqual({
+      status: 'ERROR',
+      message:
+        'Exa MCP is unavailable for "ai agents". Configure MCP servers in /mcp-config to enable real research results.',
+      error: 'Exa MCP unavailable',
+      results: [],
+    });
+    expect(queueApiMock.markError).toHaveBeenCalledWith(
+      'call-exa-1',
+      'Exa MCP is unavailable for "ai agents". Configure MCP servers in /mcp-config to enable real research results.',
+    );
+    expect(emitError).toHaveBeenCalledWith(
+      call,
+      expect.objectContaining({
+        status: 'ERROR',
+        message:
+          'Exa MCP is unavailable for "ai agents". Configure MCP servers in /mcp-config to enable real research results.',
+      }),
+    );
+    expect(emitDone).not.toHaveBeenCalled();
+    expect(updateSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/src/components/tool-dispatcher/hooks/useToolRunner.ts
+++ b/src/components/tool-dispatcher/hooks/useToolRunner.ts
@@ -7,6 +7,7 @@ import { useToolRegistry } from './useToolRegistry';
 import { useToolQueue } from './useToolQueue';
 import type { ToolCall, ToolParameters, ToolRunResult } from '../utils/toolTypes';
 import { TOOL_STEWARD_DELAY_MS, TOOL_STEWARD_WINDOW_MS } from '../utils/constants';
+import { normalizeExaFallbackResult } from '../utils/resultNormalizers';
 import type { ToolEventsApi } from './useToolEvents';
 import { ComponentRegistry } from '@/lib/component-registry';
 import { applyEnvelope } from '@/components/tool-dispatcher/handlers/tldraw-actions';
@@ -710,19 +711,7 @@ export function useToolRunner(options: UseToolRunnerOptions): ToolRunnerApi {
         }
       }
 
-      const resultRecord = toRecord(result);
-      if ((!resultRecord || resultRecord.status === 'IGNORED') && toolName === 'exa') {
-        const q = String(params.query || '').trim();
-        result = {
-          status: 'STUB',
-          results: [
-            {
-              title: `Research stub for: ${q}`,
-              snippet: 'MCP not wired. Configure MCP servers in /mcp-config to enable real results.',
-            },
-          ],
-        };
-      }
+      result = normalizeExaFallbackResult({ toolName, result, params, mcpError });
 
       try {
         logger.debug('mcp result', {
@@ -738,7 +727,12 @@ export function useToolRunner(options: UseToolRunnerOptions): ToolRunnerApi {
           observedResult?.results ?? observedResult?.items ?? observedResult?.documents ?? [];
         const list = Array.isArray(listRaw) ? listRaw : [];
         const resultCount = Array.isArray(list) ? list.length : undefined;
-        const eventType = mcpError ? 'mcp_error' : 'mcp_result';
+        const observedError =
+          mcpError ??
+          (typeof observedResult?.message === 'string' && observedResult?.status === 'ERROR'
+            ? observedResult.message
+            : undefined);
+        const eventType = observedError ? 'mcp_error' : 'mcp_result';
         logJourneyEvent({
           eventType,
           source: 'dispatcher',
@@ -747,7 +741,7 @@ export function useToolRunner(options: UseToolRunnerOptions): ToolRunnerApi {
           payload: {
             status: observedResult?.status ?? null,
             resultCount,
-            error: mcpError,
+            error: observedError,
           },
         });
       } catch {}
@@ -756,6 +750,9 @@ export function useToolRunner(options: UseToolRunnerOptions): ToolRunnerApi {
         try {
           const queryText = String(params.query || '').trim();
           const exaResult = toRecord(result);
+          if (exaResult?.status === 'ERROR') {
+            return toToolRunResult(result);
+          }
           const itemsRaw = exaResult?.results ?? exaResult?.items ?? exaResult?.documents ?? [];
           const items = Array.isArray(itemsRaw) ? itemsRaw : [];
           const sourcesText = Array.isArray(items)

--- a/src/components/tool-dispatcher/utils/resultNormalizers.test.ts
+++ b/src/components/tool-dispatcher/utils/resultNormalizers.test.ts
@@ -1,4 +1,8 @@
-import { getMermaidLastNode, normalizeMermaidText } from './resultNormalizers';
+import {
+  getMermaidLastNode,
+  normalizeExaFallbackResult,
+  normalizeMermaidText,
+} from './resultNormalizers';
 
 describe('resultNormalizers', () => {
   it('normalizes mermaid text by adding headers and semicolons', () => {
@@ -9,5 +13,35 @@ describe('resultNormalizers', () => {
   it('returns last node in mermaid text', () => {
     const text = 'graph TD; A-->B; B-->C;';
     expect(getMermaidLastNode(text)).toBe('C');
+  });
+
+  it('returns an explicit error instead of fake exa research results', () => {
+    expect(
+      normalizeExaFallbackResult({
+        toolName: 'exa',
+        result: { status: 'IGNORED' },
+        params: { query: 'ai agents' },
+      }),
+    ).toEqual({
+      status: 'ERROR',
+      message:
+        'Exa MCP is unavailable for "ai agents". Configure MCP servers in /mcp-config to enable real research results.',
+      error: 'Exa MCP unavailable',
+      results: [],
+    });
+  });
+
+  it('preserves real exa results', () => {
+    const result = {
+      status: 'SUCCESS',
+      results: [{ title: 'Real result' }],
+    };
+    expect(
+      normalizeExaFallbackResult({
+        toolName: 'exa',
+        result,
+        params: { query: 'ai agents' },
+      }),
+    ).toBe(result);
   });
 });

--- a/src/components/tool-dispatcher/utils/resultNormalizers.ts
+++ b/src/components/tool-dispatcher/utils/resultNormalizers.ts
@@ -44,3 +44,33 @@ export function getMermaidLastNode(text: string): string | undefined {
   const last = matches[matches.length - 1];
   return last?.[2]?.replace(/;$/, '') || undefined;
 }
+
+function toRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+export function normalizeExaFallbackResult(args: {
+  toolName: string;
+  result: unknown;
+  params: Record<string, unknown>;
+  mcpError?: string;
+}): unknown {
+  const { toolName, result, params, mcpError } = args;
+  if (toolName !== 'exa') return result;
+
+  const resultRecord = toRecord(result);
+  if (resultRecord && resultRecord.status !== 'IGNORED') return result;
+
+  const queryText = typeof params.query === 'string' ? params.query.trim() : '';
+  const querySuffix = queryText ? ` for "${queryText}"` : '';
+
+  return {
+    status: 'ERROR',
+    message:
+      mcpError ??
+      `Exa MCP is unavailable${querySuffix}. Configure MCP servers in /mcp-config to enable real research results.`,
+    error: mcpError ?? 'Exa MCP unavailable',
+    results: [],
+  };
+}


### PR DESCRIPTION
## Summary

This PR removes the fake `exa` fallback path in the tool dispatcher so missing MCP wiring is reported honestly instead of being silently converted into fabricated research output.

## Issue And User Impact

On `origin/main`, the browser dispatcher still synthesizes fake Exa results when the MCP tool is unavailable:

- `src/components/tool-dispatcher/hooks/useToolRunner.ts` emits `status: 'STUB'`
- it fabricates `Research stub for: ...` result rows
- it then reflects those stubbed results into `DebateScorecard` timeline entries via `source: 'tool:exa'`

That behavior is actively misleading. It makes the UI look like research succeeded, hides MCP configuration failures, and can contaminate downstream scorecard state with invented sources.

## Root Cause

The dispatcher was treating missing Exa MCP output as a UX fallback instead of an execution failure. Because the fallback shape looked like a successful result payload, later code paths treated it as real research and updated the most recent `DebateScorecard` with synthetic source text.

## Why This Fix Solves The Root Cause

The fix changes the contract at the point of failure:

- missing or ignored Exa MCP responses are normalized into an explicit `ERROR`
- telemetry now records those normalized failures as `mcp_error`, even when the transport layer did not throw
- the Exa reflection path returns early on error, so no `DebateScorecard` timeline patch is synthesized from unavailable research
- the hook-level regression test exercises the real `useToolRunner` MCP branch to prove the dispatcher emits `emitError`, skips `emitDone`, and does not call `ComponentRegistry.update`

That addresses the root problem directly: unavailable MCP research now stays unavailable instead of being disguised as successful output.

## What Changed

### Dispatcher result normalization

- added `normalizeExaFallbackResult()` in `src/components/tool-dispatcher/utils/resultNormalizers.ts`
- removed the fake `STUB` Exa payload generation from `useToolRunner`
- surfaced a user-facing error message that points to MCP configuration instead of fake results

### Telemetry and follow-on behavior

- updated dispatcher telemetry so normalized Exa failures are logged as `mcp_error`
- short-circuited Exa reflection when the normalized result is `ERROR`

### Tests

- expanded `src/components/tool-dispatcher/utils/resultNormalizers.test.ts`
- added `useToolRunner` regression coverage in `src/components/tool-dispatcher/hooks/useToolRunner.test.tsx`

## Backward Compatibility

This is a behavior change, but it is the intended contract correction.

- Frontend: users now see an explicit Exa MCP failure instead of fabricated research content
- Backend/API: no schema or server contract changes
- Data: no persisted data migration required

Any existing caller that depended on the fake `STUB` payload was depending on incorrect behavior. The new behavior is stricter and safer.

## Validation

Ran locally in `/Users/bsteinher/.codex/worktrees/present-cleanup-wave2`:

- `npx jest src/components/tool-dispatcher/hooks/useToolRunner.test.tsx src/components/tool-dispatcher/utils/resultNormalizers.test.ts --runInBand`
- `npm run typecheck:app`
- `git diff --check`

Additional build gate:

- `npm run build` is still blocked in the current repo setup by unrelated missing-module failures under reset/codex package paths:
  - `packages/ui/src/reset-monaco-editor.tsx` missing `@monaco-editor/react`, `y-protocols/awareness`, `yjs`, `y-monaco`
  - `services/codex-adapter/src/sdk.ts` missing `@openai/codex-sdk`

These errors are outside this diff and should not be attributed to the Exa cleanup.

## Reviewer Passes

Independent review lanes after the final fix/test wave:

- `reviewer_correctness`: no findings
- `reviewer_maintainability`: no findings

## Remaining Risks

- This PR intentionally stops fabricating Exa fallback content. Any UI flow that was implicitly relying on fake research rows will now surface an error instead, which is the correct contract but could expose latent MCP setup gaps.
