### PR TITLE
[codex] share capability profile contract

### DIFF
--- a/src/lib/agents/capabilities.ts
+++ b/src/lib/agents/capabilities.ts
@@ -1,4 +1,7 @@
+import type { CapabilityProfile, WidgetTier } from './capability-contract';
 import { getWidgetLifecycleMetadata, type WidgetGroup } from './widget-lifecycle-manifest';
+
+export type { CapabilityProfile, WidgetTier } from './capability-contract';
 
 // Accept either browser or node LiveKit Room by using a minimal interface
 export interface RoomLike {
@@ -8,8 +11,6 @@ export interface RoomLike {
     publishData: (data: Uint8Array, options?: { reliable?: boolean; topic?: string }) => unknown;
   } | null;
 }
-
-export type CapabilityProfile = 'full' | 'lean_adaptive';
 export type CapabilityGroup =
   | 'visual'
   | 'widget-lifecycle'
@@ -18,7 +19,6 @@ export type CapabilityGroup =
   | 'mcp'
   | 'canvas'
   | 'utility';
-export type WidgetTier = 'tier1' | 'tier2';
 export type LifecycleOp =
   | 'create'
   | 'resolve'

--- a/src/lib/agents/capability-contract.test.ts
+++ b/src/lib/agents/capability-contract.test.ts
@@ -1,0 +1,11 @@
+import { CAPABILITY_PROFILES, WIDGET_TIERS } from './capability-contract';
+
+describe('capability-contract', () => {
+  it('exports the canonical capability profiles', () => {
+    expect(CAPABILITY_PROFILES).toEqual(['full', 'lean_adaptive']);
+  });
+
+  it('exports the canonical widget tiers', () => {
+    expect(WIDGET_TIERS).toEqual(['tier1', 'tier2']);
+  });
+});

--- a/src/lib/agents/capability-contract.ts
+++ b/src/lib/agents/capability-contract.ts
@@ -1,0 +1,5 @@
+export const CAPABILITY_PROFILES = ['full', 'lean_adaptive'] as const;
+export type CapabilityProfile = (typeof CAPABILITY_PROFILES)[number];
+
+export const WIDGET_TIERS = ['tier1', 'tier2'] as const;
+export type WidgetTier = (typeof WIDGET_TIERS)[number];

--- a/src/lib/agents/widget-lifecycle-manifest.ts
+++ b/src/lib/agents/widget-lifecycle-manifest.ts
@@ -1,6 +1,6 @@
-export type CapabilityProfile = 'full' | 'lean_adaptive';
+import type { CapabilityProfile, WidgetTier } from './capability-contract';
 
-export type WidgetTier = 'tier1' | 'tier2';
+export type { CapabilityProfile, WidgetTier };
 export type WidgetGroup =
   | 'productivity'
   | 'research'


### PR DESCRIPTION
## Summary
- centralize `CapabilityProfile` and `WidgetTier` into one shared agent contract module
- make both `capabilities.ts` and `widget-lifecycle-manifest.ts` consume that shared contract
- preserve the existing `capabilities.ts` export surface via re-exports so downstream callers do not churn

## Issue and user impact
The agent capability layer and the widget lifecycle manifest each defined their own copies of `CapabilityProfile` and `WidgetTier`. That duplication was small but unnecessary, and it created another contract that could drift silently if one side changed first.

## Root cause
Shared agent capability concepts were expressed as local unions in multiple files instead of one explicit contract module. The files happened to agree today, but there was no mechanism keeping them aligned.

## Why this fixes the root cause
This introduces `src/lib/agents/capability-contract.ts` as the single source of truth for `CapabilityProfile` and `WidgetTier`. Both `src/lib/agents/capabilities.ts` and `src/lib/agents/widget-lifecycle-manifest.ts` now consume the same shared contract, and `capabilities.ts` re-exports the shared types so existing imports remain stable.

## Changed surfaces
- `src/lib/agents/capability-contract.ts`: canonical capability-profile and widget-tier contract
- `src/lib/agents/capability-contract.test.ts`: direct coverage for the shared contract values
- `src/lib/agents/capabilities.ts`: imports/re-exports shared contract types instead of defining local copies
- `src/lib/agents/widget-lifecycle-manifest.ts`: consumes/re-exports shared contract types instead of defining local copies

## Backward compatibility
No runtime behavior, API shape, or downstream import path changed. This is a contract-only cleanup. Existing callers that import types from `capabilities.ts` continue to work because that module now re-exports the shared types.

## Validation
- `npx jest src/lib/agents/capability-contract.test.ts src/lib/agents/capabilities.test.ts src/lib/agents/widget-lifecycle-manifest.test.ts --runInBand`
- `npm run typecheck:app`
- `git diff --check`
- `npm run build` still fails on the same unrelated repo-level missing-package blocker outside this diff:
  - `packages/ui/src/reset-monaco-editor.tsx`: `@monaco-editor/react`, `y-protocols/awareness`, `yjs`, `y-monaco`
  - `services/codex-adapter/src/sdk.ts`: `@openai/codex-sdk`

## Reviewer passes
- `reviewer_correctness`: no findings
- `reviewer_maintainability`: no findings
