### PR TITLE
[codex] share admin provider contract

### DIFF
--- a/src/components/admin/types.ts
+++ b/src/components/admin/types.ts
@@ -1,30 +1,10 @@
-export type AgentProvider =
-  | 'openai'
-  | 'anthropic'
-  | 'google'
-  | 'cerebras'
-  | 'together'
-  | 'fal'
-  | 'xai'
-  | 'debug'
-  | 'unknown';
+import type {
+  AgentProvider,
+  AgentProviderPath,
+  AgentProviderSource,
+} from '@/lib/agents/admin/provider-contract';
 
-export type AgentProviderSource =
-  | 'explicit'
-  | 'model_inferred'
-  | 'runtime_selected'
-  | 'task_params'
-  | 'payload'
-  | 'unknown';
-
-export type AgentProviderPath =
-  | 'primary'
-  | 'fallback'
-  | 'fast'
-  | 'slow'
-  | 'shadow'
-  | 'teacher'
-  | 'unknown';
+export type { AgentProvider, AgentProviderPath, AgentProviderSource };
 
 export type AgentProviderSummary = {
   provider: AgentProvider;

--- a/src/lib/agents/admin/provider-contract.ts
+++ b/src/lib/agents/admin/provider-contract.ts
@@ -1,0 +1,36 @@
+export const AGENT_PROVIDER_VALUES = [
+  'openai',
+  'anthropic',
+  'google',
+  'cerebras',
+  'together',
+  'fal',
+  'xai',
+  'debug',
+  'unknown',
+] as const;
+
+export type AgentProvider = (typeof AGENT_PROVIDER_VALUES)[number];
+
+export const AGENT_PROVIDER_SOURCE_VALUES = [
+  'explicit',
+  'model_inferred',
+  'runtime_selected',
+  'task_params',
+  'payload',
+  'unknown',
+] as const;
+
+export type AgentProviderSource = (typeof AGENT_PROVIDER_SOURCE_VALUES)[number];
+
+export const AGENT_PROVIDER_PATH_VALUES = [
+  'primary',
+  'fallback',
+  'fast',
+  'slow',
+  'shadow',
+  'teacher',
+  'unknown',
+] as const;
+
+export type AgentProviderPath = (typeof AGENT_PROVIDER_PATH_VALUES)[number];

--- a/src/lib/agents/admin/provider-parity.test.ts
+++ b/src/lib/agents/admin/provider-parity.test.ts
@@ -16,6 +16,8 @@ describe('provider-parity', () => {
 
   it('normalizes provider/source/path values', () => {
     expect(normalizeProvider('OpenAI')).toBe('openai');
+    expect(normalizeProvider('fal')).toBe('fal');
+    expect(normalizeProvider('xai')).toBe('xai');
     expect(normalizeProvider('unknown-provider')).toBe('unknown');
     expect(normalizeProviderSource('runtime_selected')).toBe('runtime_selected');
     expect(normalizeProviderSource('bogus')).toBe('unknown');
@@ -29,6 +31,8 @@ describe('provider-parity', () => {
     expect(inferProviderFromModel('claude-3-5-sonnet')).toBe('anthropic');
     expect(inferProviderFromModel('gemini-2.5-pro')).toBe('google');
     expect(inferProviderFromModel('llama-3.3-70b')).toBe('cerebras');
+    expect(inferProviderFromModel('fal:flux-2-flash')).toBe('fal');
+    expect(inferProviderFromModel('grok-imagine-image')).toBe('xai');
     expect(inferProviderFromModel('black-forest-labs/flux-1')).toBe('together');
   });
 
@@ -72,5 +76,14 @@ describe('provider-parity', () => {
 
     process.env.AGENT_ADMIN_PROVIDER_LINK_TEMPLATE_OPENAI = 'notaurl';
     expect(buildProviderLinkUrl('openai', { traceId: 'trace-2' })).toBeNull();
+  });
+
+  it('keeps direct provider values aligned with the shared admin provider contract', async () => {
+    const { AGENT_PROVIDER_VALUES } = await import('./provider-contract');
+
+    expect(AGENT_PROVIDER_VALUES).toContain('fal');
+    expect(AGENT_PROVIDER_VALUES).toContain('xai');
+    expect(normalizeProvider('fal')).toBe('fal');
+    expect(normalizeProvider('xai')).toBe('xai');
   });
 });

--- a/src/lib/agents/admin/provider-parity.ts
+++ b/src/lib/agents/admin/provider-parity.ts
@@ -1,30 +1,13 @@
+import {
+  AGENT_PROVIDER_PATH_VALUES,
+  AGENT_PROVIDER_SOURCE_VALUES,
+  AGENT_PROVIDER_VALUES,
+  type AgentProvider,
+  type AgentProviderPath,
+  type AgentProviderSource,
+} from './provider-contract';
+
 type JsonRecord = Record<string, unknown>;
-
-export type AgentProvider =
-  | 'openai'
-  | 'anthropic'
-  | 'google'
-  | 'cerebras'
-  | 'together'
-  | 'debug'
-  | 'unknown';
-
-export type AgentProviderSource =
-  | 'explicit'
-  | 'model_inferred'
-  | 'runtime_selected'
-  | 'task_params'
-  | 'payload'
-  | 'unknown';
-
-export type AgentProviderPath =
-  | 'primary'
-  | 'fallback'
-  | 'fast'
-  | 'slow'
-  | 'shadow'
-  | 'teacher'
-  | 'unknown';
 
 export type AgentProviderParity = {
   provider: AgentProvider;
@@ -56,36 +39,14 @@ type ProviderLinkContext = {
   taskId?: string | null;
 };
 
-const PROVIDER_VALUES: AgentProvider[] = [
-  'openai',
-  'anthropic',
-  'google',
-  'cerebras',
-  'together',
-  'debug',
-  'unknown',
-];
+type ProviderLinkTemplateProvider =
+  | 'openai'
+  | 'anthropic'
+  | 'cerebras'
+  | 'google'
+  | 'together';
 
-const PROVIDER_SOURCE_VALUES: AgentProviderSource[] = [
-  'explicit',
-  'model_inferred',
-  'runtime_selected',
-  'task_params',
-  'payload',
-  'unknown',
-];
-
-const PROVIDER_PATH_VALUES: AgentProviderPath[] = [
-  'primary',
-  'fallback',
-  'fast',
-  'slow',
-  'shadow',
-  'teacher',
-  'unknown',
-];
-
-const PROVIDER_LINK_TEMPLATE_ENV: Record<Exclude<AgentProvider, 'debug' | 'unknown'>, string> = {
+const PROVIDER_LINK_TEMPLATE_ENV: Record<ProviderLinkTemplateProvider, string> = {
   openai: 'AGENT_ADMIN_PROVIDER_LINK_TEMPLATE_OPENAI',
   anthropic: 'AGENT_ADMIN_PROVIDER_LINK_TEMPLATE_ANTHROPIC',
   cerebras: 'AGENT_ADMIN_PROVIDER_LINK_TEMPLATE_CEREBRAS',
@@ -117,7 +78,7 @@ const readNestedRecord = (record: JsonRecord | null, key: string): JsonRecord | 
 const normalizeProviderInternal = (value: unknown): AgentProvider | null => {
   const normalized = normalizeString(value)?.toLowerCase();
   if (!normalized) return null;
-  if (PROVIDER_VALUES.includes(normalized as AgentProvider)) {
+  if (AGENT_PROVIDER_VALUES.includes(normalized as AgentProvider)) {
     return normalized as AgentProvider;
   }
   if (normalized === 'openai.responses' || normalized === 'openai.chat.completions') return 'openai';
@@ -126,6 +87,23 @@ const normalizeProviderInternal = (value: unknown): AgentProvider | null => {
     return 'google';
   }
   if (normalized.includes('cerebras')) return 'cerebras';
+  if (
+    normalized === 'fal' ||
+    normalized.startsWith('fal:') ||
+    normalized.startsWith('fal-ai/') ||
+    normalized.includes('fal-ai/')
+  ) {
+    return 'fal';
+  }
+  if (
+    normalized === 'xai' ||
+    normalized === 'x.ai' ||
+    normalized.startsWith('xai:') ||
+    normalized.startsWith('x.ai/') ||
+    normalized.startsWith('grok')
+  ) {
+    return 'xai';
+  }
   if (normalized.includes('together')) return 'together';
   if (normalized.includes('debug') || normalized.includes('fake')) return 'debug';
   return null;
@@ -138,7 +116,7 @@ export const normalizeProvider = (value: unknown): AgentProvider => {
 export const normalizeProviderSource = (value: unknown): AgentProviderSource => {
   const normalized = normalizeString(value)?.toLowerCase();
   if (!normalized) return 'unknown';
-  if (PROVIDER_SOURCE_VALUES.includes(normalized as AgentProviderSource)) {
+  if (AGENT_PROVIDER_SOURCE_VALUES.includes(normalized as AgentProviderSource)) {
     return normalized as AgentProviderSource;
   }
   return 'unknown';
@@ -147,7 +125,7 @@ export const normalizeProviderSource = (value: unknown): AgentProviderSource => 
 export const normalizeProviderPath = (value: unknown): AgentProviderPath => {
   const normalized = normalizeString(value)?.toLowerCase();
   if (!normalized) return 'unknown';
-  if (PROVIDER_PATH_VALUES.includes(normalized as AgentProviderPath)) {
+  if (AGENT_PROVIDER_PATH_VALUES.includes(normalized as AgentProviderPath)) {
     return normalized as AgentProviderPath;
   }
   return 'unknown';
@@ -169,6 +147,22 @@ export const inferProviderFromModel = (value: unknown): AgentProvider | null => 
   }
   if (withoutPrefix.startsWith('claude')) return 'anthropic';
   if (withoutPrefix.startsWith('gemini')) return 'google';
+  if (
+    normalized.startsWith('fal:') ||
+    normalized.startsWith('fal-ai/') ||
+    withoutPrefix.startsWith('fal:') ||
+    withoutPrefix.startsWith('fal-ai/')
+  ) {
+    return 'fal';
+  }
+  if (
+    normalized.startsWith('xai:') ||
+    normalized.startsWith('x.ai/') ||
+    normalized.startsWith('grok') ||
+    withoutPrefix.startsWith('grok')
+  ) {
+    return 'xai';
+  }
   if (withoutPrefix.includes('flux') || withoutPrefix.includes('black-forest-labs/')) return 'together';
   if (withoutPrefix.startsWith('debug/') || withoutPrefix === 'fake') return 'debug';
   return normalizeProviderInternal(normalized);
@@ -302,8 +296,14 @@ const interpolateTemplate = (template: string, context: ProviderLinkContext): st
   }, template);
 };
 
+const isProviderLinkTemplateProvider = (
+  provider: AgentProvider,
+): provider is ProviderLinkTemplateProvider => {
+  return provider in PROVIDER_LINK_TEMPLATE_ENV;
+};
+
 const readProviderLinkTemplate = (provider: AgentProvider): string | null => {
-  if (provider === 'debug' || provider === 'unknown') return null;
+  if (!isProviderLinkTemplateProvider(provider)) return null;
   const envKey = PROVIDER_LINK_TEMPLATE_ENV[provider];
   const value = normalizeString(process.env[envKey]);
   if (!value) return null;


### PR DESCRIPTION
## Summary
- centralize the admin provider/provider-source/provider-path contract into one shared module
- re-export the shared contract from the frontend admin types surface instead of duplicating unions
- align backend provider parity normalization with the shared contract, including `fal` and `xai`

## Issue and user impact
The admin provider contract was duplicated between the frontend admin types and the backend provider parity helper. That duplication had already drifted: the frontend admin types knew about `fal` and `xai`, but the backend parity helper did not. As a result, admin trace and queue diagnostics could collapse valid `fal`/`xai` provider data into `unknown`, even though the admin UI contract already claimed those providers existed.

## Root cause
Provider/provider-source/provider-path values were defined in multiple files instead of one shared contract. The backend parity helper maintained its own narrower `AgentProvider` union and value lists, so adding providers in one surface did not force parity updates in the other.

## Why this fixes the root cause
This introduces `src/lib/agents/admin/provider-contract.ts` as the single source of truth for admin provider contract values and types. `src/components/admin/types.ts` now re-exports those types, and `src/lib/agents/admin/provider-parity.ts` consumes the same shared value sets for normalization. The parity helper now also recognizes `fal` and `xai` directly and infers them from model names like `fal:...` and `grok...`, which closes the already-present contract mismatch instead of just moving duplicated code around.

## Changed surfaces
- `src/lib/agents/admin/provider-contract.ts`: shared provider, provider-source, and provider-path values/types
- `src/components/admin/types.ts`: re-export shared admin provider contract types
- `src/lib/agents/admin/provider-parity.ts`: consume shared contract values and add `fal`/`xai` normalization + model inference support
- `src/lib/agents/admin/provider-parity.test.ts`: extend coverage for `fal`/`xai` parity behavior and shared-contract alignment

## Backward compatibility
No schema or API shape changed. This is a backward-compatible contract cleanup that makes backend normalization match the provider values the admin frontend already understands. The only behavioral change is improved classification of existing `fal`/`xai` provider data that previously degraded to `unknown`.

## Validation
- `npx jest src/lib/agents/admin/provider-parity.test.ts src/lib/agents/admin/trace-diagnostics.test.ts --runInBand`
- `npm run typecheck:app`
- `git diff --check`
- `npm run build` still fails on the same unrelated repo-level missing-package blocker outside this diff:
  - `packages/ui/src/reset-monaco-editor.tsx`: `@monaco-editor/react`, `y-protocols/awareness`, `yjs`, `y-monaco`
  - `services/codex-adapter/src/sdk.ts`: `@openai/codex-sdk`

## Reviewer passes
- `reviewer_correctness`: no findings
- `reviewer_maintainability`: no findings
