### PR TITLE
Wire Remote Codex widget production runtime

### DIFF
--- a/.github/workflows/deploy-railway-prod.yml
+++ b/.github/workflows/deploy-railway-prod.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
     paths:
       - 'src/lib/agents/**'
+      - 'services/codex-broker/**'
+      - 'services/widget-codex/**'
+      - 'src/app/api/widget-codex/**'
+      - 'src/components/ui/codex/**'
+      - 'src/lib/widget-codex/**'
       - 'scripts/start-service.sh'
       - 'railway.toml'
       - 'Dockerfile'
@@ -23,6 +28,16 @@ on:
         required: false
         default: false
         type: boolean
+      force_codex_broker:
+        description: 'Force deploy present-codex-broker'
+        required: false
+        default: false
+        type: boolean
+      force_widget_codex:
+        description: 'Force deploy present-widget-codex'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -36,6 +51,8 @@ env:
   RAILWAY_ENVIRONMENT: production
   RAILWAY_CONDUCTOR_SERVICE: present-conductor
   RAILWAY_REALTIME_SERVICE: present-realtime
+  RAILWAY_CODEX_BROKER_SERVICE: present-codex-broker
+  RAILWAY_WIDGET_CODEX_SERVICE: present-widget-codex
 
 jobs:
   plan:
@@ -43,6 +60,8 @@ jobs:
     outputs:
       deploy_conductor: ${{ steps.plan.outputs.deploy_conductor }}
       deploy_realtime: ${{ steps.plan.outputs.deploy_realtime }}
+      deploy_codex_broker: ${{ steps.plan.outputs.deploy_codex_broker }}
+      deploy_widget_codex: ${{ steps.plan.outputs.deploy_widget_codex }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -54,6 +73,14 @@ jobs:
           filters: |
             agents:
               - 'src/lib/agents/**'
+            codex_broker:
+              - 'services/codex-broker/**'
+              - 'src/app/api/reset/codex/**'
+            widget_codex:
+              - 'services/widget-codex/**'
+              - 'src/app/api/widget-codex/**'
+              - 'src/components/ui/codex/**'
+              - 'src/lib/widget-codex/**'
             shared:
               - 'scripts/start-service.sh'
               - 'railway.toml'
@@ -74,6 +101,8 @@ jobs:
           set -euo pipefail
           deploy_conductor=false
           deploy_realtime=false
+          deploy_codex_broker=false
+          deploy_widget_codex=false
           is_dispatch_from_main=false
 
           if [ "${{ github.event_name }}" != "workflow_dispatch" ] || [ "${{ github.ref }}" = "refs/heads/main" ]; then
@@ -92,6 +121,17 @@ jobs:
             deploy_realtime=true
           fi
 
+          if [ "${{ steps.paths.outputs.shared }}" = "true" ] || \
+             [ "${{ steps.paths.outputs.codex_broker }}" = "true" ]; then
+            deploy_codex_broker=true
+          fi
+
+          if [ "${{ steps.paths.outputs.shared }}" = "true" ] || \
+             [ "${{ steps.paths.outputs.codex_broker }}" = "true" ] || \
+             [ "${{ steps.paths.outputs.widget_codex }}" = "true" ]; then
+            deploy_widget_codex=true
+          fi
+
           if [ "${{ github.event.inputs.force_conductor || 'false' }}" = "true" ]; then
             deploy_conductor=true
           fi
@@ -100,15 +140,29 @@ jobs:
             deploy_realtime=true
           fi
 
+          if [ "${{ github.event.inputs.force_codex_broker || 'false' }}" = "true" ]; then
+            deploy_codex_broker=true
+          fi
+
+          if [ "${{ github.event.inputs.force_widget_codex || 'false' }}" = "true" ]; then
+            deploy_widget_codex=true
+          fi
+
           if [ "$is_dispatch_from_main" = false ]; then
             deploy_conductor=false
             deploy_realtime=false
+            deploy_codex_broker=false
+            deploy_widget_codex=false
           fi
 
           echo "deploy_conductor=$deploy_conductor" >> "$GITHUB_OUTPUT"
           echo "deploy_realtime=$deploy_realtime" >> "$GITHUB_OUTPUT"
+          echo "deploy_codex_broker=$deploy_codex_broker" >> "$GITHUB_OUTPUT"
+          echo "deploy_widget_codex=$deploy_widget_codex" >> "$GITHUB_OUTPUT"
           echo "deploy_conductor=$deploy_conductor"
           echo "deploy_realtime=$deploy_realtime"
+          echo "deploy_codex_broker=$deploy_codex_broker"
+          echo "deploy_widget_codex=$deploy_widget_codex"
 
   deploy-conductor:
     runs-on: ubuntu-latest
@@ -247,3 +301,201 @@ jobs:
 
           run_with_railway_auth link railway link -p "$RAILWAY_PROJECT_ID" -e "$RAILWAY_ENVIRONMENT"
           run_with_railway_auth redeploy railway redeploy --service "$RAILWAY_REALTIME_SERVICE" --yes
+
+  deploy-codex-broker:
+    runs-on: ubuntu-latest
+    needs: plan
+    if: needs.plan.outputs.deploy_codex_broker == 'true'
+    steps:
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install Railway CLI
+        run: npm install --global @railway/cli
+
+      - name: Redeploy present-codex-broker
+        env:
+          RAILWAY_API_KEY: ${{ secrets.RAILWAY_API_KEY || '' }}
+          RAILWAY_PROJECT_TOKEN: ${{ secrets.RAILWAY_TOKEN || '' }}
+          CODEX_BROKER_AUTH_TOKEN: ${{ secrets.CODEX_BROKER_AUTH_TOKEN || '' }}
+          CODEX_BROKER_PUBLIC_BASE_URL: ${{ vars.CODEX_BROKER_PUBLIC_BASE_URL || '' }}
+          CODEX_BROKER_DIRECT_TARGET_URL: ${{ secrets.CODEX_BROKER_DIRECT_TARGET_URL || vars.CODEX_BROKER_DIRECT_TARGET_URL || '' }}
+          CODEX_BROKER_SSH_HOST: ${{ secrets.CODEX_BROKER_SSH_HOST || vars.CODEX_BROKER_SSH_HOST || '' }}
+          CODEX_BROKER_SSH_USERNAME: ${{ secrets.CODEX_BROKER_SSH_USERNAME || vars.CODEX_BROKER_SSH_USERNAME || '' }}
+          CODEX_BROKER_SSH_PORT: ${{ vars.CODEX_BROKER_SSH_PORT || '22' }}
+          CODEX_BROKER_REMOTE_HOST: ${{ vars.CODEX_BROKER_REMOTE_HOST || '127.0.0.1' }}
+          CODEX_BROKER_REMOTE_PORT: ${{ vars.CODEX_BROKER_REMOTE_PORT || '4500' }}
+          CODEX_BROKER_REMOTE_PROTOCOL: ${{ vars.CODEX_BROKER_REMOTE_PROTOCOL || 'http' }}
+          CODEX_BROKER_SSH_HOST_KEY_SHA256: ${{ secrets.CODEX_BROKER_SSH_HOST_KEY_SHA256 || vars.CODEX_BROKER_SSH_HOST_KEY_SHA256 || '' }}
+          CODEX_BROKER_SSH_PRIVATE_KEY: ${{ secrets.CODEX_BROKER_SSH_PRIVATE_KEY || '' }}
+          CODEX_BROKER_SSH_PRIVATE_KEY_PATH: ${{ vars.CODEX_BROKER_SSH_PRIVATE_KEY_PATH || '' }}
+          CODEX_BROKER_SSH_PASSPHRASE: ${{ secrets.CODEX_BROKER_SSH_PASSPHRASE || '' }}
+        run: |
+          set -euo pipefail
+          if [ -z "${RAILWAY_API_KEY:-}" ] && [ -z "${RAILWAY_PROJECT_TOKEN:-}" ]; then
+            echo "::error::Missing Railway auth. Set RAILWAY_API_KEY and/or RAILWAY_TOKEN in GitHub Actions secrets."
+            exit 1
+          fi
+          if [ -z "${CODEX_BROKER_AUTH_TOKEN:-}" ]; then
+            echo "::error::Missing CODEX_BROKER_AUTH_TOKEN secret."
+            exit 1
+          fi
+          if [ -z "${CODEX_BROKER_PUBLIC_BASE_URL:-}" ]; then
+            echo "::error::Missing CODEX_BROKER_PUBLIC_BASE_URL repository variable."
+            exit 1
+          fi
+          if [ -z "${CODEX_BROKER_DIRECT_TARGET_URL:-}" ] && { [ -z "${CODEX_BROKER_SSH_HOST:-}" ] || [ -z "${CODEX_BROKER_SSH_USERNAME:-}" ]; }; then
+            echo "::error::Set CODEX_BROKER_DIRECT_TARGET_URL or CODEX_BROKER_SSH_HOST plus CODEX_BROKER_SSH_USERNAME."
+            exit 1
+          fi
+          tmp_dir="$(mktemp -d)"
+          cd "$tmp_dir"
+          run_with_railway_auth() {
+            local action="$1"
+            shift
+            local code=1
+            if [ -n "${RAILWAY_API_KEY:-}" ]; then
+              set +e
+              RAILWAY_API_TOKEN="" RAILWAY_TOKEN="$RAILWAY_API_KEY" "$@"
+              code=$?
+              set -e
+              if [ "$code" -eq 0 ]; then
+                echo "auth_source=RAILWAY_API_KEY action=$action"
+                return 0
+              fi
+            fi
+            if [ -n "${RAILWAY_PROJECT_TOKEN:-}" ]; then
+              set +e
+              RAILWAY_API_TOKEN="" RAILWAY_TOKEN="$RAILWAY_PROJECT_TOKEN" "$@"
+              code=$?
+              set -e
+              if [ "$code" -eq 0 ]; then
+                echo "auth_source=RAILWAY_TOKEN action=$action"
+                return 0
+              fi
+            fi
+            return "$code"
+          }
+          add_optional_set() {
+            local name="$1"
+            local value="$2"
+            if [ -n "$value" ]; then
+              variable_args+=(--set "$name=$value")
+            fi
+          }
+
+          run_with_railway_auth link railway link -p "$RAILWAY_PROJECT_ID" -e "$RAILWAY_ENVIRONMENT"
+          variable_args=(
+            railway variables
+            --service "$RAILWAY_CODEX_BROKER_SERVICE"
+            --environment "$RAILWAY_ENVIRONMENT"
+            --set "SERVICE_TYPE=codex-broker"
+            --set "CODEX_BROKER_HOST=0.0.0.0"
+            --set "CODEX_BROKER_AUTH_TOKEN=$CODEX_BROKER_AUTH_TOKEN"
+            --set "CODEX_BROKER_PUBLIC_BASE_URL=$CODEX_BROKER_PUBLIC_BASE_URL"
+            --set "CODEX_BROKER_REMOTE_HOST=$CODEX_BROKER_REMOTE_HOST"
+            --set "CODEX_BROKER_REMOTE_PORT=$CODEX_BROKER_REMOTE_PORT"
+            --set "CODEX_BROKER_REMOTE_PROTOCOL=$CODEX_BROKER_REMOTE_PROTOCOL"
+          )
+          add_optional_set CODEX_BROKER_DIRECT_TARGET_URL "$CODEX_BROKER_DIRECT_TARGET_URL"
+          add_optional_set CODEX_BROKER_SSH_HOST "$CODEX_BROKER_SSH_HOST"
+          add_optional_set CODEX_BROKER_SSH_USERNAME "$CODEX_BROKER_SSH_USERNAME"
+          add_optional_set CODEX_BROKER_SSH_PORT "$CODEX_BROKER_SSH_PORT"
+          add_optional_set CODEX_BROKER_SSH_HOST_KEY_SHA256 "$CODEX_BROKER_SSH_HOST_KEY_SHA256"
+          add_optional_set CODEX_BROKER_SSH_PRIVATE_KEY "$CODEX_BROKER_SSH_PRIVATE_KEY"
+          add_optional_set CODEX_BROKER_SSH_PRIVATE_KEY_PATH "$CODEX_BROKER_SSH_PRIVATE_KEY_PATH"
+          add_optional_set CODEX_BROKER_SSH_PASSPHRASE "$CODEX_BROKER_SSH_PASSPHRASE"
+          variable_args+=(--skip-deploys)
+          run_with_railway_auth variables "${variable_args[@]}"
+          run_with_railway_auth redeploy railway redeploy --service "$RAILWAY_CODEX_BROKER_SERVICE" --yes
+
+  deploy-widget-codex:
+    runs-on: ubuntu-latest
+    needs: plan
+    if: needs.plan.outputs.deploy_widget_codex == 'true'
+    steps:
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install Railway CLI
+        run: npm install --global @railway/cli
+
+      - name: Redeploy present-widget-codex
+        env:
+          RAILWAY_API_KEY: ${{ secrets.RAILWAY_API_KEY || '' }}
+          RAILWAY_PROJECT_TOKEN: ${{ secrets.RAILWAY_TOKEN || '' }}
+          CODEX_BROKER_URL: ${{ vars.CODEX_BROKER_URL || '' }}
+          CODEX_BROKER_AUTH_TOKEN: ${{ secrets.CODEX_BROKER_AUTH_TOKEN || '' }}
+          WIDGET_CODEX_PUBLIC_WS_URL: ${{ vars.WIDGET_CODEX_PUBLIC_WS_URL || '' }}
+          WIDGET_CODEX_ALLOWED_ORIGIN: ${{ vars.WIDGET_CODEX_ALLOWED_ORIGIN || 'https://present.best' }}
+          WIDGET_CODEX_STATE_FILE: ${{ vars.WIDGET_CODEX_STATE_FILE || '/data/widget-codex/state.json' }}
+          WIDGET_CODEX_DEFAULT_SERVERS: ${{ secrets.WIDGET_CODEX_DEFAULT_SERVERS || vars.WIDGET_CODEX_DEFAULT_SERVERS || '' }}
+        run: |
+          set -euo pipefail
+          if [ -z "${RAILWAY_API_KEY:-}" ] && [ -z "${RAILWAY_PROJECT_TOKEN:-}" ]; then
+            echo "::error::Missing Railway auth. Set RAILWAY_API_KEY and/or RAILWAY_TOKEN in GitHub Actions secrets."
+            exit 1
+          fi
+          if [ -z "${CODEX_BROKER_URL:-}" ]; then
+            echo "::error::Missing CODEX_BROKER_URL repository variable for widget-codex service."
+            exit 1
+          fi
+          if [ -z "${CODEX_BROKER_AUTH_TOKEN:-}" ]; then
+            echo "::error::Missing CODEX_BROKER_AUTH_TOKEN secret."
+            exit 1
+          fi
+          if [ -z "${WIDGET_CODEX_PUBLIC_WS_URL:-}" ]; then
+            echo "::error::Missing WIDGET_CODEX_PUBLIC_WS_URL repository variable."
+            exit 1
+          fi
+          if [ -z "${WIDGET_CODEX_DEFAULT_SERVERS:-}" ]; then
+            echo "::error::Missing WIDGET_CODEX_DEFAULT_SERVERS secret or repository variable."
+            exit 1
+          fi
+          tmp_dir="$(mktemp -d)"
+          cd "$tmp_dir"
+          run_with_railway_auth() {
+            local action="$1"
+            shift
+            local code=1
+            if [ -n "${RAILWAY_API_KEY:-}" ]; then
+              set +e
+              RAILWAY_API_TOKEN="" RAILWAY_TOKEN="$RAILWAY_API_KEY" "$@"
+              code=$?
+              set -e
+              if [ "$code" -eq 0 ]; then
+                echo "auth_source=RAILWAY_API_KEY action=$action"
+                return 0
+              fi
+            fi
+            if [ -n "${RAILWAY_PROJECT_TOKEN:-}" ]; then
+              set +e
+              RAILWAY_API_TOKEN="" RAILWAY_TOKEN="$RAILWAY_PROJECT_TOKEN" "$@"
+              code=$?
+              set -e
+              if [ "$code" -eq 0 ]; then
+                echo "auth_source=RAILWAY_TOKEN action=$action"
+                return 0
+              fi
+            fi
+            return "$code"
+          }
+
+          run_with_railway_auth link railway link -p "$RAILWAY_PROJECT_ID" -e "$RAILWAY_ENVIRONMENT"
+          run_with_railway_auth variables railway variables \
+            --service "$RAILWAY_WIDGET_CODEX_SERVICE" \
+            --environment "$RAILWAY_ENVIRONMENT" \
+            --set "SERVICE_TYPE=widget-codex" \
+            --set "WIDGET_CODEX_HOST=0.0.0.0" \
+            --set "CODEX_BROKER_URL=$CODEX_BROKER_URL" \
+            --set "CODEX_BROKER_AUTH_TOKEN=$CODEX_BROKER_AUTH_TOKEN" \
+            --set "WIDGET_CODEX_PUBLIC_WS_URL=$WIDGET_CODEX_PUBLIC_WS_URL" \
+            --set "WIDGET_CODEX_ALLOWED_ORIGIN=$WIDGET_CODEX_ALLOWED_ORIGIN" \
+            --set "WIDGET_CODEX_STATE_FILE=$WIDGET_CODEX_STATE_FILE" \
+            --set "WIDGET_CODEX_DEFAULT_SERVERS=$WIDGET_CODEX_DEFAULT_SERVERS" \
+            --skip-deploys
+          run_with_railway_auth redeploy railway redeploy --service "$RAILWAY_WIDGET_CODEX_SERVICE" --yes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,8 +72,8 @@
 - Commits: Imperative ("fix: handle LiveKit reconnect").
 - PRs: Include summary, linked issues, screenshots/logs for agent changes.
 - Requirements: Passing `npm test`, `npm run lint`; no uncommitted changes.
-- Railway prod deploys run on `main` via `.github/workflows/deploy-railway-prod.yml`; archived realtime/conductor deploys are now scoped to legacy runtime paths instead of reset-shell/package changes.
-- Manual workflow dispatch is supported for env updates (`force_conductor`, `force_realtime`) and is ignored unless triggered from `main` (non-main manual triggers are a no-op).
+- Railway prod deploys run on `main` via `.github/workflows/deploy-railway-prod.yml`; long-lived services include realtime, conductor, `codex-broker`, and `widget-codex`.
+- Manual workflow dispatch is supported for env updates (`force_conductor`, `force_realtime`, `force_codex_broker`, `force_widget_codex`) and is ignored unless triggered from `main` (non-main manual triggers are a no-op).
 
 ## Data Compatibility & Persistence
 

--- a/docs/ops/remote-codex-widget-prod.md
+++ b/docs/ops/remote-codex-widget-prod.md
@@ -1,0 +1,44 @@
+# Remote Codex Widget Production Runbook
+
+The `/canvas` Remote Codex widget uses two long-lived Railway services:
+
+- `present-codex-broker`: owns brokered Codex app-server sessions and proxying.
+- `present-widget-codex`: owns the widget server registry, auth state, workspace selection, websocket snapshots, and broker session lifecycle.
+
+Do not route this lifecycle through Vercel/serverless. The Next.js API routes only authorize the browser and proxy control-plane calls to `present-widget-codex`.
+
+## Required Production Configuration
+
+Set these before dispatching `.github/workflows/deploy-railway-prod.yml` from `main`.
+
+GitHub secrets:
+
+- `RAILWAY_API_KEY` or `RAILWAY_TOKEN`
+- `CODEX_BROKER_AUTH_TOKEN`
+- `CODEX_BROKER_DIRECT_TARGET_URL` or the SSH secret set required by `services/codex-broker/src/service.ts`
+- `WIDGET_CODEX_DEFAULT_SERVERS`
+
+GitHub repository variables:
+
+- `CODEX_BROKER_PUBLIC_BASE_URL`
+- `CODEX_BROKER_URL`
+- `WIDGET_CODEX_PUBLIC_WS_URL`
+- `WIDGET_CODEX_ALLOWED_ORIGIN=https://present.best`
+- `WIDGET_CODEX_STATE_FILE=/data/widget-codex/state.json` or another durable Railway volume path
+
+Vercel production env:
+
+- `WIDGET_CODEX_URL` pointing at the public or private URL for `present-widget-codex`
+
+## Smoke Test
+
+1. Open `https://present.best/canvas`.
+2. Insert the Remote Codex widget from the toolbar.
+3. Confirm a saved server appears without manually entering a frame URL.
+4. Authenticate if the server reports `Login Required` or `Login Expired`.
+5. Select a workspace and connect.
+6. Send a native widget turn and confirm it binds a reset workspace/executor.
+7. Refresh the page and confirm the widget restores the same session.
+8. Disconnect and confirm the broker session is torn down.
+
+Browser payloads must not include the saved server transport config, SSH keys, broker auth token, or remote auth credentials.

--- a/services/codex-broker/src/server.ts
+++ b/services/codex-broker/src/server.ts
@@ -356,8 +356,11 @@ export async function buildCodexBrokerServer(options: { service?: CodexBrokerSer
 
 export async function main() {
   const app = await buildCodexBrokerServer();
-  const port = Number(process.env.CODEX_BROKER_PORT ?? '4101');
-  const host = process.env.CODEX_BROKER_HOST ?? '127.0.0.1';
+  const port = Number(process.env.CODEX_BROKER_PORT ?? process.env.PORT ?? '4101');
+  const host =
+    process.env.CODEX_BROKER_HOST ??
+    process.env.HOST ??
+    (process.env.RAILWAY_ENVIRONMENT ? '0.0.0.0' : '127.0.0.1');
   await app.listen({ port, host });
 }
 

--- a/services/kernel/src/collaboration-docs.ts
+++ b/services/kernel/src/collaboration-docs.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import * as Y from 'yjs';
 import { z } from 'zod';
@@ -29,9 +30,15 @@ export type CollaborationDocument = z.infer<typeof collaborationDocumentSchema>;
 const COLLABORATOR_TTL_MS = 30_000;
 let storeLock: Promise<void> = Promise.resolve();
 
+const getDefaultWritableStorePath = () => {
+  if (process.env.VERCEL || process.env.AWS_LAMBDA_FUNCTION_NAME || process.cwd() === '/var/task') {
+    return path.join(os.tmpdir(), 'present-reset-collaboration.json');
+  }
+  return path.join(process.cwd(), '.tmp', 'present-reset-collaboration.json');
+};
+
 const getStorePath = () =>
-  process.env.PRESENT_RESET_COLLABORATION_PATH ??
-  path.join(process.cwd(), '.tmp', 'present-reset-collaboration.json');
+  process.env.PRESENT_RESET_COLLABORATION_PATH ?? getDefaultWritableStorePath();
 
 const ensureParentDirectory = (storePath: string) => {
   fs.mkdirSync(path.dirname(storePath), { recursive: true });

--- a/services/kernel/src/persistence.test.ts
+++ b/services/kernel/src/persistence.test.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import type { KernelEvent, ModelProfile, WorkspaceSession } from '@present/contracts';
 
@@ -77,6 +78,7 @@ describe('reset persistence', () => {
     resetSupabaseTables();
     delete process.env.PRESENT_RESET_STATE_PATH;
     delete process.env.PRESENT_RESET_SUPABASE_CACHE_TTL_MS;
+    delete process.env.VERCEL;
     delete process.env.NEXT_PUBLIC_SUPABASE_URL;
     delete process.env.SUPABASE_SERVICE_ROLE_KEY;
   });
@@ -280,5 +282,15 @@ describe('reset persistence', () => {
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('could not be read'));
 
     warnSpy.mockRestore();
+  });
+
+  it('uses os temp storage by default in serverless runtimes', async () => {
+    delete process.env.PRESENT_RESET_STATE_PATH;
+    process.env.VERCEL = '1';
+    resetKernelStateForTests();
+
+    expect(getResetKernelStatePath()).toBe(path.join(os.tmpdir(), 'present-reset-state.json'));
+
+    delete process.env.VERCEL;
   });
 });

--- a/services/kernel/src/persistence.ts
+++ b/services/kernel/src/persistence.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 import { z } from 'zod';
@@ -346,8 +347,14 @@ let lastSupabaseHydratedAt = 0;
 const pendingMirrorWrites = new Set<Promise<void>>();
 let warningKeys = new Set<string>();
 
-const getStatePath = () =>
-  process.env.PRESENT_RESET_STATE_PATH ?? path.join(process.cwd(), '.tmp', 'present-reset-state.json');
+const getDefaultWritableStatePath = () => {
+  if (process.env.VERCEL || process.env.AWS_LAMBDA_FUNCTION_NAME || process.cwd() === '/var/task') {
+    return path.join(os.tmpdir(), 'present-reset-state.json');
+  }
+  return path.join(process.cwd(), '.tmp', 'present-reset-state.json');
+};
+
+const getStatePath = () => process.env.PRESENT_RESET_STATE_PATH ?? getDefaultWritableStatePath();
 
 const getSupabaseCacheTtlMs = () => {
   const rawValue = Number(process.env.PRESENT_RESET_SUPABASE_CACHE_TTL_MS ?? '2000');

--- a/services/widget-codex/src/client.ts
+++ b/services/widget-codex/src/client.ts
@@ -90,10 +90,20 @@ export async function startWidgetCodexAuth(serverId: string) {
   );
 }
 
-export async function completeWidgetCodexAuth(serverId: string) {
+export async function completeWidgetCodexAuth(
+  serverId: string,
+  input: {
+    widgetSessionId?: string;
+    remoteWorkspaceId?: string;
+    remoteWorkspacePath?: string;
+  } = {},
+) {
   return widgetCodexRequest<{ server: WidgetCodexPublicServer }>(
     `/servers/${encodeURIComponent(serverId)}/auth/complete`,
-    { method: 'POST' },
+    {
+      method: 'POST',
+      body: JSON.stringify(input),
+    },
   );
 }
 

--- a/services/widget-codex/src/contracts.ts
+++ b/services/widget-codex/src/contracts.ts
@@ -7,7 +7,7 @@ export const widgetCodexWorkspaceSchema = z.object({
 });
 
 export const widgetCodexAuthStrategySchema = z.enum(['none', 'external_url', 'iframe']);
-export const widgetCodexAuthStateSchema = z.enum(['unknown', 'login_required', 'pending', 'authenticated']);
+export const widgetCodexAuthStateSchema = z.enum(['unknown', 'login_required', 'pending', 'authenticated', 'expired']);
 export const widgetCodexConnectionStatusSchema = z.enum(['disconnected', 'connecting', 'ready', 'error']);
 
 export const widgetCodexServerInputSchema = z.object({
@@ -32,6 +32,12 @@ export const widgetCodexCreateConnectionInputSchema = z.object({
   widgetSessionId: z.string().min(1).optional(),
   title: z.string().min(1).optional(),
   serverId: z.string().min(1),
+  remoteWorkspaceId: z.string().min(1).optional(),
+  remoteWorkspacePath: z.string().min(1).optional(),
+});
+
+export const widgetCodexCompleteAuthInputSchema = z.object({
+  widgetSessionId: z.string().min(1).optional(),
   remoteWorkspaceId: z.string().min(1).optional(),
   remoteWorkspacePath: z.string().min(1).optional(),
 });

--- a/services/widget-codex/src/server.test.ts
+++ b/services/widget-codex/src/server.test.ts
@@ -96,31 +96,20 @@ describe('Widget Codex server', () => {
       const authCompleteResponse = await app.inject({
         method: 'POST',
         url: `/servers/${createdServer.id}/auth/complete`,
+        payload: {
+          widgetSessionId: 'wcws_123',
+          remoteWorkspaceId: 'present',
+        },
       });
       expect(authCompleteResponse.statusCode).toBe(200);
-      expect(authCompleteResponse.json().server.authState).toBe('login_required');
-
-      const patchServerResponse = await app.inject({
-        method: 'PATCH',
-        url: `/servers/${createdServer.id}`,
-        payload: {
-          authStrategy: 'none',
-          authUrl: null,
-        },
-      });
-      expect(patchServerResponse.statusCode).toBe(200);
-      expect(patchServerResponse.json().server.authState).toBe('authenticated');
-
-      const repatchServerResponse = await app.inject({
-        method: 'PATCH',
-        url: `/servers/${createdServer.id}`,
-        payload: {
-          authStrategy: 'external_url',
-          authUrl: 'https://remote-codex.example/login',
-        },
-      });
-      expect(repatchServerResponse.statusCode).toBe(200);
-      expect(repatchServerResponse.json().server.authState).toBe('login_required');
+      expect(authCompleteResponse.json().server.authState).toBe('authenticated');
+      expect(broker.createSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          workspaceSessionId: 'wcws_123',
+          remoteWorkingDirectory: '/srv/codex/repos/PRESENT',
+        }),
+      );
+      expect(broker.deleteSession).toHaveBeenCalledWith('cxs_widget');
 
       const createConnectionResponse = await app.inject({
         method: 'POST',
@@ -147,6 +136,11 @@ describe('Widget Codex server', () => {
         connection: { id: string; frameUrl: string };
       };
       expect(connectionPayload.connection.frameUrl).toContain('/sessions/cxs_widget/proxy/token/');
+      expect(JSON.stringify(createConnectionResponse.json())).not.toContain('https://remote-codex.example');
+
+      const serversResponse = await app.inject({ method: 'GET', url: '/servers' });
+      expect(serversResponse.statusCode).toBe(200);
+      expect(JSON.stringify(serversResponse.json())).not.toContain('directTargetUrl');
 
       const refreshConnectionResponse = await app.inject({
         method: 'GET',
@@ -173,5 +167,63 @@ describe('Widget Codex server', () => {
     } finally {
       await app.close();
     }
+  });
+
+  it('marks auth as expired when a verified auth probe fails with an auth-shaped broker error', async () => {
+    const broker = {
+      createSession: jest.fn().mockRejectedValue(new Error('401 unauthorized session expired')),
+      getSession: jest.fn(),
+      deleteSession: jest.fn(),
+    };
+    const service = new WidgetCodexService({
+      stateFilePath,
+      broker,
+      defaultServers: [
+        {
+          id: 'wcsrv_expired',
+          label: 'Expired Remote',
+          description: null,
+          authStrategy: 'external_url',
+          authState: 'pending',
+          authUrl: 'https://remote-codex.example/login',
+          transport: {
+            directTargetUrl: 'https://remote-codex.example/',
+          },
+          workspaces: [
+            {
+              id: 'present',
+              label: 'PRESENT',
+              path: '/srv/codex/repos/PRESENT',
+            },
+          ],
+        },
+      ],
+    });
+    const app = await buildWidgetCodexServer({ service });
+
+    try {
+      const authCompleteResponse = await app.inject({
+        method: 'POST',
+        url: '/servers/wcsrv_expired/auth/complete',
+        payload: {
+          remoteWorkspaceId: 'present',
+        },
+      });
+      expect(authCompleteResponse.statusCode).toBe(400);
+
+      const serversResponse = await app.inject({ method: 'GET', url: '/servers' });
+      expect(serversResponse.json().servers[0].authState).toBe('expired');
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('fails fast when the state file path points at a directory', async () => {
+    const directoryPath = path.join(os.tmpdir(), `present-widget-codex-dir-${Date.now()}`);
+    await fs.mkdir(directoryPath, { recursive: true });
+    const service = new WidgetCodexService({ stateFilePath: directoryPath });
+
+    await expect(buildWidgetCodexServer({ service })).rejects.toThrow(/state file path points to a directory/i);
+    await fs.rm(directoryPath, { recursive: true, force: true });
   });
 });

--- a/services/widget-codex/src/server.ts
+++ b/services/widget-codex/src/server.ts
@@ -5,6 +5,7 @@ import websocketPlugin from '@fastify/websocket';
 import type WebSocket from 'ws';
 import {
   createWidgetCodexServiceFromEnv,
+  widgetCodexCompleteAuthInputSchema,
   widgetCodexCreateConnectionInputSchema,
   widgetCodexServerInputSchema,
   widgetCodexServerPatchSchema,
@@ -53,7 +54,10 @@ export async function buildWidgetCodexServer(options: { service?: WidgetCodexSer
   });
   await app.register(websocketPlugin);
 
-  app.get('/health', async () => ({ ok: true }));
+  app.get('/health', async () => ({
+    ok: true,
+    runtime: service.getRuntimeStatus(),
+  }));
 
   app.get('/servers', async () => ({
     realtimeUrl: process.env.WIDGET_CODEX_PUBLIC_WS_URL ?? null,
@@ -114,13 +118,17 @@ export async function buildWidgetCodexServer(options: { service?: WidgetCodexSer
   });
 
   app.post('/servers/:serverId/auth/complete', async (request, reply) => {
-    const serverId = String((request.params as { serverId?: string } | undefined)?.serverId ?? '');
-    const server = await service.completeAuth(serverId);
-    if (!server) {
-      reply.code(404).send({ error: 'Widget Codex server not found.' });
-      return;
+    try {
+      const serverId = String((request.params as { serverId?: string } | undefined)?.serverId ?? '');
+      const server = await service.completeAuth(serverId, widgetCodexCompleteAuthInputSchema.parse(request.body ?? {}));
+      if (!server) {
+        reply.code(404).send({ error: 'Widget Codex server not found.' });
+        return;
+      }
+      reply.send({ server });
+    } catch (error) {
+      reply.code(400).send({ error: error instanceof Error ? error.message : 'Failed to complete Widget Codex auth.' });
     }
-    reply.send({ server });
   });
 
   app.post('/connections', async (request, reply) => {
@@ -213,8 +221,11 @@ export async function buildWidgetCodexServer(options: { service?: WidgetCodexSer
 
 export async function main() {
   const app = await buildWidgetCodexServer();
-  const port = Number(process.env.WIDGET_CODEX_PORT ?? '4102');
-  const host = process.env.WIDGET_CODEX_HOST ?? '127.0.0.1';
+  const port = Number(process.env.WIDGET_CODEX_PORT ?? process.env.PORT ?? '4102');
+  const host =
+    process.env.WIDGET_CODEX_HOST ??
+    process.env.HOST ??
+    (process.env.RAILWAY_ENVIRONMENT ? '0.0.0.0' : '127.0.0.1');
   await app.listen({ port, host });
 }
 

--- a/services/widget-codex/src/service.ts
+++ b/services/widget-codex/src/service.ts
@@ -1,5 +1,6 @@
 import crypto from 'node:crypto';
 import { EventEmitter } from 'node:events';
+import { constants as fsConstants } from 'node:fs';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { z } from 'zod';
@@ -13,6 +14,7 @@ import type { CodexBrokerSessionSnapshot } from '@present/codex-broker/session-s
 import {
   widgetCodexAuthStateSchema,
   widgetCodexAuthStrategySchema,
+  widgetCodexCompleteAuthInputSchema,
   widgetCodexConnectionStatusSchema,
   widgetCodexCreateConnectionInputSchema,
   widgetCodexServerInputSchema,
@@ -117,10 +119,26 @@ export type WidgetCodexServiceConfig = {
 
 const DEFAULT_STATE_DIR = path.join(process.cwd(), '.present-data', 'widget-codex');
 const DEFAULT_STATE_FILE = path.join(DEFAULT_STATE_DIR, 'state.json');
+const AUTH_EXPIRED_PATTERN = /\b(auth|login|session|token|credential).*\b(expired|invalid|unauthorized|forbidden)|\b(401|403)\b/i;
 
 const createId = (prefix: string) => `${prefix}_${crypto.randomUUID().replace(/-/g, '')}`;
 
 const nowIso = () => new Date().toISOString();
+
+const isAuthExpiredError = (error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error ?? '');
+  return AUTH_EXPIRED_PATTERN.test(message);
+};
+
+const resolveStateFilePath = (input?: string | null) => {
+  const trimmed = input?.trim();
+  if (trimmed) return path.resolve(trimmed);
+  const railwayVolume = process.env.RAILWAY_VOLUME_MOUNT_PATH?.trim();
+  if (railwayVolume) {
+    return path.join(path.resolve(railwayVolume), 'widget-codex', 'state.json');
+  }
+  return DEFAULT_STATE_FILE;
+};
 
 const defaultBrokerClient: BrokerClient = {
   createSession: createCodexBrokerSession,
@@ -160,9 +178,107 @@ function normalizeDefaultServer(input: z.infer<typeof widgetCodexDefaultServerSc
 async function ensureStateFile(stateFilePath: string) {
   await fs.mkdir(path.dirname(stateFilePath), { recursive: true });
   try {
+    const stats = await fs.stat(stateFilePath);
+    if (stats.isDirectory()) {
+      throw new Error(`Widget Codex state file path points to a directory: ${stateFilePath}`);
+    }
     await fs.access(stateFilePath);
-  } catch {
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw error;
+    }
     await fs.writeFile(stateFilePath, JSON.stringify(widgetCodexStateSchema.parse({ schemaVersion: 1 }), null, 2), 'utf8');
+  }
+}
+
+async function assertStateFileWritable(stateFilePath: string) {
+  await ensureStateFile(stateFilePath);
+  await fs.access(stateFilePath, fsConstants.R_OK | fsConstants.W_OK);
+}
+
+async function removeProbeSession(broker: BrokerClient, sessionId: string) {
+  try {
+    await broker.deleteSession(sessionId);
+  } catch {
+    /* auth probes should not leave user-visible failures when teardown races */
+  }
+}
+
+function resolveWorkspaceForServer(
+  server: WidgetCodexServerInternal,
+  input: {
+    remoteWorkspaceId?: string;
+    remoteWorkspacePath?: string;
+  },
+) {
+  return (
+    (input.remoteWorkspaceId
+      ? server.workspaces.find((entry) => entry.id === input.remoteWorkspaceId)
+      : null) ??
+    (input.remoteWorkspacePath
+      ? server.workspaces.find((entry) => entry.path === input.remoteWorkspacePath)
+      : null) ??
+    server.workspaces[0] ??
+    (input.remoteWorkspacePath
+      ? {
+          id: createId('wcwsp'),
+          label: input.remoteWorkspacePath.split('/').filter(Boolean).at(-1) ?? input.remoteWorkspacePath,
+          path: input.remoteWorkspacePath,
+        }
+      : null)
+  );
+}
+
+function mergeWidgetSessionPatch(
+  session: WidgetCodexWidgetSession,
+  patch: Partial<Pick<WidgetCodexWidgetSession, 'authState' | 'status' | 'lastError' | 'lastHeartbeatAt'>>,
+) {
+  return widgetCodexWidgetSessionSchema.parse({
+    ...session,
+    ...patch,
+    updatedAt: nowIso(),
+  });
+}
+
+function mergeConnectionPatch(
+  connection: WidgetCodexConnectionRecord,
+  patch: Partial<Pick<WidgetCodexConnectionRecord, 'authState' | 'status' | 'lastError' | 'lastHeartbeatAt'>>,
+) {
+  return widgetCodexConnectionRecordSchema.parse({
+    ...connection,
+    ...patch,
+    updatedAt: nowIso(),
+  });
+}
+
+function authStateForFailedRemoteError(error: unknown, fallback: WidgetCodexAuthState) {
+  return isAuthExpiredError(error) ? 'expired' : fallback;
+}
+
+function patchValue<T extends Record<string, unknown>, K extends keyof T>(
+  input: T,
+  existing: T | null,
+  key: K,
+  fallback: T[K],
+) {
+  return Object.prototype.hasOwnProperty.call(input, key) ? input[key] : existing?.[key] ?? fallback;
+}
+
+async function verifyServerAuth(input: {
+  broker: BrokerClient;
+  server: WidgetCodexServerInternal;
+  widgetSessionId: string;
+  remoteWorkspacePath: string;
+}) {
+  const { session } = await input.broker.createSession({
+    workspaceSessionId: input.widgetSessionId,
+    remoteWorkingDirectory: input.remoteWorkspacePath,
+    reconnect: true,
+    transport: input.server.transport,
+  });
+  await removeProbeSession(input.broker, session.sessionId);
+  if (session.status !== 'ready') {
+    throw new Error(`Remote Codex auth probe did not become ready: ${session.status}`);
   }
 }
 
@@ -180,7 +296,7 @@ export class WidgetCodexService {
   private hydrated = false;
 
   constructor(config: WidgetCodexServiceConfig = {}) {
-    this.stateFilePath = config.stateFilePath?.trim() || DEFAULT_STATE_FILE;
+    this.stateFilePath = resolveStateFilePath(config.stateFilePath);
     this.realtimeUrl = config.realtimeUrl?.trim() || null;
     this.broker = config.broker ?? defaultBrokerClient;
     if (config.defaultServers?.length) {
@@ -198,7 +314,7 @@ export class WidgetCodexService {
 
   async hydrate() {
     if (this.hydrated) return;
-    await ensureStateFile(this.stateFilePath);
+    await assertStateFileWritable(this.stateFilePath);
     const raw = await fs.readFile(this.stateFilePath, 'utf8');
     const parsed = widgetCodexStateSchema.parse(JSON.parse(raw));
     const mergedServers = [...parsed.servers];
@@ -212,6 +328,14 @@ export class WidgetCodexService {
     });
     this.hydrated = true;
     await this.saveState();
+  }
+
+  getRuntimeStatus() {
+    return {
+      stateFilePath: this.stateFilePath,
+      realtimeUrl: this.realtimeUrl,
+      hydrated: this.hydrated,
+    };
   }
 
   subscribe(listener: (snapshot: WidgetCodexSnapshot) => void) {
@@ -380,14 +504,41 @@ export class WidgetCodexService {
     };
   }
 
-  async completeAuth(serverId: string) {
+  async completeAuth(serverId: string, input: z.infer<typeof widgetCodexCompleteAuthInputSchema> = {}) {
     await this.hydrate();
     const server = this.resolveServer(serverId);
     if (!server) return null;
+    const payload = widgetCodexCompleteAuthInputSchema.parse(input);
+    if (server.authStrategy !== 'none') {
+      const workspace = resolveWorkspaceForServer(server, payload);
+      if (!workspace) {
+        throw new Error('Server does not expose a workspace to verify authentication against.');
+      }
+      try {
+        await verifyServerAuth({
+          broker: this.broker,
+          server,
+          widgetSessionId: payload.widgetSessionId ?? `auth_probe_${server.id}`,
+          remoteWorkspacePath: workspace.path,
+        });
+      } catch (error) {
+        const failed = {
+          ...server,
+          authState: authStateForFailedRemoteError(error, 'login_required'),
+          updatedAt: nowIso(),
+        };
+        this.state = widgetCodexStateSchema.parse({
+          ...this.state,
+          servers: this.state.servers.map((entry) => (entry.id === serverId ? failed : entry)),
+        });
+        await this.saveState();
+        this.emitSnapshot(null);
+        throw error;
+      }
+    }
     const next = {
       ...server,
-      authState:
-        server.authStrategy === 'none' ? ('authenticated' as const) : server.authUrl ? ('login_required' as const) : ('unknown' as const),
+      authState: 'authenticated' as const,
       updatedAt: nowIso(),
     };
     this.state = widgetCodexStateSchema.parse({
@@ -419,14 +570,14 @@ export class WidgetCodexService {
     const widgetSession = widgetCodexWidgetSessionSchema.parse({
       id: existing?.id ?? input.widgetSessionId ?? createId('wcws'),
       title: input.title?.trim() || existing?.title || 'Remote Codex',
-      serverId: input.serverId ?? existing?.serverId ?? null,
-      connectionId: input.connectionId ?? existing?.connectionId ?? null,
-      remoteWorkspaceId: input.remoteWorkspaceId ?? existing?.remoteWorkspaceId ?? null,
-      remoteWorkspacePath: input.remoteWorkspacePath ?? existing?.remoteWorkspacePath ?? null,
+      serverId: patchValue(input, existing, 'serverId', null),
+      connectionId: patchValue(input, existing, 'connectionId', null),
+      remoteWorkspaceId: patchValue(input, existing, 'remoteWorkspaceId', null),
+      remoteWorkspacePath: patchValue(input, existing, 'remoteWorkspacePath', null),
       status: input.status,
       authState: input.authState,
       activeThreadId: existing?.activeThreadId ?? null,
-      lastHeartbeatAt: input.lastHeartbeatAt ?? existing?.lastHeartbeatAt ?? null,
+      lastHeartbeatAt: patchValue(input, existing, 'lastHeartbeatAt', null),
       lastError: input.lastError ?? null,
       createdAt: existing?.createdAt ?? timestamp,
       updatedAt: timestamp,
@@ -448,21 +599,15 @@ export class WidgetCodexService {
     if (!server) {
       throw new Error('Widget Codex server not found.');
     }
-    const workspace =
-      (payload.remoteWorkspaceId
-        ? server.workspaces.find((entry) => entry.id === payload.remoteWorkspaceId)
-        : null) ??
-      (payload.remoteWorkspacePath
-        ? server.workspaces.find((entry) => entry.path === payload.remoteWorkspacePath)
-        : null) ??
-      server.workspaces[0] ??
-      (payload.remoteWorkspacePath
-        ? {
-            id: createId('wcwsp'),
-            label: payload.remoteWorkspacePath.split('/').filter(Boolean).at(-1) ?? payload.remoteWorkspacePath,
-            path: payload.remoteWorkspacePath,
-          }
-        : null);
+    if (server.authStrategy !== 'none' && server.authState !== 'authenticated') {
+      throw new Error(
+        server.authState === 'expired'
+          ? 'Remote Codex authentication expired. Re-authenticate before connecting.'
+          : 'Remote Codex authentication is required before connecting.',
+      );
+    }
+
+    const workspace = resolveWorkspaceForServer(server, payload);
 
     if (!workspace) {
       throw new Error('Server does not expose any remote workspaces yet.');
@@ -484,12 +629,42 @@ export class WidgetCodexService {
       await this.deleteConnection(widgetSession.connectionId);
     }
 
-    const { session } = await this.broker.createSession({
-      workspaceSessionId: widgetSession.id,
-      remoteWorkingDirectory: workspace.path,
-      reconnect: true,
-      transport: server.transport,
-    });
+    let session: CodexBrokerSessionSnapshot;
+    try {
+      const result = await this.broker.createSession({
+        workspaceSessionId: widgetSession.id,
+        remoteWorkingDirectory: workspace.path,
+        reconnect: true,
+        transport: server.transport,
+      });
+      session = result.session;
+    } catch (error) {
+      const nextAuthState = authStateForFailedRemoteError(error, server.authState);
+      this.state = widgetCodexStateSchema.parse({
+        ...this.state,
+        servers: this.state.servers.map((entry) =>
+          entry.id === server.id
+            ? {
+                ...entry,
+                authState: nextAuthState,
+                updatedAt: nowIso(),
+              }
+            : entry,
+        ),
+        widgetSessions: this.state.widgetSessions.map((entry) =>
+          entry.id === widgetSession.id
+            ? mergeWidgetSessionPatch(entry, {
+                status: 'error',
+                authState: nextAuthState,
+                lastError: error instanceof Error ? error.message : 'Remote Codex connection failed.',
+              })
+            : entry,
+        ),
+      });
+      await this.saveState();
+      this.emitSnapshot(widgetSession.id);
+      throw error;
+    }
 
     const connection = widgetCodexConnectionRecordSchema.parse({
       id: createId('wccx'),
@@ -567,14 +742,23 @@ export class WidgetCodexService {
       return toPublicConnection(next);
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Connection refresh failed.';
-      const next = widgetCodexConnectionRecordSchema.parse({
-        ...current,
+      const nextAuthState = authStateForFailedRemoteError(error, current.authState);
+      const next = mergeConnectionPatch(current, {
         status: 'error',
+        authState: nextAuthState,
         lastError: message,
-        updatedAt: nowIso(),
       });
       this.state = widgetCodexStateSchema.parse({
         ...this.state,
+        servers: this.state.servers.map((server) =>
+          server.id === next.serverId && nextAuthState === 'expired'
+            ? {
+                ...server,
+                authState: 'expired',
+                updatedAt: nowIso(),
+              }
+            : server,
+        ),
         connections: this.state.connections.map((entry) => (entry.id === connectionId ? next : entry)),
       });
       this.upsertWidgetSession({
@@ -584,7 +768,7 @@ export class WidgetCodexService {
         remoteWorkspaceId: next.remoteWorkspaceId,
         remoteWorkspacePath: next.remoteWorkspacePath,
         status: 'error',
-        authState: next.authState,
+        authState: nextAuthState,
         lastHeartbeatAt: next.lastHeartbeatAt,
         lastError: message,
       });
@@ -641,6 +825,7 @@ export function createWidgetCodexServiceFromEnv() {
 }
 
 export {
+  widgetCodexCompleteAuthInputSchema,
   widgetCodexCreateConnectionInputSchema,
   widgetCodexServerInputSchema,
   widgetCodexServerPatchSchema,

--- a/src/app/api/widget-codex/servers/[serverId]/auth/complete/route.ts
+++ b/src/app/api/widget-codex/servers/[serverId]/auth/complete/route.ts
@@ -13,7 +13,8 @@ export async function POST(
   if (authResponse) return authResponse;
   try {
     const { serverId } = await params;
-    const response = await completeWidgetCodexAuth(serverId);
+    const body = await request.json().catch(() => ({}));
+    const response = await completeWidgetCodexAuth(serverId, body);
     return NextResponse.json(response);
   } catch (error) {
     return toWidgetCodexErrorResponse(error, 'Failed to complete Widget Codex auth.');

--- a/src/components/ui/codex/codex-remote-widget.test.tsx
+++ b/src/components/ui/codex/codex-remote-widget.test.tsx
@@ -256,4 +256,89 @@ describe('CodexRemoteWidget', () => {
     });
     expect(await screen.findByTitle('Widget Codex Login')).toBeTruthy();
   });
+
+  it('verifies auth completion with the selected workspace instead of closing the helper blindly', async () => {
+    (global.fetch as jest.Mock).mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === '/api/widget-codex/servers') {
+        return {
+          ok: true,
+          json: async () => ({
+            realtimeUrl: null,
+            servers: [
+              {
+                ...buildServersPayload().servers[0],
+                authStrategy: 'iframe',
+                authState: 'pending',
+                authUrl: 'https://remote-codex.example/login',
+              },
+            ],
+          }),
+        } as Response;
+      }
+      if (url === '/api/widget-codex/servers/wcsrv_1/auth/complete') {
+        return {
+          ok: true,
+          json: async () => ({
+            server: {
+              ...buildServersPayload().servers[0],
+              authStrategy: 'iframe',
+              authState: 'authenticated',
+              authUrl: 'https://remote-codex.example/login',
+            },
+          }),
+        } as Response;
+      }
+      return {
+        ok: true,
+        json: async () => buildServersPayload(),
+      } as Response;
+    });
+
+    render(<CodexRemoteWidget title="Remote Codex" />);
+
+    await screen.findByRole('option', { name: 'Remote Prod' });
+    fireEvent.click(screen.getByText('Close Login Helper'));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/widget-codex/servers/wcsrv_1/auth/complete',
+        expect.objectContaining({
+          method: 'POST',
+          body: expect.stringContaining('"remoteWorkspaceId":"present"'),
+        }),
+      );
+    });
+  });
+
+  it('surfaces expired auth as a re-authentication state', async () => {
+    (global.fetch as jest.Mock).mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/api/widget-codex/servers') {
+        return {
+          ok: true,
+          json: async () => ({
+            realtimeUrl: null,
+            servers: [
+              {
+                ...buildServersPayload().servers[0],
+                authStrategy: 'external_url',
+                authState: 'expired',
+                authUrl: 'https://remote-codex.example/login',
+              },
+            ],
+          }),
+        } as Response;
+      }
+      return {
+        ok: true,
+        json: async () => ({}),
+      } as Response;
+    });
+
+    render(<CodexRemoteWidget title="Remote Codex" />);
+
+    expect(await screen.findByText('Auth: Login Expired')).toBeTruthy();
+    expect(screen.getByText('Open Login')).toBeTruthy();
+  });
 });

--- a/src/components/ui/codex/codex-remote-widget.tsx
+++ b/src/components/ui/codex/codex-remote-widget.tsx
@@ -37,7 +37,7 @@ type WidgetCodexServer = {
   label: string;
   description: string | null;
   authStrategy: 'none' | 'external_url' | 'iframe';
-  authState: 'unknown' | 'login_required' | 'pending' | 'authenticated';
+  authState: 'unknown' | 'login_required' | 'pending' | 'authenticated' | 'expired';
   authUrl: string | null;
   workspaces: Array<{
     id: string;
@@ -58,7 +58,7 @@ type WidgetCodexConnection = {
   frameUrl: string;
   proxyBaseUrl: string;
   status: 'disconnected' | 'connecting' | 'ready' | 'error';
-  authState: 'unknown' | 'login_required' | 'pending' | 'authenticated';
+  authState: 'unknown' | 'login_required' | 'pending' | 'authenticated' | 'expired';
   lastHeartbeatAt: string | null;
   lastError: string | null;
   createdAt: string;
@@ -73,7 +73,7 @@ type WidgetCodexWidgetSession = {
   remoteWorkspaceId: string | null;
   remoteWorkspacePath: string | null;
   status: 'disconnected' | 'connecting' | 'ready' | 'error';
-  authState: 'unknown' | 'login_required' | 'pending' | 'authenticated';
+  authState: 'unknown' | 'login_required' | 'pending' | 'authenticated' | 'expired';
   activeThreadId: string | null;
   lastHeartbeatAt: string | null;
   lastError: string | null;
@@ -712,6 +712,13 @@ export function CodexRemoteWidget(props: CanvasCodexRemoteWidgetProps) {
     try {
       await requestJson(`/api/widget-codex/servers/${encodeURIComponent(selectedServerId)}/auth/complete`, {
         method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          widgetSessionId: state.widgetSessionId ?? createWidgetSessionId(),
+          remoteWorkspaceId: selectedWorkspaceId || undefined,
+          remoteWorkspacePath:
+            workspaces.find((workspace) => workspace.id === selectedWorkspaceId)?.path ?? undefined,
+        }),
       });
       setLoginUrl(null);
       await loadServers();
@@ -1009,6 +1016,8 @@ export function CodexRemoteWidget(props: CanvasCodexRemoteWidgetProps) {
       ? 'Authenticated'
       : selectedServer?.authState === 'pending'
         ? 'Login Pending'
+        : selectedServer?.authState === 'expired'
+          ? 'Login Expired'
         : selectedServer?.authState === 'login_required'
           ? 'Login Required'
           : 'Unknown';

--- a/src/lib/agents/control-plane/apply-config.ts
+++ b/src/lib/agents/control-plane/apply-config.ts
@@ -21,8 +21,12 @@ const ApplyConfigSchema = z
         environmentName: z.string().trim().min(1).optional(),
         conductorServiceId: z.string().trim().min(1).optional(),
         realtimeServiceId: z.string().trim().min(1).optional(),
+        codexBrokerServiceId: z.string().trim().min(1).optional(),
+        widgetCodexServiceId: z.string().trim().min(1).optional(),
         conductorServiceName: z.string().trim().min(1).optional(),
         realtimeServiceName: z.string().trim().min(1).optional(),
+        codexBrokerServiceName: z.string().trim().min(1).optional(),
+        widgetCodexServiceName: z.string().trim().min(1).optional(),
       })
       .strict()
       .optional(),

--- a/src/lib/agents/control-plane/apply-runtime.test.ts
+++ b/src/lib/agents/control-plane/apply-runtime.test.ts
@@ -75,7 +75,7 @@ describe('apply runtime', () => {
     expect(global.fetch).toHaveBeenCalledTimes(2);
   });
 
-  it('dedupes railway discovery when both railway services apply concurrently', async () => {
+  it('dedupes railway discovery when all railway services apply concurrently', async () => {
     process.env[CONFIG_ENV] = JSON.stringify({
       railway: {
         token: 'railway-token',
@@ -83,6 +83,8 @@ describe('apply runtime', () => {
         environmentName: 'production',
         conductorServiceName: 'present-conductor',
         realtimeServiceName: 'present-realtime',
+        codexBrokerServiceName: 'present-codex-broker',
+        widgetCodexServiceName: 'present-widget-codex',
       },
     });
 
@@ -107,6 +109,8 @@ describe('apply runtime', () => {
                         edges: [
                           { node: { serviceId: 'svc-conductor', serviceName: 'present-conductor' } },
                           { node: { serviceId: 'svc-realtime', serviceName: 'present-realtime' } },
+                          { node: { serviceId: 'svc-codex-broker', serviceName: 'present-codex-broker' } },
+                          { node: { serviceId: 'svc-widget-codex', serviceName: 'present-widget-codex' } },
                         ],
                       },
                     },
@@ -132,17 +136,26 @@ describe('apply runtime', () => {
     const { runApplyService, __resetApplyRuntimeCachesForTests } = require('./apply-runtime');
     __resetApplyRuntimeCachesForTests();
 
-    const [conductor, realtime] = await Promise.all([
+    const [conductor, realtime, codexBroker, widgetCodex] = await Promise.all([
       runApplyService('railway_conductor'),
       runApplyService('railway_realtime'),
+      runApplyService('railway_codex_broker'),
+      runApplyService('railway_widget_codex'),
     ]);
-    if (conductor.status !== 'applied' || realtime.status !== 'applied') {
+    if (
+      conductor.status !== 'applied' ||
+      realtime.status !== 'applied' ||
+      codexBroker.status !== 'applied' ||
+      widgetCodex.status !== 'applied'
+    ) {
       throw new Error(
-        `railway apply failed in test: conductor=${conductor.detail || conductor.status}, realtime=${realtime.detail || realtime.status}`,
+        `railway apply failed in test: conductor=${conductor.detail || conductor.status}, realtime=${realtime.detail || realtime.status}, codexBroker=${codexBroker.detail || codexBroker.status}, widgetCodex=${widgetCodex.detail || widgetCodex.status}`,
       );
     }
     expect(conductor.status).toBe('applied');
     expect(realtime.status).toBe('applied');
+    expect(codexBroker.status).toBe('applied');
+    expect(widgetCodex.status).toBe('applied');
     expect(discoveryCalls).toBe(1);
   });
 });

--- a/src/lib/agents/control-plane/apply-runtime.ts
+++ b/src/lib/agents/control-plane/apply-runtime.ts
@@ -13,8 +13,15 @@ const DEFAULT_RAILWAY_PROJECT_ID = '98df8e65-3c11-452c-beb7-8fd0cb3754d3';
 const DEFAULT_RAILWAY_ENVIRONMENT_NAME = 'production';
 const DEFAULT_RAILWAY_CONDUCTOR_SERVICE_NAME = 'present-conductor';
 const DEFAULT_RAILWAY_REALTIME_SERVICE_NAME = 'present-realtime';
+const DEFAULT_RAILWAY_CODEX_BROKER_SERVICE_NAME = 'present-codex-broker';
+const DEFAULT_RAILWAY_WIDGET_CODEX_SERVICE_NAME = 'present-widget-codex';
 
-export type ApplyServiceName = 'vercel_web' | 'railway_conductor' | 'railway_realtime';
+export type ApplyServiceName =
+  | 'vercel_web'
+  | 'railway_conductor'
+  | 'railway_realtime'
+  | 'railway_codex_broker'
+  | 'railway_widget_codex';
 export type ApplyStepStatus = 'applied' | 'failed' | 'skipped_unconfigured';
 export type ApplyStepResult = {
   service: ApplyServiceName;
@@ -22,7 +29,13 @@ export type ApplyStepResult = {
   detail?: string;
 };
 
-const APPLY_SERVICES: readonly ApplyServiceName[] = ['vercel_web', 'railway_conductor', 'railway_realtime'];
+const APPLY_SERVICES: readonly ApplyServiceName[] = [
+  'vercel_web',
+  'railway_conductor',
+  'railway_realtime',
+  'railway_codex_broker',
+  'railway_widget_codex',
+];
 
 class MissingApplySettingError extends Error {
   constructor(public readonly key: string) {
@@ -216,10 +229,20 @@ const resolveRailwaySettings = async (service: ApplyServiceName) => {
           config.railway?.conductorServiceId,
           process.env.MODEL_CONTROL_APPLY_RAILWAY_CONDUCTOR_SERVICE_ID,
         )
-      : pickFirstNonEmpty(
-          config.railway?.realtimeServiceId,
-          process.env.MODEL_CONTROL_APPLY_RAILWAY_REALTIME_SERVICE_ID,
-        );
+      : service === 'railway_realtime'
+        ? pickFirstNonEmpty(
+            config.railway?.realtimeServiceId,
+            process.env.MODEL_CONTROL_APPLY_RAILWAY_REALTIME_SERVICE_ID,
+          )
+        : service === 'railway_codex_broker'
+          ? pickFirstNonEmpty(
+              config.railway?.codexBrokerServiceId,
+              process.env.MODEL_CONTROL_APPLY_RAILWAY_CODEX_BROKER_SERVICE_ID,
+            )
+          : pickFirstNonEmpty(
+              config.railway?.widgetCodexServiceId,
+              process.env.MODEL_CONTROL_APPLY_RAILWAY_WIDGET_CODEX_SERVICE_ID,
+            );
 
   if (directEnvironmentId && directServiceId) {
     return {
@@ -250,7 +273,11 @@ const resolveRailwaySettings = async (service: ApplyServiceName) => {
   const serviceName =
     service === 'railway_conductor'
       ? pickFirstNonEmpty(config.railway?.conductorServiceName, DEFAULT_RAILWAY_CONDUCTOR_SERVICE_NAME)
-      : pickFirstNonEmpty(config.railway?.realtimeServiceName, DEFAULT_RAILWAY_REALTIME_SERVICE_NAME);
+      : service === 'railway_realtime'
+        ? pickFirstNonEmpty(config.railway?.realtimeServiceName, DEFAULT_RAILWAY_REALTIME_SERVICE_NAME)
+        : service === 'railway_codex_broker'
+          ? pickFirstNonEmpty(config.railway?.codexBrokerServiceName, DEFAULT_RAILWAY_CODEX_BROKER_SERVICE_NAME)
+          : pickFirstNonEmpty(config.railway?.widgetCodexServiceName, DEFAULT_RAILWAY_WIDGET_CODEX_SERVICE_NAME);
 
   const discoveredServiceId = serviceName ? discovery.serviceIdsByName[serviceName] : null;
   const serviceId = directServiceId || discoveredServiceId;
@@ -264,7 +291,11 @@ const resolveRailwaySettings = async (service: ApplyServiceName) => {
     const missingKey =
       service === 'railway_conductor'
         ? 'MODEL_CONTROL_APPLY_RAILWAY_CONDUCTOR_SERVICE_ID'
-        : 'MODEL_CONTROL_APPLY_RAILWAY_REALTIME_SERVICE_ID';
+        : service === 'railway_realtime'
+          ? 'MODEL_CONTROL_APPLY_RAILWAY_REALTIME_SERVICE_ID'
+          : service === 'railway_codex_broker'
+            ? 'MODEL_CONTROL_APPLY_RAILWAY_CODEX_BROKER_SERVICE_ID'
+            : 'MODEL_CONTROL_APPLY_RAILWAY_WIDGET_CODEX_SERVICE_ID';
     throw new MissingApplySettingError(missingKey);
   }
 
@@ -402,6 +433,8 @@ const APPLY_ADAPTERS: Record<ApplyServiceName, ApplyAdapter> = {
   vercel_web: redeployVercel,
   railway_conductor: () => redeployRailway('railway_conductor'),
   railway_realtime: () => redeployRailway('railway_realtime'),
+  railway_codex_broker: () => redeployRailway('railway_codex_broker'),
+  railway_widget_codex: () => redeployRailway('railway_widget_codex'),
 };
 
 export function getApplyServices(): readonly ApplyServiceName[] {


### PR DESCRIPTION
## Summary
- adds Railway deploy coverage for long-lived codex-broker and widget-codex services
- hardens widget-codex auth completion with a broker-backed verification probe and expired-auth state
- updates runtime apply support, service host/port behavior, tests, and production runbook
- fixes reset persistence/collaboration defaults to use writable temp storage on Vercel/serverless instead of `/var/task/.tmp`

## Verification
- `npm run typecheck`
- `npm run test:reset`
- `npm run build`
- `npm run lint` (existing warnings only; exit 0)
- `npm run codex:manifest`
- `npx jest --runInBand --runTestsByPath services/widget-codex/src/server.test.ts src/components/ui/codex/codex-remote-widget.test.tsx src/lib/agents/control-plane/apply-runtime.test.ts src/lib/agents/control-plane/apply-config.test.ts`
- `npx jest --runInBand --runTestsByPath services/kernel/src/persistence.test.ts services/kernel/src/collaboration-docs.test.ts src/app/api/reset/runtime-manifest/route.test.ts`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-railway-prod.yml"); puts "yaml ok"'`

## Prod Smoke Evidence Before This Patch
- `https://present.best/canvas?id=abb6bb40-bc01-4ec3-b61e-090854d8e796` returns HTTP 200.
- `https://present.best/api/widget-codex/servers` returns HTTP 401 unauthenticated, as expected for admin-gated widget control-plane calls.
- `https://present.best/` and `https://present.best/api/reset/runtime-manifest` returned HTTP 500.
- Vercel runtime logs showed `ENOENT: no such file or directory, mkdir '/var/task/.tmp'` from `/api/reset/runtime-manifest`; this PR now fixes that by using `os.tmpdir()` in serverless.

## Deployment Blocker
GitHub repo config currently has `RAILWAY_API_KEY` but does not have the required Remote Codex widget variables/secrets by name: `CODEX_BROKER_AUTH_TOKEN`, `CODEX_BROKER_PUBLIC_BASE_URL`, `CODEX_BROKER_URL`, `WIDGET_CODEX_PUBLIC_WS_URL`, `WIDGET_CODEX_DEFAULT_SERVERS`, or a broker target (`CODEX_BROKER_DIRECT_TARGET_URL` or SSH target keys). Local env does not contain them either. This PR intentionally makes the Railway workflow fail fast if those are missing so prod does not deploy a dead widget service.

## Deployment Notes
- Configure the values in `docs/ops/remote-codex-widget-prod.md` before merging/deploying.
- Vercel production must have `WIDGET_CODEX_URL` pointing at `present-widget-codex`.
