### PR TITLE
[codex] share model control apply-mode contract

### DIFF
--- a/src/app/settings/models/_components/guided-controls-panel.tsx
+++ b/src/app/settings/models/_components/guided-controls-panel.tsx
@@ -1,13 +1,19 @@
 'use client';
 
 import { useEffect, useMemo, useState } from 'react';
+import type { ApplyMode } from '@/lib/agents/control-plane/types';
 import {
   filterGuidedSections,
   formatFieldSource,
   inputIdForPath,
   resolveApplyModeForPath,
 } from '../_lib/guided-config';
-import type { GuidedField, GuidedSection, ModelControlStatusResponse } from '../_lib/types';
+import type {
+  AdminScopeType,
+  GuidedField,
+  GuidedSection,
+  ModelControlStatusResponse,
+} from '../_lib/types';
 
 type Props = {
   sections: GuidedSection[];
@@ -19,12 +25,12 @@ type Props = {
   onSaveGuidedUser: () => void;
   onSaveGuidedAdmin?: () => void;
   adminProfileForm?: {
-    scopeType: 'global' | 'room' | 'user' | 'task';
+    scopeType: AdminScopeType;
     scopeId: string;
     taskPrefix: string;
     priority: string;
     enabled: boolean;
-    onScopeTypeChange: (value: 'global' | 'room' | 'user' | 'task') => void;
+    onScopeTypeChange: (value: AdminScopeType) => void;
     onScopeIdChange: (value: string) => void;
     onTaskPrefixChange: (value: string) => void;
     onPriorityChange: (value: string) => void;
@@ -32,7 +38,7 @@ type Props = {
   };
 };
 
-const modeClasses: Record<'live' | 'next_session' | 'restart_required', string> = {
+const modeClasses: Record<ApplyMode, string> = {
   live: 'bg-emerald-50 text-emerald-700 border-emerald-200',
   next_session: 'bg-amber-50 text-amber-700 border-amber-200',
   restart_required: 'bg-rose-50 text-rose-700 border-rose-200',
@@ -285,7 +291,7 @@ export function GuidedControlsPanel({
             <select
               value={adminProfileForm.scopeType}
               onChange={(event) =>
-                adminProfileForm.onScopeTypeChange(event.target.value as 'global' | 'room' | 'user' | 'task')
+                adminProfileForm.onScopeTypeChange(event.target.value as AdminScopeType)
               }
               className="mt-1 w-full rounded-md border px-3 py-2 text-sm"
               disabled={busy}

--- a/src/app/settings/models/_lib/guided-config.ts
+++ b/src/app/settings/models/_lib/guided-config.ts
@@ -1,3 +1,5 @@
+import { resolveApplyModeForPath as resolveCanonicalApplyModeForPath } from '@/lib/agents/control-plane/apply-mode';
+import { isApplyMode, type ApplyMode } from '@/lib/agents/control-plane/types';
 import type { GuidedField, GuidedSection, ResolvedFieldSource } from './types';
 
 const MODEL_SUGGESTIONS = {
@@ -347,26 +349,6 @@ export const GUIDED_SECTIONS: GuidedSection[] = [
   },
 ];
 
-const RESTART_REQUIRED_PREFIXES = [
-  'knobs.conductor.taskLeaseTtlMs',
-  'knobs.conductor.taskIdlePollMs',
-  'knobs.conductor.taskIdlePollMaxMs',
-  'knobs.conductor.taskMaxRetryAttempts',
-  'knobs.conductor.taskRetryBaseDelayMs',
-  'knobs.conductor.taskRetryMaxDelayMs',
-  'knobs.conductor.taskRetryJitterRatio',
-];
-
-const NEXT_SESSION_PREFIXES = [
-  'knobs.conductor.roomConcurrency',
-  'models.voiceRealtime',
-  'models.voiceRealtimePrimary',
-  'models.voiceRealtimeSecondary',
-  'models.voiceRouter',
-  'models.voiceStt',
-  'knobs.voice.realtimeModelStrategy',
-];
-
 export const ALL_GUIDED_FIELDS = GUIDED_SECTIONS.flatMap((section) => section.fields);
 
 export const inputIdForPath = (path: string): string => `guided-${path.replace(/[^a-zA-Z0-9]/g, '-')}`;
@@ -495,19 +477,13 @@ export const buildPatchFromGuided = (values: Record<string, string>): Record<str
 
 export const resolveApplyModeForPath = (
   path: string,
-  applyModes: Record<string, string> | null | undefined,
-): 'live' | 'next_session' | 'restart_required' => {
+  applyModes: Record<string, ApplyMode> | null | undefined,
+): ApplyMode => {
   const explicit = applyModes?.[path];
-  if (explicit === 'live' || explicit === 'next_session' || explicit === 'restart_required') {
+  if (isApplyMode(explicit)) {
     return explicit;
   }
-  if (RESTART_REQUIRED_PREFIXES.some((prefix) => path.startsWith(prefix))) {
-    return 'restart_required';
-  }
-  if (NEXT_SESSION_PREFIXES.some((prefix) => path.startsWith(prefix))) {
-    return 'next_session';
-  }
-  return 'live';
+  return resolveCanonicalApplyModeForPath(path);
 };
 
 export const formatFieldSource = (

--- a/src/app/settings/models/_lib/types.ts
+++ b/src/app/settings/models/_lib/types.ts
@@ -1,9 +1,17 @@
+import type {
+  ApplyMode,
+  KnobScope,
+  ResolvedFieldScope,
+} from '@/lib/agents/control-plane/types';
+
 export type ResolvedFieldSource = {
-  scope: 'env' | 'request' | 'global' | 'room' | 'user' | 'task';
+  scope: ResolvedFieldScope;
   scopeId: string;
   profileId?: string;
   version?: number;
 };
+
+export type AdminScopeType = KnobScope;
 
 export type ModelControlStatusResponse = {
   ok: boolean;
@@ -17,7 +25,7 @@ export type ModelControlStatusResponse = {
     configVersion: string;
     resolvedAt: string;
     effective: Record<string, unknown>;
-    applyModes: Record<string, string>;
+    applyModes: Record<string, ApplyMode>;
     fieldSources?: Record<string, ResolvedFieldSource>;
     sources: Array<Record<string, unknown>>;
   };

--- a/src/app/settings/models/page.tsx
+++ b/src/app/settings/models/page.tsx
@@ -12,7 +12,7 @@ import { GuidedControlsPanel } from './_components/guided-controls-panel';
 import { SharedKeyUnlockPanel } from './_components/shared-key-unlock-panel';
 import { StatusSummary } from './_components/status-summary';
 import { buildPatchFromGuided, GUIDED_SECTIONS, seedGuidedValues } from './_lib/guided-config';
-import type { ModelControlStatusResponse } from './_lib/types';
+import type { AdminScopeType, ModelControlStatusResponse } from './_lib/types';
 
 const pretty = (value: unknown) => JSON.stringify(value, null, 2);
 
@@ -42,7 +42,7 @@ export default function ModelControlsPage() {
     }),
   );
 
-  const [adminScopeType, setAdminScopeType] = useState<'global' | 'room' | 'user' | 'task'>('global');
+  const [adminScopeType, setAdminScopeType] = useState<AdminScopeType>('global');
   const [adminScopeId, setAdminScopeId] = useState('global');
   const [adminTaskPrefix, setAdminTaskPrefix] = useState('');
   const [adminPriority, setAdminPriority] = useState('100');

--- a/src/lib/agents/control-plane/apply-mode.test.ts
+++ b/src/lib/agents/control-plane/apply-mode.test.ts
@@ -1,0 +1,19 @@
+import { resolveApplyModeForPath } from './apply-mode';
+
+describe('resolveApplyModeForPath', () => {
+  it('marks voice and realtime paths as next_session', () => {
+    expect(resolveApplyModeForPath('knobs.voice.replyTimeoutMs')).toBe('next_session');
+    expect(resolveApplyModeForPath('knobs.voice.turnDetection')).toBe('next_session');
+    expect(resolveApplyModeForPath('models.voiceRealtime')).toBe('next_session');
+  });
+
+  it('marks conductor lease and retry settings as restart_required', () => {
+    expect(resolveApplyModeForPath('knobs.conductor.taskLeaseTtlMs')).toBe('restart_required');
+    expect(resolveApplyModeForPath('knobs.conductor.taskRetryBaseDelayMs')).toBe('restart_required');
+  });
+
+  it('defaults unrelated paths to live', () => {
+    expect(resolveApplyModeForPath('models.canvasSteward')).toBe('live');
+    expect(resolveApplyModeForPath('knobs.canvas.temperature')).toBe('live');
+  });
+});

--- a/src/lib/agents/control-plane/apply-mode.ts
+++ b/src/lib/agents/control-plane/apply-mode.ts
@@ -1,0 +1,26 @@
+import type { ApplyMode } from './types';
+
+const APPLY_MODE_BY_PATH: Array<{ prefix: string; mode: ApplyMode }> = [
+  { prefix: 'knobs.conductor.taskLeaseTtlMs', mode: 'restart_required' },
+  { prefix: 'knobs.conductor.taskIdlePollMs', mode: 'restart_required' },
+  { prefix: 'knobs.conductor.taskIdlePollMaxMs', mode: 'restart_required' },
+  { prefix: 'knobs.conductor.taskMaxRetryAttempts', mode: 'restart_required' },
+  { prefix: 'knobs.conductor.taskRetryBaseDelayMs', mode: 'restart_required' },
+  { prefix: 'knobs.conductor.taskRetryMaxDelayMs', mode: 'restart_required' },
+  { prefix: 'knobs.conductor.taskRetryJitterRatio', mode: 'restart_required' },
+  { prefix: 'knobs.conductor.roomConcurrency', mode: 'next_session' },
+  { prefix: 'knobs.voice', mode: 'next_session' },
+  { prefix: 'models.voiceRealtime', mode: 'next_session' },
+  { prefix: 'models.voiceRealtimePrimary', mode: 'next_session' },
+  { prefix: 'models.voiceRealtimeSecondary', mode: 'next_session' },
+  { prefix: 'models.voiceRouter', mode: 'next_session' },
+  { prefix: 'models.voiceStt', mode: 'next_session' },
+  { prefix: 'knobs.voice.realtimeModelStrategy', mode: 'next_session' },
+];
+
+export const resolveApplyModeForPath = (path: string): ApplyMode => {
+  for (const entry of APPLY_MODE_BY_PATH) {
+    if (path.startsWith(entry.prefix)) return entry.mode;
+  }
+  return 'live';
+};

--- a/src/lib/agents/control-plane/resolver.ts
+++ b/src/lib/agents/control-plane/resolver.ts
@@ -1,9 +1,11 @@
 import { createHash } from 'node:crypto';
+import { resolveApplyModeForPath } from './apply-mode';
 import { modelControlKnobsSchema, modelControlModelsSchema, modelControlPatchSchema } from './schemas';
 import { getModelControlProfilesForResolution } from './profiles';
 import type {
   ApplyMode,
   ModelControlPatch,
+  ResolvedFieldScope,
   ResolveModelControlInput,
   ResolvedModelControl,
 } from './types';
@@ -16,24 +18,6 @@ type CacheEntry = {
 };
 
 const resolverCache = new Map<string, CacheEntry>();
-
-const APPLY_MODE_BY_PATH: Array<{ prefix: string; mode: ApplyMode }> = [
-  { prefix: 'knobs.conductor.taskLeaseTtlMs', mode: 'restart_required' },
-  { prefix: 'knobs.conductor.taskIdlePollMs', mode: 'restart_required' },
-  { prefix: 'knobs.conductor.taskIdlePollMaxMs', mode: 'restart_required' },
-  { prefix: 'knobs.conductor.taskMaxRetryAttempts', mode: 'restart_required' },
-  { prefix: 'knobs.conductor.taskRetryBaseDelayMs', mode: 'restart_required' },
-  { prefix: 'knobs.conductor.taskRetryMaxDelayMs', mode: 'restart_required' },
-  { prefix: 'knobs.conductor.taskRetryJitterRatio', mode: 'restart_required' },
-  { prefix: 'knobs.conductor.roomConcurrency', mode: 'next_session' },
-  { prefix: 'knobs.voice', mode: 'next_session' },
-  { prefix: 'models.voiceRealtime', mode: 'next_session' },
-  { prefix: 'models.voiceRealtimePrimary', mode: 'next_session' },
-  { prefix: 'models.voiceRealtimeSecondary', mode: 'next_session' },
-  { prefix: 'models.voiceRouter', mode: 'next_session' },
-  { prefix: 'models.voiceStt', mode: 'next_session' },
-  { prefix: 'knobs.voice.realtimeModelStrategy', mode: 'next_session' },
-];
 
 const deepMerge = <T extends Record<string, unknown>>(target: T, patch: Record<string, unknown>): T => {
   const output: Record<string, unknown> = { ...target };
@@ -70,13 +54,6 @@ const flattenPaths = (value: unknown, prefix = ''): string[] => {
   return paths;
 };
 
-const applyModeForPath = (path: string): ApplyMode => {
-  for (const entry of APPLY_MODE_BY_PATH) {
-    if (path.startsWith(entry.prefix)) return entry.mode;
-  }
-  return 'live';
-};
-
 const normalizePatch = (value: unknown): ModelControlPatch => {
   const parsed = modelControlPatchSchema.safeParse(value ?? {});
   if (parsed.success) return parsed.data;
@@ -100,7 +77,7 @@ const assignFieldSource = (
   map: Record<
     string,
     {
-      scope: 'env' | 'request' | 'global' | 'room' | 'user' | 'task';
+      scope: ResolvedFieldScope;
       scopeId: string;
       profileId?: string;
       version?: number;
@@ -108,7 +85,7 @@ const assignFieldSource = (
   >,
   patch: ModelControlPatch,
   source: {
-    scope: 'env' | 'request' | 'global' | 'room' | 'user' | 'task';
+    scope: ResolvedFieldScope;
     scopeId: string;
     profileId?: string;
     version?: number;
@@ -291,7 +268,7 @@ export async function resolveModelControl(
   const paths = flattenPaths(effective);
   const applyModes: Record<string, ApplyMode> = {};
   for (const path of paths) {
-    applyModes[path] = applyModeForPath(path);
+    applyModes[path] = resolveApplyModeForPath(path);
   }
   const configVersion = createHash('sha1')
     .update(

--- a/src/lib/agents/control-plane/types.ts
+++ b/src/lib/agents/control-plane/types.ts
@@ -4,7 +4,13 @@ export type ModelProvider = (typeof MODEL_PROVIDERS)[number];
 export const KNOB_SCOPES = ['global', 'room', 'user', 'task'] as const;
 export type KnobScope = (typeof KNOB_SCOPES)[number];
 
-export type ApplyMode = 'live' | 'next_session' | 'restart_required';
+export const APPLY_MODE_VALUES = ['live', 'next_session', 'restart_required'] as const;
+export type ApplyMode = (typeof APPLY_MODE_VALUES)[number];
+export type ResolvedFieldScope = KnobScope | 'env' | 'request';
+
+export const isApplyMode = (value: unknown): value is ApplyMode => {
+  return typeof value === 'string' && APPLY_MODE_VALUES.includes(value as ApplyMode);
+};
 
 export type CanvasKnobPatch = {
   preset?: 'creative' | 'precise';
@@ -106,7 +112,7 @@ export type ResolvedModelControl = {
   fieldSources: Record<
     string,
     {
-      scope: KnobScope | 'env' | 'request';
+      scope: ResolvedFieldScope;
       scopeId: string;
       profileId?: string;
       version?: number;


### PR DESCRIPTION
## Summary
- centralize model-control apply-mode rules in one shared control-plane helper
- make the settings UI consume shared control-plane apply-mode and scope contracts instead of weak string copies
- fix the settings-side apply-mode fallback so `knobs.voice.*` matches resolver behavior

## Issue and user impact
The model-controls settings surface carried its own apply-mode fallback table and weakened parts of the control-plane contract to plain strings or repeated unions. That had already drifted from the backend resolver: the settings helper treated `knobs.voice.*` fields as `live` by default, while the resolver treated them as `next_session`. This meant the UI could present the wrong apply-mode guidance for voice settings even when the backend was enforcing a different contract.

## Root cause
Apply-mode rules and related scope/mode contracts were split across the control-plane resolver and the settings UI. The resolver owned the canonical rule table, but the settings-side helper reimplemented a partial copy and separately retyped `ApplyMode` and scope unions instead of consuming the shared contract.

## Why this fixes the root cause
This introduces `src/lib/agents/control-plane/apply-mode.ts` as the canonical apply-mode rule helper and makes both the resolver and settings guided-config use it. The settings types now also consume shared `ApplyMode`, `KnobScope`, and `ResolvedFieldScope` contracts from the control-plane instead of plain strings or repeated unions. A shared `isApplyMode()` guard closes the remaining literal duplication for explicit mode validation. Together that removes the contract split and fixes the already-existing mismatch for `knobs.voice.*` paths.

## Changed surfaces
- `src/lib/agents/control-plane/apply-mode.ts`: canonical apply-mode resolution helper
- `src/lib/agents/control-plane/apply-mode.test.ts`: direct coverage for next-session, restart-required, and live path classes
- `src/lib/agents/control-plane/resolver.ts`: uses shared apply-mode helper and shared resolved-field scope type
- `src/lib/agents/control-plane/types.ts`: exports `APPLY_MODE_VALUES`, `isApplyMode`, and `ResolvedFieldScope`
- `src/app/settings/models/_lib/types.ts`: uses shared control-plane `ApplyMode`, `KnobScope`, and `ResolvedFieldScope`
- `src/app/settings/models/_lib/guided-config.ts`: uses shared apply-mode helper and shared runtime mode guard
- `src/app/settings/models/_components/guided-controls-panel.tsx` and `src/app/settings/models/page.tsx`: use shared admin scope/apply-mode types

## Backward compatibility
No API or schema shape changed. This is a contract cleanup plus UI-guidance fix. Backend behavior stays the same; the settings UI now reflects the same apply-mode semantics the backend resolver already used.

## Validation
- `npx jest src/lib/agents/control-plane/apply-mode.test.ts src/app/settings/models/_lib/guided-config.test.ts --runInBand`
- `npm run typecheck:app`
- `git diff --check`
- `npm run build` still fails on the same unrelated repo-level missing-package blocker outside this diff:
  - `packages/ui/src/reset-monaco-editor.tsx`: `@monaco-editor/react`, `y-protocols/awareness`, `yjs`, `y-monaco`
  - `services/codex-adapter/src/sdk.ts`: `@openai/codex-sdk`

## Reviewer passes
- `reviewer_correctness`: no findings on final diff
- `reviewer_maintainability`: initially flagged duplicated apply-mode literal validation in settings guided-config; fixed by moving validation to the shared control-plane contract, then reran review with no findings
