### PR TITLE
[codex] share model key provider config

### DIFF
--- a/src/app/api/provider-links/route.test.ts
+++ b/src/app/api/provider-links/route.test.ts
@@ -1,0 +1,58 @@
+/**
+ * @jest-environment node
+ */
+
+const resolveRequestUserIdMock = jest.fn();
+const listUserModelKeyStatusMock = jest.fn();
+
+jest.mock('@/lib/supabase/server/resolve-request-user', () => ({
+  resolveRequestUserId: resolveRequestUserIdMock,
+}));
+
+jest.mock('@/lib/agents/shared/user-model-keys', () => ({
+  ...jest.requireActual('@/lib/agents/shared/user-model-keys'),
+  listUserModelKeyStatus: listUserModelKeyStatusMock,
+}));
+
+const loadGet = async () => {
+  let GET: ((req: import('next/server').NextRequest) => Promise<Response>) | null = null;
+  await jest.isolateModulesAsync(async () => {
+    const route = await import('./route');
+    GET = route.GET;
+  });
+  return GET as (req: import('next/server').NextRequest) => Promise<Response>;
+};
+
+describe('/api/provider-links', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    resolveRequestUserIdMock.mockReset();
+    listUserModelKeyStatusMock.mockReset();
+  });
+
+  it('returns link state for every shared model-key provider', async () => {
+    resolveRequestUserIdMock.mockResolvedValue('user-1');
+    listUserModelKeyStatusMock.mockResolvedValue([
+      { provider: 'openai', configured: true, last4: '1234' },
+      { provider: 'fal', configured: true, last4: '9876' },
+    ]);
+
+    const GET = await loadGet();
+    const response = await GET({
+      nextUrl: new URL('http://localhost/api/provider-links'),
+    } as import('next/server').NextRequest);
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.ok).toBe(true);
+    expect(json.links).toEqual([
+      { provider: 'openai', state: 'api_key_configured', apiKeyConfigured: true, linked: false },
+      { provider: 'anthropic', state: 'missing', apiKeyConfigured: false, linked: false },
+      { provider: 'google', state: 'missing', apiKeyConfigured: false, linked: false },
+      { provider: 'together', state: 'missing', apiKeyConfigured: false, linked: false },
+      { provider: 'cerebras', state: 'missing', apiKeyConfigured: false, linked: false },
+      { provider: 'fal', state: 'api_key_configured', apiKeyConfigured: true, linked: false },
+      { provider: 'xai', state: 'missing', apiKeyConfigured: false, linked: false },
+    ]);
+  });
+});

--- a/src/app/api/provider-links/route.ts
+++ b/src/app/api/provider-links/route.ts
@@ -1,12 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
+import {
+  listUserModelKeyStatus,
+  MODEL_KEY_PROVIDERS,
+} from '@/lib/agents/shared/user-model-keys';
 import { resolveRequestUserId } from '@/lib/supabase/server/resolve-request-user';
-import { listUserModelKeyStatus } from '@/lib/agents/shared/user-model-keys';
 
 export const runtime = 'nodejs';
 
 type ProviderLinkState = 'linked_supported' | 'linked_unsupported' | 'api_key_configured' | 'missing';
-
-const PROVIDERS = ['openai', 'anthropic', 'google', 'together', 'cerebras', 'fal', 'xai'] as const;
 
 export async function GET(req: NextRequest) {
   const userId = await resolveRequestUserId(req);
@@ -17,7 +18,7 @@ export async function GET(req: NextRequest) {
   try {
     const keyStatuses = await listUserModelKeyStatus(userId);
     const byProvider = new Map(keyStatuses.map((entry) => [entry.provider, entry]));
-    const links = PROVIDERS.map((provider) => {
+    const links = MODEL_KEY_PROVIDERS.map((provider) => {
       const keyStatus = byProvider.get(provider);
       const state: ProviderLinkState = keyStatus?.configured ? 'api_key_configured' : 'missing';
       return {

--- a/src/app/settings/keys/page.tsx
+++ b/src/app/settings/keys/page.tsx
@@ -3,22 +3,25 @@
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { ModelKeyProvider } from '@/lib/agents/shared/user-model-keys';
+import {
+  buildProviderStateMap,
+  MODEL_KEY_PROVIDER_CONFIGS,
+} from '@/lib/model-key-provider-config';
 import { useAuth } from '@/hooks/use-auth';
 import { fetchWithSupabaseAuth } from '@/lib/supabase/auth-headers';
 import { buildAuthPageHref, getCurrentPathWithSearchAndHash } from '@/lib/auth/redirects';
 import { getBooleanFlag } from '@/lib/feature-flags';
 
-type ProviderId = 'openai' | 'anthropic' | 'google' | 'together' | 'cerebras' | 'fal' | 'xai';
-
 type ProviderStatus = {
-  provider: ProviderId;
+  provider: ModelKeyProvider;
   configured: boolean;
   last4?: string;
   updatedAt?: string;
 };
 
 type ProviderLinkState = {
-  provider: ProviderId;
+  provider: ModelKeyProvider;
   state: 'linked_supported' | 'linked_unsupported' | 'api_key_configured' | 'missing';
   linked: boolean;
   apiKeyConfigured: boolean;
@@ -36,100 +39,24 @@ const getErrorMessage = (error: unknown, fallback: string): string => {
 const formatProviderLinkState = (state: ProviderLinkState['state']): string =>
   state.replaceAll('_', ' ');
 
-const PROVIDERS: Array<{
-  id: ProviderId;
-  label: string;
-  required: boolean;
-  helpUrl: string;
-  note: string;
-}> = [
-  {
-    id: 'openai',
-    label: 'OpenAI',
-    required: true,
-    helpUrl: 'https://platform.openai.com/api-keys',
-    note: 'Required for voice + most stewards.',
-  },
-  {
-    id: 'anthropic',
-    label: 'Anthropic',
-    required: false,
-    helpUrl: 'https://console.anthropic.com/settings/keys',
-    note: 'Optional (Claude models).',
-  },
-  {
-    id: 'google',
-    label: 'Google (Gemini)',
-    required: false,
-    helpUrl: 'https://aistudio.google.com/app/apikey',
-    note: 'Optional (Gemini image model / AI Studio).',
-  },
-  {
-    id: 'together',
-    label: 'Together AI',
-    required: false,
-    helpUrl: 'https://api.together.ai/settings/api-keys',
-    note: 'Optional legacy provider for older routing paths. Not used by the current image widget.',
-  },
-  {
-    id: 'fal',
-    label: 'fal',
-    required: false,
-    helpUrl: 'https://fal.ai/dashboard/keys',
-    note: 'Optional (FLUX.2 Flash image generation).',
-  },
-  {
-    id: 'xai',
-    label: 'xAI',
-    required: false,
-    helpUrl: 'https://console.x.ai/',
-    note: 'Optional (Grok image generation).',
-  },
-  {
-    id: 'cerebras',
-    label: 'Cerebras',
-    required: false,
-    helpUrl: 'https://cloud.cerebras.ai/',
-    note: 'Optional (FAST stewards + router).',
-  },
-];
-
 export default function ModelKeysPage() {
   const { user, loading } = useAuth();
   const router = useRouter();
 
   const [statuses, setStatuses] = useState<ProviderStatus[] | null>(null);
-  const [drafts, setDrafts] = useState<Record<ProviderId, string>>({
-    openai: '',
-    anthropic: '',
-    google: '',
-    together: '',
-    cerebras: '',
-    fal: '',
-    xai: '',
-  });
-  const [busy, setBusy] = useState<Record<ProviderId, boolean>>({
-    openai: false,
-    anthropic: false,
-    google: false,
-    together: false,
-    cerebras: false,
-    fal: false,
-    xai: false,
-  });
+  const [drafts, setDrafts] = useState<Record<ModelKeyProvider, string>>(() =>
+    buildProviderStateMap(() => ''),
+  );
+  const [busy, setBusy] = useState<Record<ModelKeyProvider, boolean>>(() =>
+    buildProviderStateMap(() => false),
+  );
   const [error, setError] = useState<string | null>(null);
-  const [providerLinks, setProviderLinks] = useState<Record<ProviderId, ProviderLinkState | undefined>>({
-    openai: undefined,
-    anthropic: undefined,
-    google: undefined,
-    together: undefined,
-    cerebras: undefined,
-    fal: undefined,
-    xai: undefined,
-  });
+  const [providerLinks, setProviderLinks] = useState<
+    Record<ModelKeyProvider, ProviderLinkState | undefined>
+  >(() => buildProviderStateMap(() => undefined));
 
   const statusByProvider = useMemo(() => {
-    const map = new Map<ProviderId, ProviderStatus>();
+    const map = new Map<ModelKeyProvider, ProviderStatus>();
     (statuses || []).forEach((s) => map.set(s.provider, s));
     return map;
   }, [statuses]);
@@ -159,15 +86,7 @@ export default function ModelKeysPage() {
         if (linksRes.ok) {
           const linksJson = await linksRes.json();
           const links = Array.isArray(linksJson?.links) ? (linksJson.links as ProviderLinkState[]) : [];
-          const linkMap: Record<ProviderId, ProviderLinkState | undefined> = {
-            openai: undefined,
-            anthropic: undefined,
-            google: undefined,
-            together: undefined,
-            cerebras: undefined,
-            fal: undefined,
-            xai: undefined,
-          };
+          const linkMap = buildProviderStateMap<ProviderLinkState | undefined>(() => undefined);
           for (const link of links) {
             if (link?.provider && link.provider in linkMap) {
               linkMap[link.provider] = link;
@@ -190,12 +109,12 @@ export default function ModelKeysPage() {
     void refresh();
   }, [user, refresh]);
 
-  const setDraft = useCallback((provider: ProviderId, value: string) => {
+  const setDraft = useCallback((provider: ModelKeyProvider, value: string) => {
     setDrafts((prev) => ({ ...prev, [provider]: value }));
   }, []);
 
   const save = useCallback(
-    async (provider: ProviderId) => {
+    async (provider: ModelKeyProvider) => {
       const apiKey = drafts[provider].trim();
       if (!apiKey) return;
       setError(null);
@@ -222,7 +141,7 @@ export default function ModelKeysPage() {
   );
 
   const clear = useCallback(
-    async (provider: ProviderId) => {
+    async (provider: ModelKeyProvider) => {
       setError(null);
       setBusy((prev) => ({ ...prev, [provider]: true }));
       try {
@@ -301,7 +220,7 @@ export default function ModelKeysPage() {
 
         <div className="mt-6 bg-white rounded-lg shadow-sm border border-slate-200 overflow-hidden">
           <div className="divide-y divide-slate-200">
-            {PROVIDERS.map((p) => {
+            {MODEL_KEY_PROVIDER_CONFIGS.map((p) => {
               const status = statusByProvider.get(p.id);
               const configured = status?.configured === true;
               const last4 = status?.last4 ? `••••${status.last4}` : '';

--- a/src/lib/model-key-provider-config.test.ts
+++ b/src/lib/model-key-provider-config.test.ts
@@ -1,0 +1,25 @@
+import { MODEL_KEY_PROVIDERS } from '@/lib/agents/shared/user-model-keys';
+import {
+  buildProviderStateMap,
+  MODEL_KEY_PROVIDER_CONFIGS,
+  MODEL_KEY_PROVIDER_UI_ORDER,
+} from './model-key-provider-config';
+
+describe('model-key-provider-config', () => {
+  it('covers every model-key provider in the state-map helper', () => {
+    const map = buildProviderStateMap((provider) => provider.toUpperCase());
+    expect(Object.keys(map).sort()).toEqual([...MODEL_KEY_PROVIDERS].sort());
+    expect(map.fal).toBe('FAL');
+    expect(map.xai).toBe('XAI');
+  });
+
+  it('keeps UI configs aligned with the declared UI order', () => {
+    expect(MODEL_KEY_PROVIDER_CONFIGS.map((provider) => provider.id)).toEqual(
+      MODEL_KEY_PROVIDER_UI_ORDER,
+    );
+  });
+
+  it('keeps the UI order in sync with the shared provider set', () => {
+    expect([...MODEL_KEY_PROVIDER_UI_ORDER].sort()).toEqual([...MODEL_KEY_PROVIDERS].sort());
+  });
+});

--- a/src/lib/model-key-provider-config.ts
+++ b/src/lib/model-key-provider-config.ts
@@ -1,0 +1,92 @@
+import {
+  MODEL_KEY_PROVIDERS,
+  type ModelKeyProvider,
+} from '@/lib/agents/shared/user-model-keys';
+
+export type ModelKeyProviderConfig = {
+  id: ModelKeyProvider;
+  label: string;
+  required: boolean;
+  helpUrl: string;
+  note: string;
+};
+
+const providerConfigById: Record<ModelKeyProvider, Omit<ModelKeyProviderConfig, 'id'>> = {
+  openai: {
+    label: 'OpenAI',
+    required: true,
+    helpUrl: 'https://platform.openai.com/api-keys',
+    note: 'Required for voice + most stewards.',
+  },
+  anthropic: {
+    label: 'Anthropic',
+    required: false,
+    helpUrl: 'https://console.anthropic.com/settings/keys',
+    note: 'Optional (Claude models).',
+  },
+  google: {
+    label: 'Google (Gemini)',
+    required: false,
+    helpUrl: 'https://aistudio.google.com/app/apikey',
+    note: 'Optional (Gemini image model / AI Studio).',
+  },
+  together: {
+    label: 'Together AI',
+    required: false,
+    helpUrl: 'https://api.together.ai/settings/api-keys',
+    note: 'Optional legacy provider for older routing paths. Not used by the current image widget.',
+  },
+  cerebras: {
+    label: 'Cerebras',
+    required: false,
+    helpUrl: 'https://cloud.cerebras.ai/',
+    note: 'Optional (FAST stewards + router).',
+  },
+  fal: {
+    label: 'fal',
+    required: false,
+    helpUrl: 'https://fal.ai/dashboard/keys',
+    note: 'Optional (FLUX.2 Flash image generation).',
+  },
+  xai: {
+    label: 'xAI',
+    required: false,
+    helpUrl: 'https://console.x.ai/',
+    note: 'Optional (Grok image generation).',
+  },
+};
+
+const providerUiPriority: Partial<Record<ModelKeyProvider, number>> = {
+  openai: 0,
+  anthropic: 1,
+  google: 2,
+  together: 3,
+  fal: 4,
+  xai: 5,
+  cerebras: 6,
+};
+
+export const MODEL_KEY_PROVIDER_UI_ORDER: ModelKeyProvider[] = [...MODEL_KEY_PROVIDERS].sort(
+  (left, right) =>
+    (providerUiPriority[left] ?? Number.MAX_SAFE_INTEGER) -
+      (providerUiPriority[right] ?? Number.MAX_SAFE_INTEGER) ||
+    left.localeCompare(right),
+);
+
+export const MODEL_KEY_PROVIDER_CONFIGS: ModelKeyProviderConfig[] =
+  MODEL_KEY_PROVIDER_UI_ORDER.map((id) => ({
+    id,
+    ...providerConfigById[id],
+  }));
+
+export function buildProviderStateMap<T>(
+  factory: (provider: ModelKeyProvider) => T,
+): Record<ModelKeyProvider, T> {
+  return MODEL_KEY_PROVIDERS.reduce(
+    (acc, provider) => {
+      acc[provider] = factory(provider);
+      return acc;
+    },
+    {} as Record<ModelKeyProvider, T>,
+  );
+}


### PR DESCRIPTION
## Summary

This PR removes duplicated model-key provider contract definitions from the settings UI and provider-links API surface by centralizing provider metadata and provider-derived state helpers.

## Issue And User Impact

`origin/main` currently repeats the same provider contract in multiple places:

- `src/app/settings/keys/page.tsx` declares a local `ProviderId` union
- the same page hardcodes provider metadata in `PROVIDERS`
- the same page hardcodes three separate per-provider state objects for `drafts`, `busy`, and `providerLinks`
- `src/app/api/provider-links/route.ts` hardcodes another provider list for the same API-key-backed surfaces

This is active maintenance risk. Any provider add/remove/rename requires synchronized edits across multiple unrelated literals, and one missed update silently drops a provider from part of the UI or API surface.

## Root Cause

The model-key provider contract already exists in `src/lib/agents/shared/user-model-keys.ts`, but higher-level UI/API surfaces were still re-declaring it instead of consuming the shared source of truth.

## Why This Fix Solves The Root Cause

The fix moves provider-specific UI metadata and provider-derived state initialization behind a shared config module:

- `src/lib/model-key-provider-config.ts` now owns provider UI metadata and shared state-map construction
- the settings page now uses `ModelKeyProvider` directly instead of a local union
- repeated `drafts`, `busy`, and `providerLinks` initializer objects are derived from the shared provider set
- the provider-links route now uses `MODEL_KEY_PROVIDERS` directly instead of a second hardcoded array
- tests now assert both helper coverage and route behavior against the shared provider contract

That removes the manual copy-update burden and makes future provider changes converge on one contract.

## What Changed

### Shared config

- added `src/lib/model-key-provider-config.ts`
- added `src/lib/model-key-provider-config.test.ts`
- derived UI ordering from the shared provider set with an explicit priority map

### Settings UI

- `src/app/settings/keys/page.tsx` now imports `ModelKeyProvider`
- provider metadata comes from `MODEL_KEY_PROVIDER_CONFIGS`
- per-provider state maps are generated with `buildProviderStateMap()` instead of three repeated object literals

### Provider-links API

- `src/app/api/provider-links/route.ts` now reads `MODEL_KEY_PROVIDERS`
- added `src/app/api/provider-links/route.test.ts` to verify the route returns every shared provider and maps configured key state correctly

## Backward Compatibility

Behavior is unchanged for users.

- No provider IDs changed
- No API response fields changed
- No storage format changed
- This is a maintenance/contract cleanup that preserves existing behavior while reducing drift risk

## Validation

Ran locally in `/Users/bsteinher/.codex/worktrees/present-cleanup-wave4`:

- `npx jest src/lib/model-key-provider-config.test.ts src/app/api/provider-links/route.test.ts --runInBand`
- `npm run typecheck:app`
- `git diff --check`

Additional build gate:

- `npm run build` is still blocked in the current repo setup by unrelated missing-module failures under reset/codex package paths:
  - `packages/ui/src/reset-monaco-editor.tsx` missing `@monaco-editor/react`, `y-protocols/awareness`, `yjs`, `y-monaco`
  - `services/codex-adapter/src/sdk.ts` missing `@openai/codex-sdk`

These errors are outside this diff.

## Reviewer Passes

Independent review lanes after the final fix wave:

- `reviewer_correctness`: no findings
- `reviewer_maintainability`: initially flagged remaining duplicate-order/test drift; both addressed; no remaining findings

## Remaining Risks

- This PR deliberately preserves current provider ordering in the settings UI through a priority map. Future provider additions will now appear deterministically even if no explicit priority is added, but a follow-up may still be useful if product wants a different default placement for new providers.
