### PR TITLE
[codex] tighten meeting summary context profile contract

### DIFF
--- a/src/components/ui/productivity/meeting-summary-schema.ts
+++ b/src/components/ui/productivity/meeting-summary-schema.ts
@@ -1,4 +1,8 @@
 import { z } from 'zod';
+import {
+  normalizeFairyContextProfile,
+  type FairyContextProfile,
+} from '@/lib/fairy-context/profiles';
 
 export const actionItemSchema = z.object({
   task: z.string().describe('Action item description'),
@@ -20,7 +24,18 @@ export const meetingSummaryWidgetSchema = z.object({
   memoryNamespace: z.string().optional().describe('Vector memory namespace'),
   autoSend: z.boolean().optional().default(false),
   lastUpdated: z.number().optional(),
-  contextProfile: z.string().optional(),
+  contextProfile: z
+    .string()
+    .transform((value, ctx): FairyContextProfile => {
+      const normalized = normalizeFairyContextProfile(value);
+      if (normalized) return normalized;
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Invalid fairy context profile',
+      });
+      return z.NEVER;
+    })
+    .optional(),
   className: z.string().optional(),
 });
 
@@ -46,5 +61,5 @@ export type MeetingSummaryState = {
   memoryNamespace?: string;
   autoSend?: boolean;
   lastUpdated?: number;
-  contextProfile?: string;
+  contextProfile?: FairyContextProfile;
 };

--- a/src/components/ui/productivity/meeting-summary-utils.test.ts
+++ b/src/components/ui/productivity/meeting-summary-utils.test.ts
@@ -1,0 +1,24 @@
+import { meetingSummaryWidgetSchema } from './meeting-summary-schema';
+import { normalizeMeetingSummaryState } from './meeting-summary-utils';
+
+describe('meeting summary context profile contract', () => {
+  it('accepts only canonical fairy context profiles in widget schema', () => {
+    expect(meetingSummaryWidgetSchema.parse({ contextProfile: 'standard' }).contextProfile).toBe(
+      'standard',
+    );
+    expect(meetingSummaryWidgetSchema.parse({ contextProfile: 'balanced' }).contextProfile).toBe(
+      'standard',
+    );
+    expect(() => meetingSummaryWidgetSchema.parse({ contextProfile: 'invalid-profile' })).toThrow();
+  });
+
+  it('normalizes aliased context profiles in widget state', () => {
+    expect(normalizeMeetingSummaryState({ contextProfile: 'balanced' }).contextProfile).toBe(
+      'standard',
+    );
+    expect(normalizeMeetingSummaryState({ contextProfile: 'archive' }).contextProfile).toBe(
+      'archive',
+    );
+    expect(normalizeMeetingSummaryState({ contextProfile: 'bogus' }).contextProfile).toBeUndefined();
+  });
+});

--- a/src/components/ui/productivity/meeting-summary-utils.ts
+++ b/src/components/ui/productivity/meeting-summary-utils.ts
@@ -1,3 +1,4 @@
+import { normalizeFairyContextProfile } from '@/lib/fairy-context/profiles';
 import type { ContextDocument } from '@/lib/stores/context-store';
 import type { MeetingSummaryState } from './meeting-summary-schema';
 
@@ -15,7 +16,7 @@ export const normalizeMeetingSummaryState = (input: Partial<MeetingSummaryState>
   memoryNamespace: input.memoryNamespace,
   autoSend: input.autoSend,
   lastUpdated: input.lastUpdated,
-  contextProfile: input.contextProfile,
+  contextProfile: normalizeFairyContextProfile(input.contextProfile),
 });
 
 export const resolveMeetingSummaryDocument = (

--- a/src/components/ui/productivity/meeting-summary-widget.tsx
+++ b/src/components/ui/productivity/meeting-summary-widget.tsx
@@ -5,6 +5,7 @@ import ReactMarkdown from 'react-markdown';
 import { Copy, Send } from 'lucide-react';
 import { Button } from '@/components/ui/shared/button';
 import { cn } from '@/lib/utils';
+import { normalizeFairyContextProfile } from '@/lib/fairy-context/profiles';
 import { useComponentRegistration } from '@/lib/component-registry';
 import { useContextDocuments } from '@/lib/stores/context-store';
 import { createMarkdownComponents } from '@/components/ui/shared/markdown-components';
@@ -69,7 +70,12 @@ export function MeetingSummaryWidget(props: MeetingSummaryWidgetProps) {
       if (typeof patch.memoryCollection === 'string') next.memoryCollection = patch.memoryCollection;
       if (typeof patch.memoryIndex === 'string') next.memoryIndex = patch.memoryIndex;
       if (typeof patch.memoryNamespace === 'string') next.memoryNamespace = patch.memoryNamespace;
-      if (typeof patch.contextProfile === 'string') next.contextProfile = patch.contextProfile;
+      if (typeof patch.contextProfile === 'string') {
+        const normalizedContextProfile = normalizeFairyContextProfile(patch.contextProfile);
+        if (normalizedContextProfile) {
+          next.contextProfile = normalizedContextProfile;
+        }
+      }
       if (typeof patch.lastUpdated === 'number') next.lastUpdated = patch.lastUpdated;
       if (typeof patch.autoSend === 'boolean') next.autoSend = patch.autoSend;
       return next;


### PR DESCRIPTION
## Summary
- tighten the meeting-summary widget `contextProfile` contract to use the canonical fairy context profile semantics
- normalize schema, state construction, and widget patch handling through the shared fairy profile normalizer
- preserve backward compatibility for legacy alias values like `balanced` by normalizing them at the schema boundary

## Issue and user impact
The meeting-summary widget path treated `contextProfile` as an arbitrary string even though the rest of the fairy stack already had a canonical `FairyContextProfile` contract and normalizer. That meant widget state and patches could drift away from the canonical profile set, and consumers had no guarantee that `contextProfile` was valid or normalized.

## Root cause
The meeting-summary widget schema and state model did not consume the existing fairy context profile contract. Instead, they accepted a plain string and passed it through unchanged, while other fairy-aware surfaces used `normalizeFairyContextProfile()` and the shared profile set.

## Why this fixes the root cause
This makes the meeting-summary widget path use the same profile contract as the rest of the fairy system. The widget schema now accepts string input but normalizes it to a canonical `FairyContextProfile` (so legacy aliases like `balanced` still work), the widget state type is narrowed to `FairyContextProfile`, the state normalizer canonicalizes incoming values, and widget patches only persist normalized profiles.

## Changed surfaces
- `src/components/ui/productivity/meeting-summary-schema.ts`: schema boundary now normalizes `contextProfile` to canonical fairy profiles and state type uses `FairyContextProfile`
- `src/components/ui/productivity/meeting-summary-utils.ts`: normalizes incoming `contextProfile` during state construction
- `src/components/ui/productivity/meeting-summary-widget.tsx`: normalizes incoming patch `contextProfile` values before storing state
- `src/components/ui/productivity/meeting-summary-utils.test.ts`: covers canonical schema parsing, legacy alias parsing, and state normalization behavior

## Backward compatibility
This keeps backward compatibility for legacy alias values such as `balanced` by normalizing them to `standard` at the schema boundary. The only rejected values are truly invalid profiles that were never part of the supported fairy profile contract.

## Validation
- `npx jest src/components/ui/productivity/meeting-summary-utils.test.ts --runInBand`
- `npm run typecheck:app`
- `git diff --check`
- `npm run build` still fails on the same unrelated repo-level missing-package blocker outside this diff:
  - `packages/ui/src/reset-monaco-editor.tsx`: `@monaco-editor/react`, `y-protocols/awareness`, `yjs`, `y-monaco`
  - `services/codex-adapter/src/sdk.ts`: `@openai/codex-sdk`

## Reviewer passes
- `reviewer_correctness`: initially flagged a regression where legacy alias values would fail schema validation before runtime normalization; fixed by normalizing aliases at the schema boundary, then reran review with no findings
- `reviewer_maintainability`: no findings on final diff
