### PR TITLE
[codex] share admin provider presentation config

### DIFF
--- a/src/app/admin/agents/page.tsx
+++ b/src/app/admin/agents/page.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { AgentOpsOverview } from '@/components/admin/agent-ops-overview';
 import { AgentQueueTable } from '@/components/admin/agent-queue-table';
+import { AGENT_PROVIDER_FILTER_OPTIONS } from '@/components/admin/provider-presentation';
 import { AgentTraceTimeline } from '@/components/admin/agent-trace-timeline';
 import { AgentVoiceSessionTable } from '@/components/admin/agent-voice-session-table';
 import { AgentWorkerHealth } from '@/components/admin/agent-worker-health';
@@ -27,17 +28,6 @@ import type {
 
 const LIST_POLL_MS = 15_000;
 const TRACE_CONTEXT_PAGE_LIMIT = 200;
-const PROVIDER_FILTER_OPTIONS: Array<{ value: AgentProvider; label: string }> = [
-  { value: 'openai', label: 'OpenAI' },
-  { value: 'anthropic', label: 'Anthropic' },
-  { value: 'google', label: 'Google' },
-  { value: 'cerebras', label: 'Cerebras' },
-  { value: 'together', label: 'Together' },
-  { value: 'fal', label: 'fal' },
-  { value: 'xai', label: 'xAI' },
-  { value: 'debug', label: 'Debug' },
-  { value: 'unknown', label: 'Unknown' },
-];
 const PROVIDER_PATH_FILTER_OPTIONS: Array<{ value: AgentProviderPath; label: string }> = [
   { value: 'primary', label: 'Primary' },
   { value: 'fallback', label: 'Fallback' },
@@ -595,7 +585,7 @@ export default function AgentAdminPage() {
                 className="rounded border border-slate-300 bg-white px-2 py-1 text-sm text-slate-900 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
               >
                 <option value="">All providers</option>
-                {PROVIDER_FILTER_OPTIONS.map((option) => (
+                {AGENT_PROVIDER_FILTER_OPTIONS.map((option) => (
                   <option key={option.value} value={option.value}>
                     {option.label}
                   </option>

--- a/src/components/admin/agent-ops-overview.tsx
+++ b/src/components/admin/agent-ops-overview.tsx
@@ -1,5 +1,9 @@
 'use client';
 
+import {
+  AGENT_PROVIDER_LABELS,
+  sortAgentProviderEntries,
+} from './provider-presentation';
 import type { AgentOverviewResponse } from './types';
 
 const QUEUE_STATUS_LABELS: Record<string, string> = {
@@ -8,18 +12,6 @@ const QUEUE_STATUS_LABELS: Record<string, string> = {
   failed: 'Failed Tasks',
   succeeded: 'Succeeded Tasks',
   canceled: 'Canceled Tasks',
-};
-
-const PROVIDER_LABELS: Record<string, string> = {
-  openai: 'OpenAI',
-  anthropic: 'Anthropic',
-  google: 'Google',
-  cerebras: 'Cerebras',
-  together: 'Together',
-  fal: 'fal',
-  xai: 'xAI',
-  debug: 'Debug',
-  unknown: 'Unknown',
 };
 
 const formatDuration = (durationMs: number | null | undefined): string => {
@@ -49,14 +41,10 @@ export function AgentOpsOverview({ overview }: { overview: AgentOverviewResponse
     const order = ['queued', 'running', 'failed', 'succeeded', 'canceled'];
     return order.indexOf(left) - order.indexOf(right);
   });
-  const providerMixEntries = Object.entries(overview.providerMix || {}).sort(([left], [right]) => {
-    const order = ['openai', 'anthropic', 'google', 'cerebras', 'together', 'fal', 'xai', 'debug', 'unknown'];
-    return order.indexOf(left) - order.indexOf(right);
-  });
-  const providerFailureEntries = Object.entries(overview.providerFailures || {}).sort(([left], [right]) => {
-    const order = ['openai', 'anthropic', 'google', 'cerebras', 'together', 'fal', 'xai', 'debug', 'unknown'];
-    return order.indexOf(left) - order.indexOf(right);
-  });
+  const providerMixEntries = sortAgentProviderEntries(Object.entries(overview.providerMix || {}));
+  const providerFailureEntries = sortAgentProviderEntries(
+    Object.entries(overview.providerFailures || {}),
+  );
 
   return (
     <section className="rounded border border-[#cbd5e1] bg-[#ffffff] p-4">
@@ -91,7 +79,9 @@ export function AgentOpsOverview({ overview }: { overview: AgentOverviewResponse
             <div className="mt-2 grid grid-cols-2 gap-2 text-xs">
               {providerMixEntries.map(([provider, count]) => (
                 <div key={`mix-${provider}`} className="rounded border border-[#dbe3ed] bg-white px-2 py-1">
-                  <span className="text-[#334155]">{PROVIDER_LABELS[provider] ?? provider}</span>
+                  <span className="text-[#334155]">
+                    {AGENT_PROVIDER_LABELS[provider as keyof typeof AGENT_PROVIDER_LABELS] ?? provider}
+                  </span>
                   <span className="ml-2 font-semibold text-[#111827]">{count}</span>
                 </div>
               ))}
@@ -102,7 +92,9 @@ export function AgentOpsOverview({ overview }: { overview: AgentOverviewResponse
             <div className="mt-2 grid grid-cols-2 gap-2 text-xs">
               {providerFailureEntries.map(([provider, count]) => (
                 <div key={`failure-${provider}`} className="rounded border border-[#dbe3ed] bg-white px-2 py-1">
-                  <span className="text-[#334155]">{PROVIDER_LABELS[provider] ?? provider}</span>
+                  <span className="text-[#334155]">
+                    {AGENT_PROVIDER_LABELS[provider as keyof typeof AGENT_PROVIDER_LABELS] ?? provider}
+                  </span>
                   <span className="ml-2 font-semibold text-[#111827]">{count}</span>
                 </div>
               ))}

--- a/src/components/admin/provider-presentation.test.ts
+++ b/src/components/admin/provider-presentation.test.ts
@@ -1,0 +1,41 @@
+import {
+  AGENT_PROVIDER_FILTER_OPTIONS,
+  AGENT_PROVIDER_LABELS,
+  AGENT_PROVIDER_ORDER,
+  sortAgentProviderEntries,
+} from './provider-presentation';
+
+describe('provider-presentation', () => {
+  it('keeps filter options aligned with provider order and labels', () => {
+    expect(AGENT_PROVIDER_FILTER_OPTIONS).toEqual(
+      AGENT_PROVIDER_ORDER.map((provider) => ({
+        value: provider,
+        label: AGENT_PROVIDER_LABELS[provider],
+      })),
+    );
+  });
+
+  it('sorts provider entries by the shared provider order', () => {
+    expect(
+      sortAgentProviderEntries([
+        ['xai', 1],
+        ['openai', 2],
+        ['fal', 3],
+        ['unknown-provider', 4],
+        ['anthropic', 5],
+      ]),
+    ).toEqual([
+      ['openai', 2],
+      ['anthropic', 5],
+      ['fal', 3],
+      ['xai', 1],
+      ['unknown-provider', 4],
+    ]);
+  });
+
+  it('covers every known provider in the shared order', () => {
+    expect([...AGENT_PROVIDER_ORDER].sort()).toEqual(
+      Object.keys(AGENT_PROVIDER_LABELS).sort(),
+    );
+  });
+});

--- a/src/components/admin/provider-presentation.ts
+++ b/src/components/admin/provider-presentation.ts
@@ -1,0 +1,46 @@
+import type { AgentProvider } from './types';
+
+export const AGENT_PROVIDER_LABELS: Record<AgentProvider, string> = {
+  openai: 'OpenAI',
+  anthropic: 'Anthropic',
+  google: 'Google',
+  cerebras: 'Cerebras',
+  together: 'Together',
+  fal: 'fal',
+  xai: 'xAI',
+  debug: 'Debug',
+  unknown: 'Unknown',
+};
+
+export const AGENT_PROVIDER_ORDER: AgentProvider[] = [
+  'openai',
+  'anthropic',
+  'google',
+  'cerebras',
+  'together',
+  'fal',
+  'xai',
+  'debug',
+  'unknown',
+];
+
+export const AGENT_PROVIDER_FILTER_OPTIONS: Array<{
+  value: AgentProvider;
+  label: string;
+}> = AGENT_PROVIDER_ORDER.map((provider) => ({
+  value: provider,
+  label: AGENT_PROVIDER_LABELS[provider],
+}));
+
+export function sortAgentProviderEntries<T>(
+  entries: Array<[string, T]>,
+): Array<[string, T]> {
+  return [...entries].sort(([left], [right]) => {
+    const leftIndex = AGENT_PROVIDER_ORDER.indexOf(left as AgentProvider);
+    const rightIndex = AGENT_PROVIDER_ORDER.indexOf(right as AgentProvider);
+    const normalizedLeft = leftIndex === -1 ? Number.MAX_SAFE_INTEGER : leftIndex;
+    const normalizedRight = rightIndex === -1 ? Number.MAX_SAFE_INTEGER : rightIndex;
+    if (normalizedLeft !== normalizedRight) return normalizedLeft - normalizedRight;
+    return left.localeCompare(right);
+  });
+}


### PR DESCRIPTION
## Summary
- centralize admin agent provider labels, ordering, and filter options in a shared presentation module
- reuse the shared provider sort helper in the ops overview cards
- add guard tests so provider order cannot silently drift from the known provider set

## Issue and user impact
The admin agents surfaces duplicated the same provider presentation contract in multiple places. Labels, filter options, and provider ordering lived separately in the admin page and the ops overview, which made routine cleanup risky and created drift potential between what the admin filter exposed and how provider metrics were rendered.

## Root cause
Provider presentation was not treated as a shared contract. The overview component owned local labels plus duplicated sort-order arrays, while the admin page owned a separate provider filter options list.

## Why this fixes the root cause
This moves provider presentation into a single shared module used by both admin surfaces. The overview now sorts provider entries through one helper and renders one shared label map, while the admin page consumes the same shared filter options. The added test also proves the declared provider order still covers the full known provider set, which closes the remaining silent-drift path.

## Changed surfaces
- `src/components/admin/provider-presentation.ts`: shared provider labels, canonical order, filter options, and provider-entry sorter
- `src/components/admin/agent-ops-overview.tsx`: removed duplicated labels and sort-order arrays in favor of the shared module
- `src/app/admin/agents/page.tsx`: removed duplicated provider filter options in favor of the shared module
- `src/components/admin/provider-presentation.test.ts`: added coverage for shared filter alignment, stable sort behavior, and full provider-order coverage

## Backward compatibility
No backend, API, or schema behavior changed. This is a frontend-only admin cleanup that preserves the existing provider labels and ordering contract while centralizing it.

## Validation
- `npx jest src/components/admin/provider-presentation.test.ts src/components/admin/agent-ops-overview.test.tsx --runInBand`
- `npm run typecheck:app`
- `git diff --check`
- `npm run build` still fails on the same unrelated repo-level missing-package blocker outside this diff:
  - `packages/ui/src/reset-monaco-editor.tsx`: `@monaco-editor/react`, `y-protocols/awareness`, `yjs`, `y-monaco`
  - `services/codex-adapter/src/sdk.ts`: `@openai/codex-sdk`

## Reviewer passes
- `reviewer_correctness`: found one real regression during review (`PROVIDER_FILTER_OPTIONS` stale reference in the admin page). Fixed and reran gates; final pass reported no findings remain.
- `reviewer_maintainability`: asked for a guard against provider-order drift. Added an explicit coverage test; final pass reported no findings.
