### PR TITLE
[codex] share context document contracts

### DIFF
--- a/src/app/api/session/context/route.test.ts
+++ b/src/app/api/session/context/route.test.ts
@@ -1,0 +1,128 @@
+/**
+ * @jest-environment node
+ */
+
+const createClientMock = jest.fn();
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: createClientMock,
+}));
+
+const loadRoute = async () => {
+  let GET: ((req: import('next/server').NextRequest) => Promise<Response>) | null = null;
+  let POST: ((req: import('next/server').NextRequest) => Promise<Response>) | null = null;
+  await jest.isolateModulesAsync(async () => {
+    const route = await import('./route');
+    GET = route.GET;
+    POST = route.POST;
+  });
+  return {
+    GET: GET as (req: import('next/server').NextRequest) => Promise<Response>,
+    POST: POST as (req: import('next/server').NextRequest) => Promise<Response>,
+  };
+};
+
+const makeRequest = (
+  method: 'GET' | 'POST',
+  url: string,
+  body?: Record<string, unknown>,
+) => ({
+  method,
+  url,
+  nextUrl: new URL(url),
+  json: async () => body,
+} as unknown as import('next/server').NextRequest);
+
+const buildContextDocumentsQuery = (result: { data: unknown; error: unknown }) => {
+  const query: any = Promise.resolve(result);
+  query.select = jest.fn(() => query);
+  query.eq = jest.fn(() => query);
+  query.maybeSingle = jest.fn(() => Promise.resolve(result));
+  return query;
+};
+
+describe('/api/session/context', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    createClientMock.mockReset();
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://example.supabase.co';
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon-test-key';
+  });
+
+  it('returns sanitized MCP context documents on GET', async () => {
+    const sessionQuery = buildContextDocumentsQuery({
+      data: {
+        context_documents: [
+          {
+            id: 'doc-1',
+            title: 'MCP Context',
+            content: 'summary',
+            type: 'text',
+            timestamp: 123,
+            source: 'mcp',
+          },
+          {
+            id: 'doc-2',
+            title: 'Bad Context',
+            content: 'summary',
+            type: 'text',
+            timestamp: 123,
+            source: 'email',
+          },
+        ],
+      },
+      error: null,
+    });
+    createClientMock.mockReturnValue({
+      from: jest.fn(() => sessionQuery),
+    });
+
+    const { GET } = await loadRoute();
+    const response = await GET(
+      makeRequest('GET', 'http://localhost/api/session/context?sessionId=canvas-room-1'),
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json).toEqual({
+      contextDocuments: [
+        {
+          id: 'doc-1',
+          title: 'MCP Context',
+          content: 'summary',
+          type: 'text',
+          timestamp: 123,
+          source: 'mcp',
+        },
+      ],
+    });
+  });
+
+  it('rejects invalid context document payloads on POST', async () => {
+    const sessionQuery = buildContextDocumentsQuery({ data: null, error: null });
+    createClientMock.mockReturnValue({
+      from: jest.fn(() => sessionQuery),
+    });
+
+    const { POST } = await loadRoute();
+    const response = await POST(
+      makeRequest('POST', 'http://localhost/api/session/context', {
+        sessionId: 'canvas-room-1',
+        contextDocuments: [
+          {
+            id: 'doc-1',
+            title: 'Invalid',
+            content: 'summary',
+            type: 'text',
+            timestamp: 123,
+            source: 'email',
+          },
+        ],
+      }),
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(json).toEqual({ error: 'contextDocuments contains invalid entries' });
+  });
+});

--- a/src/app/api/session/context/route.ts
+++ b/src/app/api/session/context/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
+import { parseContextDocuments } from '@/lib/context-documents';
 
 let cachedSupabase: ReturnType<typeof createClient> | null = null;
 
@@ -55,7 +56,7 @@ export async function GET(request: NextRequest) {
     }
 
     return NextResponse.json({
-      contextDocuments: data?.context_documents || [],
+      contextDocuments: parseContextDocuments(data?.context_documents),
     });
   } catch (err) {
     console.error('[ContextAPI] GET exception:', err);
@@ -85,6 +86,11 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'contextDocuments must be an array' }, { status: 400 });
     }
 
+    const parsedDocuments = parseContextDocuments(contextDocuments);
+    if (parsedDocuments.length !== contextDocuments.length) {
+      return NextResponse.json({ error: 'contextDocuments contains invalid entries' }, { status: 400 });
+    }
+
     // Check if session exists
     const { data: existing } = await supabase
       .from('sessions')
@@ -98,7 +104,7 @@ export async function POST(request: NextRequest) {
       const result = await supabase
         .from('sessions')
         .update({
-          context_documents: contextDocuments,
+          context_documents: parsedDocuments,
           updated_at: new Date().toISOString(),
         })
         .eq('room_name', sessionId);
@@ -107,7 +113,7 @@ export async function POST(request: NextRequest) {
       // Insert new session
       const result = await supabase.from('sessions').insert({
         room_name: sessionId,
-        context_documents: contextDocuments,
+        context_documents: parsedDocuments,
         updated_at: new Date().toISOString(),
       });
       error = result.error;

--- a/src/components/ui/documents/context-feeder.tsx
+++ b/src/components/ui/documents/context-feeder.tsx
@@ -1,5 +1,9 @@
 'use client';
 
+import {
+    contextDocumentSchema,
+    type ContextDocument,
+} from '@/lib/context-documents';
 import { cn } from '@/lib/utils';
 import { useComponentRegistration } from '@/lib/component-registry';
 import { z } from 'zod';
@@ -16,19 +20,6 @@ import {
 import { useState, useCallback, useMemo, useRef, useEffect } from 'react';
 import { useDropzone } from 'react-dropzone';
 
-// =============================================================================
-// Schema
-// =============================================================================
-
-export const contextDocumentSchema = z.object({
-    id: z.string(),
-    title: z.string(),
-    content: z.string(),
-    type: z.enum(['markdown', 'text']),
-    timestamp: z.number(),
-    source: z.enum(['file', 'paste']),
-});
-
 export const contextFeederSchema = z.object({
     documents: z.array(contextDocumentSchema).optional().describe('Array of context documents'),
     allowMarkdown: z.boolean().optional().describe('Allow markdown file uploads'),
@@ -36,7 +27,6 @@ export const contextFeederSchema = z.object({
     title: z.string().optional().describe('Title for the widget'),
 });
 
-export type ContextDocument = z.infer<typeof contextDocumentSchema>;
 export type ContextFeederProps = z.infer<typeof contextFeederSchema>;
 
 type ContextFeederHostProps = ContextFeederProps &

--- a/src/lib/agents/shared/supabase-context.ts
+++ b/src/lib/agents/shared/supabase-context.ts
@@ -3,6 +3,10 @@ import { config } from 'dotenv';
 import { join } from 'path';
 import { randomUUID } from 'crypto';
 import { RoomServiceClient, DataPacket_Kind } from 'livekit-server-sdk';
+import {
+  parseContextDocuments,
+  type ContextDocument,
+} from '@/lib/context-documents';
 import type { JsonObject } from '@/lib/utils/json-schema';
 import { deriveRequestCorrelation } from '@/lib/agents/shared/request-correlation';
 import {
@@ -1287,15 +1291,6 @@ export async function getTranscriptWindow(room: string, windowMs: number) {
 // Context Documents (user-uploaded markdown/text for steward context)
 // =============================================================================
 
-export type ContextDocument = {
-  id: string;
-  title: string;
-  content: string;
-  type: 'markdown' | 'text';
-  timestamp: number;
-  source: 'file' | 'paste';
-};
-
 /**
  * Retrieves user-uploaded context documents for a room/session.
  * These documents are injected into steward prompts alongside the transcript.
@@ -1324,8 +1319,7 @@ export async function getContextDocuments(room: string): Promise<ContextDocument
       return [];
     }
 
-    const docs = Array.isArray(data.context_documents) ? data.context_documents : [];
-    return docs as ContextDocument[];
+    return parseContextDocuments(data.context_documents);
   } catch (err) {
     warnFallback('getContextDocuments', err);
     return [];

--- a/src/lib/context-documents.test.ts
+++ b/src/lib/context-documents.test.ts
@@ -1,0 +1,42 @@
+import { parseContextDocuments } from './context-documents';
+
+describe('context documents', () => {
+  it('accepts MCP-sourced documents', () => {
+    expect(
+      parseContextDocuments([
+        {
+          id: 'doc-1',
+          title: 'MCP Context',
+          content: '# Summary',
+          type: 'markdown',
+          timestamp: 123,
+          source: 'mcp',
+        },
+      ]),
+    ).toEqual([
+      {
+        id: 'doc-1',
+        title: 'MCP Context',
+        content: '# Summary',
+        type: 'markdown',
+        timestamp: 123,
+        source: 'mcp',
+      },
+    ]);
+  });
+
+  it('rejects invalid document sources', () => {
+    expect(
+      parseContextDocuments([
+        {
+          id: 'doc-1',
+          title: 'Invalid',
+          content: 'x',
+          type: 'text',
+          timestamp: 123,
+          source: 'email',
+        },
+      ]),
+    ).toEqual([]);
+  });
+});

--- a/src/lib/context-documents.ts
+++ b/src/lib/context-documents.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+
+export const contextDocumentSourceSchema = z.enum(['file', 'paste', 'mcp']);
+
+export const contextDocumentSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  content: z.string(),
+  type: z.enum(['markdown', 'text']),
+  timestamp: z.number(),
+  source: contextDocumentSourceSchema,
+});
+
+export const contextDocumentsSchema = z.array(contextDocumentSchema);
+
+export type ContextDocument = z.infer<typeof contextDocumentSchema>;
+
+export function parseContextDocuments(input: unknown): ContextDocument[] {
+  if (!Array.isArray(input)) return [];
+  return input.flatMap((value) => {
+    const parsed = contextDocumentSchema.safeParse(value);
+    return parsed.success ? [parsed.data] : [];
+  });
+}

--- a/src/lib/stores/context-store.tsx
+++ b/src/lib/stores/context-store.tsx
@@ -1,6 +1,10 @@
 'use client';
 
 import {
+    parseContextDocuments,
+    type ContextDocument,
+} from '@/lib/context-documents';
+import {
     createContext,
     useContext,
     useReducer,
@@ -10,18 +14,7 @@ import {
     type ReactNode,
 } from 'react';
 
-// =============================================================================
-// Types
-// =============================================================================
-
-export interface ContextDocument {
-    id: string;
-    title: string;
-    content: string;
-    type: 'markdown' | 'text';
-    timestamp: number;
-    source: 'file' | 'paste' | 'mcp';
-}
+export type { ContextDocument } from '@/lib/context-documents';
 
 interface ContextState {
     documents: ContextDocument[];
@@ -172,9 +165,10 @@ export function ContextProvider({ children, sessionId }: ContextProviderProps) {
                 const res = await fetch(`/api/session/context?sessionId=${sessionId}`);
                 if (res.ok) {
                     const data = await res.json();
-                    if (Array.isArray(data.contextDocuments) && data.contextDocuments.length > 0) {
-                        dispatch({ type: 'SET_ALL', payload: data.contextDocuments });
-                        lastSyncedRef.current = JSON.stringify(data.contextDocuments);
+                    if (Array.isArray(data.contextDocuments)) {
+                        const documents = parseContextDocuments(data.contextDocuments);
+                        dispatch({ type: 'SET_ALL', payload: documents });
+                        lastSyncedRef.current = JSON.stringify(documents);
                     }
                 }
             } catch {
@@ -186,8 +180,9 @@ export function ContextProvider({ children, sessionId }: ContextProviderProps) {
     // Listen for ContextFeeder DOM events
     useEffect(() => {
         const handleDocumentAdded = (e: CustomEvent) => {
-            if (e.detail) {
-                dispatch({ type: 'ADD_DOCUMENT', payload: e.detail });
+            const [document] = parseContextDocuments(e.detail ? [e.detail] : []);
+            if (document) {
+                dispatch({ type: 'ADD_DOCUMENT', payload: document });
             }
         };
 
@@ -202,8 +197,9 @@ export function ContextProvider({ children, sessionId }: ContextProviderProps) {
         };
 
         const handleDocumentsUpdated = (e: CustomEvent) => {
-            if (e.detail?.documents && Array.isArray(e.detail.documents)) {
-                dispatch({ type: 'SET_ALL', payload: e.detail.documents });
+            const documents = parseContextDocuments(e.detail?.documents);
+            if (documents.length > 0 || Array.isArray(e.detail?.documents)) {
+                dispatch({ type: 'SET_ALL', payload: documents });
             }
         };
 


### PR DESCRIPTION
## Summary

This PR consolidates the `ContextDocument` contract into one shared schema and fixes a real source mismatch: `origin/main` can emit MCP-sourced context documents, but parts of the repo still only declare `'file' | 'paste'` as valid sources.

## Issue And User Impact

The mismatch exists on `origin/main` today:

- `src/components/ui/mcp/mcp-app-widget.tsx` emits `source: 'mcp'`
- `src/components/ui/documents/context-feeder.tsx` still declares `source: z.enum(['file', 'paste'])`
- `src/lib/agents/shared/supabase-context.ts` still types stored context docs as `source: 'file' | 'paste'`

That drift means a legitimate document source is outside part of the repo's declared contract. It invites silent casts, inconsistent validation, and prompt/context readers that no longer match what the UI can actually produce.

## Root Cause

`ContextDocument` was defined independently in multiple places. The client store had already grown to include `'mcp'`, but the widget schema and steward-side type had not been updated with the same source enum, so the contract diverged across the app.

## Why This Fix Solves The Root Cause

The fix removes the duplicate source-of-truth problem:

- a new shared schema/type in `src/lib/context-documents.ts` defines the contract once
- `context-feeder`, `context-store`, the session context API, and steward-side Supabase readers now use the shared contract
- GET/read paths sanitize stored rows through the shared parser
- POST/write paths reject invalid entries instead of persisting drift back into `sessions.context_documents`
- the client initial-load path now clears stale documents even when server sanitization reduces the source of truth to `[]`

## What Changed

### Shared contract

- added `src/lib/context-documents.ts`
- added `src/lib/context-documents.test.ts`
- shared schema now explicitly allows `source: 'mcp'`

### Client/store surfaces

- `src/components/ui/documents/context-feeder.tsx` now imports the shared schema/type instead of maintaining a duplicate enum
- `src/lib/stores/context-store.tsx` now parses API/event payloads with the shared parser and keeps initial load aligned with sanitized server state

### Server/steward surfaces

- `src/app/api/session/context/route.ts` sanitizes GET responses and rejects invalid POST payload entries
- `src/app/api/session/context/route.test.ts` covers GET sanitization and POST rejection
- `src/lib/agents/shared/supabase-context.ts` now reads context docs via the shared parser instead of a blind cast

## Backward Compatibility

This is backward compatible for valid stored documents and corrects behavior for invalid ones.

- Valid `file`, `paste`, and `mcp` documents continue to work
- Invalid stored rows are filtered out on read instead of leaking through as unchecked JSON
- Invalid write payloads now fail fast with `400`
- No schema migration is required

## Validation

Ran locally in `/Users/bsteinher/.codex/worktrees/present-cleanup-wave3`:

- `npx jest src/lib/context-documents.test.ts src/app/api/session/context/route.test.ts --runInBand`
- `npm run typecheck:app`
- `git diff --check`

Additional build gate:

- `npm run build` is still blocked in the current repo setup by unrelated missing-module failures under reset/codex package paths:
  - `packages/ui/src/reset-monaco-editor.tsx` missing `@monaco-editor/react`, `y-protocols/awareness`, `yjs`, `y-monaco`
  - `services/codex-adapter/src/sdk.ts` missing `@openai/codex-sdk`

These errors are outside this diff.

## Reviewer Passes

Independent review lanes after the final fix wave:

- `reviewer_correctness`: found and then cleared one stale-client-state issue on initial load; no remaining findings
- `reviewer_maintainability`: no findings

## Remaining Risks

- Stored invalid context rows are now filtered on read. That is the intended cleanup behavior, but if someone was relying on malformed rows surfacing unchanged in the UI or steward prompt path, this PR will expose that inconsistency instead of preserving it.
