### PR TITLE
Fix Remote Codex widget-owned server setup

### DIFF
--- a/.github/workflows/deploy-railway-prod.yml
+++ b/.github/workflows/deploy-railway-prod.yml
@@ -347,8 +347,7 @@ jobs:
             exit 1
           fi
           if [ -z "${CODEX_BROKER_DIRECT_TARGET_URL:-}" ] && { [ -z "${CODEX_BROKER_SSH_HOST:-}" ] || [ -z "${CODEX_BROKER_SSH_USERNAME:-}" ]; }; then
-            echo "::error::Set CODEX_BROKER_DIRECT_TARGET_URL or CODEX_BROKER_SSH_HOST plus CODEX_BROKER_SSH_USERNAME."
-            exit 1
+            echo "No global broker target configured; broker will require per-session widget/server transport."
           fi
           tmp_dir="$(mktemp -d)"
           cd "$tmp_dir"
@@ -452,10 +451,6 @@ jobs:
             echo "::error::Missing WIDGET_CODEX_PUBLIC_WS_URL repository variable."
             exit 1
           fi
-          if [ -z "${WIDGET_CODEX_DEFAULT_SERVERS:-}" ]; then
-            echo "::error::Missing WIDGET_CODEX_DEFAULT_SERVERS secret or repository variable."
-            exit 1
-          fi
           tmp_dir="$(mktemp -d)"
           cd "$tmp_dir"
           run_with_railway_auth() {
@@ -496,6 +491,12 @@ jobs:
             --set "WIDGET_CODEX_PUBLIC_WS_URL=$WIDGET_CODEX_PUBLIC_WS_URL" \
             --set "WIDGET_CODEX_ALLOWED_ORIGIN=$WIDGET_CODEX_ALLOWED_ORIGIN" \
             --set "WIDGET_CODEX_STATE_FILE=$WIDGET_CODEX_STATE_FILE" \
-            --set "WIDGET_CODEX_DEFAULT_SERVERS=$WIDGET_CODEX_DEFAULT_SERVERS" \
             --skip-deploys
+          if [ -n "${WIDGET_CODEX_DEFAULT_SERVERS:-}" ]; then
+            run_with_railway_auth variables railway variables \
+              --service "$RAILWAY_WIDGET_CODEX_SERVICE" \
+              --environment "$RAILWAY_ENVIRONMENT" \
+              --set "WIDGET_CODEX_DEFAULT_SERVERS=$WIDGET_CODEX_DEFAULT_SERVERS" \
+              --skip-deploys
+          fi
           run_with_railway_auth redeploy railway redeploy --service "$RAILWAY_WIDGET_CODEX_SERVICE" --yes

--- a/docs/ops/remote-codex-widget-prod.md
+++ b/docs/ops/remote-codex-widget-prod.md
@@ -15,8 +15,8 @@ GitHub secrets:
 
 - `RAILWAY_API_KEY` or `RAILWAY_TOKEN`
 - `CODEX_BROKER_AUTH_TOKEN`
-- `CODEX_BROKER_DIRECT_TARGET_URL` or the SSH secret set required by `services/codex-broker/src/service.ts`
-- `WIDGET_CODEX_DEFAULT_SERVERS`
+- Optional: `CODEX_BROKER_DIRECT_TARGET_URL` or the SSH secret set required by `services/codex-broker/src/service.ts`
+- Optional: `WIDGET_CODEX_DEFAULT_SERVERS`
 
 GitHub repository variables:
 
@@ -30,15 +30,18 @@ Vercel production env:
 
 - `WIDGET_CODEX_URL` pointing at the public or private URL for `present-widget-codex`
 
+The widget-owned setup path does not require a preseeded default server or global broker target. Users can create a direct or SSH-backed saved server from the canvas widget. SSH credentials are submitted to `present-widget-codex` and used server-side by `present-codex-broker`; public server/list responses and TLDraw shape state must never include private keys, host secrets, broker tokens, or remote auth credentials.
+
 ## Smoke Test
 
 1. Open `https://present.best/canvas`.
 2. Insert the Remote Codex widget from the toolbar.
-3. Confirm a saved server appears without manually entering a frame URL.
-4. Authenticate if the server reports `Login Required` or `Login Expired`.
-5. Select a workspace and connect.
-6. Send a native widget turn and confirm it binds a reset workspace/executor.
-7. Refresh the page and confirm the widget restores the same session.
-8. Disconnect and confirm the broker session is torn down.
+3. Add a direct or SSH-backed saved server from inside the widget if no saved server exists.
+4. Confirm no manual `frameUrl` entry is needed.
+5. Authenticate if the server reports `Login Required` or `Login Expired`.
+6. Select a workspace and connect.
+7. Send a native widget turn and confirm it binds a reset workspace/executor.
+8. Refresh the page and confirm the widget restores the same session.
+9. Disconnect and confirm the broker session is torn down.
 
 Browser payloads must not include the saved server transport config, SSH keys, broker auth token, or remote auth credentials.

--- a/services/widget-codex/src/client.ts
+++ b/services/widget-codex/src/client.ts
@@ -51,7 +51,20 @@ export async function createWidgetCodexServer(input: {
   description?: string | null;
   authStrategy?: 'none' | 'external_url' | 'iframe';
   authUrl?: string | null;
-  directTargetUrl: string;
+  transportKind?: 'direct' | 'ssh';
+  directTargetUrl?: string | null;
+  ssh?: {
+    host: string;
+    port?: number;
+    username: string;
+    remoteHost?: string;
+    remotePort?: number;
+    remoteProtocol?: 'http' | 'https';
+    hostKeySha256?: string | null;
+    privateKey?: string | null;
+    privateKeyPath?: string | null;
+    passphrase?: string | null;
+  } | null;
   workspaces?: WidgetCodexWorkspace[];
 }) {
   return widgetCodexRequest<{ server: WidgetCodexPublicServer }>('/servers', {
@@ -67,7 +80,20 @@ export async function updateWidgetCodexServer(
     description: string | null;
     authStrategy: 'none' | 'external_url' | 'iframe';
     authUrl: string | null;
-    directTargetUrl: string;
+    transportKind: 'direct' | 'ssh';
+    directTargetUrl: string | null;
+    ssh: {
+      host: string;
+      port?: number;
+      username: string;
+      remoteHost?: string;
+      remotePort?: number;
+      remoteProtocol?: 'http' | 'https';
+      hostKeySha256?: string | null;
+      privateKey?: string | null;
+      privateKeyPath?: string | null;
+      passphrase?: string | null;
+    } | null;
     workspaces: WidgetCodexWorkspace[];
   }>,
 ) {

--- a/services/widget-codex/src/contracts.ts
+++ b/services/widget-codex/src/contracts.ts
@@ -9,24 +9,83 @@ export const widgetCodexWorkspaceSchema = z.object({
 export const widgetCodexAuthStrategySchema = z.enum(['none', 'external_url', 'iframe']);
 export const widgetCodexAuthStateSchema = z.enum(['unknown', 'login_required', 'pending', 'authenticated', 'expired']);
 export const widgetCodexConnectionStatusSchema = z.enum(['disconnected', 'connecting', 'ready', 'error']);
+export const widgetCodexTransportKindSchema = z.enum(['direct', 'ssh']);
 
-export const widgetCodexServerInputSchema = z.object({
-  label: z.string().min(1),
-  description: z.string().optional().nullable(),
-  authStrategy: widgetCodexAuthStrategySchema.default('none'),
-  authUrl: z.string().url().optional().nullable(),
-  directTargetUrl: z.string().url(),
-  workspaces: z.array(widgetCodexWorkspaceSchema).default([]),
+export const widgetCodexSshInputSchema = z.object({
+  host: z.string().min(1),
+  port: z.coerce.number().int().positive().default(22),
+  username: z.string().min(1),
+  remoteHost: z.string().min(1).default('127.0.0.1'),
+  remotePort: z.coerce.number().int().positive().default(4500),
+  remoteProtocol: z.enum(['http', 'https']).default('http'),
+  hostKeySha256: z.string().min(1),
+  privateKey: z.string().min(1).optional().nullable(),
+  privateKeyPath: z.string().min(1).optional().nullable(),
+  passphrase: z.string().min(1).optional().nullable(),
 });
 
-export const widgetCodexServerPatchSchema = z.object({
-  label: z.string().min(1).optional(),
-  description: z.string().optional().nullable(),
-  authStrategy: widgetCodexAuthStrategySchema.optional(),
-  authUrl: z.string().url().optional().nullable(),
-  directTargetUrl: z.string().url().optional(),
-  workspaces: z.array(widgetCodexWorkspaceSchema).optional(),
-});
+export const widgetCodexServerInputSchema = z
+  .object({
+    label: z.string().min(1),
+    description: z.string().optional().nullable(),
+    authStrategy: widgetCodexAuthStrategySchema.default('none'),
+    authUrl: z.string().url().optional().nullable(),
+    transportKind: widgetCodexTransportKindSchema.default('direct'),
+    directTargetUrl: z.string().url().optional().nullable(),
+    ssh: widgetCodexSshInputSchema.optional().nullable(),
+    workspaces: z.array(widgetCodexWorkspaceSchema).default([]),
+  })
+  .superRefine((value, context) => {
+    if (value.transportKind === 'direct' && !value.directTargetUrl) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['directTargetUrl'],
+        message: 'Direct target URL is required for direct transport.',
+      });
+    }
+    if (value.transportKind === 'ssh' && !value.ssh) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['ssh'],
+        message: 'SSH settings are required for SSH transport.',
+      });
+    }
+    if (value.transportKind === 'ssh' && value.ssh && !value.ssh.privateKey && !value.ssh.privateKeyPath) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['ssh', 'privateKey'],
+        message: 'SSH private key is required for widget-created SSH servers.',
+      });
+    }
+  });
+
+export const widgetCodexServerPatchSchema = z
+  .object({
+    label: z.string().min(1).optional(),
+    description: z.string().optional().nullable(),
+    authStrategy: widgetCodexAuthStrategySchema.optional(),
+    authUrl: z.string().url().optional().nullable(),
+    transportKind: widgetCodexTransportKindSchema.optional(),
+    directTargetUrl: z.string().url().optional().nullable(),
+    ssh: widgetCodexSshInputSchema.optional().nullable(),
+    workspaces: z.array(widgetCodexWorkspaceSchema).optional(),
+  })
+  .superRefine((value, context) => {
+    if (value.transportKind === 'direct' && !value.directTargetUrl) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['directTargetUrl'],
+        message: 'Direct target URL is required when switching to direct transport.',
+      });
+    }
+    if (value.transportKind === 'ssh' && value.ssh === null) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['ssh'],
+        message: 'SSH settings cannot be cleared when switching to SSH transport.',
+      });
+    }
+  });
 
 export const widgetCodexCreateConnectionInputSchema = z.object({
   widgetSessionId: z.string().min(1).optional(),

--- a/services/widget-codex/src/server.test.ts
+++ b/services/widget-codex/src/server.test.ts
@@ -218,6 +218,97 @@ describe('Widget Codex server', () => {
     }
   });
 
+  it('creates SSH-backed servers without exposing SSH credentials in public payloads', async () => {
+    const broker = {
+      createSession: jest.fn().mockResolvedValue({
+        session: {
+          sessionId: 'cxs_ssh',
+          workspaceSessionId: 'wcws_ssh',
+          remoteWorkingDirectory: '/srv/codex/repos/PRESENT',
+          proxyBaseUrl: 'http://127.0.0.1:4101/sessions/cxs_ssh/proxy/token',
+          frameUrl: 'http://127.0.0.1:4101/sessions/cxs_ssh/proxy/token/',
+          status: 'ready',
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+          lastHeartbeatAt: new Date().toISOString(),
+        },
+      }),
+      getSession: jest.fn(),
+      deleteSession: jest.fn().mockResolvedValue({ deleted: true }),
+    };
+    const service = new WidgetCodexService({
+      stateFilePath,
+      broker,
+    });
+    const app = await buildWidgetCodexServer({ service });
+
+    try {
+      const createServerResponse = await app.inject({
+        method: 'POST',
+        url: '/servers',
+        payload: {
+          label: 'Tailnet Codex',
+          transportKind: 'ssh',
+          authStrategy: 'none',
+          ssh: {
+            host: 'codex-box.tailnet.example',
+            port: 22,
+            username: 'ubuntu',
+            remoteHost: '127.0.0.1',
+            remotePort: 4500,
+            remoteProtocol: 'http',
+            hostKeySha256: 'SHA256:test',
+            privateKey: '-----BEGIN OPENSSH PRIVATE KEY-----\ntest\n-----END OPENSSH PRIVATE KEY-----',
+          },
+          workspaces: [
+            {
+              id: 'present',
+              label: 'PRESENT',
+              path: '/srv/codex/repos/PRESENT',
+            },
+          ],
+        },
+      });
+      expect(createServerResponse.statusCode).toBe(201);
+      expect(JSON.stringify(createServerResponse.json())).not.toContain('OPENSSH PRIVATE KEY');
+
+      const serverId = createServerResponse.json().server.id as string;
+      const serversResponse = await app.inject({ method: 'GET', url: '/servers' });
+      expect(serversResponse.statusCode).toBe(200);
+      expect(JSON.stringify(serversResponse.json())).not.toContain('codex-box.tailnet.example');
+      expect(JSON.stringify(serversResponse.json())).not.toContain('OPENSSH PRIVATE KEY');
+      expect(serversResponse.json().servers[0]).toMatchObject({
+        id: serverId,
+        transportKind: 'ssh',
+      });
+
+      const createConnectionResponse = await app.inject({
+        method: 'POST',
+        url: '/connections',
+        payload: {
+          widgetSessionId: 'wcws_ssh',
+          serverId,
+          remoteWorkspaceId: 'present',
+        },
+      });
+      expect(createConnectionResponse.statusCode).toBe(201);
+      expect(broker.createSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          transport: expect.objectContaining({
+            ssh: expect.objectContaining({
+              host: 'codex-box.tailnet.example',
+              username: 'ubuntu',
+              privateKey: expect.stringContaining('OPENSSH PRIVATE KEY'),
+            }),
+          }),
+        }),
+      );
+      expect(JSON.stringify(createConnectionResponse.json())).not.toContain('OPENSSH PRIVATE KEY');
+    } finally {
+      await app.close();
+    }
+  });
+
   it('fails fast when the state file path points at a directory', async () => {
     const directoryPath = path.join(os.tmpdir(), `present-widget-codex-dir-${Date.now()}`);
     await fs.mkdir(directoryPath, { recursive: true });

--- a/services/widget-codex/src/service.ts
+++ b/services/widget-codex/src/service.ts
@@ -19,6 +19,7 @@ import {
   widgetCodexCreateConnectionInputSchema,
   widgetCodexServerInputSchema,
   widgetCodexServerPatchSchema,
+  widgetCodexTransportKindSchema,
   widgetCodexWorkspaceSchema,
 } from './contracts';
 
@@ -29,6 +30,7 @@ const widgetCodexServerInternalSchema = z.object({
   authStrategy: widgetCodexAuthStrategySchema,
   authState: widgetCodexAuthStateSchema,
   authUrl: z.string().url().nullable(),
+  transportKind: widgetCodexTransportKindSchema.default('direct'),
   transport: codexBrokerTransportSchema,
   workspaces: z.array(widgetCodexWorkspaceSchema).default([]),
   createdAt: z.string().min(1),
@@ -157,6 +159,72 @@ const toPublicConnection = (connection: WidgetCodexConnectionRecord | null) =>
 const toPublicWidgetSession = (widgetSession: WidgetCodexWidgetSession | null) =>
   widgetSession ? publicWidgetSessionSchema.parse(widgetSession) : null;
 
+function transportKindForTransport(transport: z.infer<typeof codexBrokerTransportSchema>) {
+  return transport.ssh ? 'ssh' : 'direct';
+}
+
+function buildCreateTransport(payload: z.infer<typeof widgetCodexServerInputSchema>) {
+  if (payload.transportKind === 'ssh') {
+    if (!payload.ssh) {
+      throw new Error('SSH settings are required for SSH transport.');
+    }
+    return {
+      transportKind: 'ssh' as const,
+      transport: {
+        ssh: payload.ssh,
+      },
+    };
+  }
+  if (!payload.directTargetUrl) {
+    throw new Error('Direct target URL is required for direct transport.');
+  }
+  return {
+    transportKind: 'direct' as const,
+    transport: {
+      directTargetUrl: payload.directTargetUrl,
+    },
+  };
+}
+
+function buildPatchTransport(
+  current: WidgetCodexServerInternal,
+  patch: z.infer<typeof widgetCodexServerPatchSchema>,
+) {
+  const nextKind = patch.transportKind ?? current.transportKind ?? transportKindForTransport(current.transport);
+  if (nextKind === 'ssh') {
+    if (patch.ssh) {
+      return {
+        transportKind: 'ssh' as const,
+        transport: {
+          ssh: patch.ssh,
+        },
+      };
+    }
+    if (current.transport.ssh) {
+      return {
+        transportKind: 'ssh' as const,
+        transport: current.transport,
+      };
+    }
+    throw new Error('SSH settings are required when switching to SSH transport.');
+  }
+  if (patch.directTargetUrl) {
+    return {
+      transportKind: 'direct' as const,
+      transport: {
+        directTargetUrl: patch.directTargetUrl,
+      },
+    };
+  }
+  if (current.transport.directTargetUrl && (patch.transportKind === undefined || patch.transportKind === 'direct')) {
+    return {
+      transportKind: 'direct' as const,
+      transport: current.transport,
+    };
+  }
+  throw new Error('Direct target URL is required when switching to direct transport.');
+}
+
 function normalizeDefaultServer(input: z.infer<typeof widgetCodexDefaultServerSchema>): WidgetCodexServerInternal {
   const timestamp = nowIso();
   return widgetCodexServerInternalSchema.parse({
@@ -168,6 +236,7 @@ function normalizeDefaultServer(input: z.infer<typeof widgetCodexDefaultServerSc
       input.authState ??
       (input.authStrategy === 'none' ? 'authenticated' : input.authUrl ? 'login_required' : 'unknown'),
     authUrl: input.authUrl ?? null,
+    transportKind: input.transportKind ?? transportKindForTransport(input.transport),
     transport: input.transport,
     workspaces: input.workspaces ?? [],
     createdAt: input.createdAt ?? timestamp,
@@ -384,6 +453,7 @@ export class WidgetCodexService {
   async createServer(input: z.infer<typeof widgetCodexServerInputSchema>) {
     await this.hydrate();
     const payload = widgetCodexServerInputSchema.parse(input);
+    const transport = buildCreateTransport(payload);
     const server = widgetCodexServerInternalSchema.parse({
       id: createId('wcsrv'),
       label: payload.label.trim(),
@@ -391,9 +461,8 @@ export class WidgetCodexService {
       authStrategy: payload.authStrategy,
       authState: payload.authStrategy === 'none' ? 'authenticated' : payload.authUrl ? 'login_required' : 'unknown',
       authUrl: payload.authUrl?.trim() || null,
-      transport: {
-        directTargetUrl: payload.directTargetUrl,
-      },
+      transportKind: transport.transportKind,
+      transport: transport.transport,
       workspaces: payload.workspaces,
       createdAt: nowIso(),
       updatedAt: nowIso(),
@@ -412,6 +481,7 @@ export class WidgetCodexService {
     const current = this.resolveServer(serverId);
     if (!current) return null;
     const patch = widgetCodexServerPatchSchema.parse(input);
+    const transport = buildPatchTransport(current, patch);
     const next = widgetCodexServerInternalSchema.parse({
       ...current,
       label: patch.label?.trim() || current.label,
@@ -427,12 +497,8 @@ export class WidgetCodexService {
                 : 'unknown')
             : current.authState,
       authUrl: patch.authUrl === undefined ? current.authUrl : patch.authUrl?.trim() || null,
-      transport:
-        patch.directTargetUrl === undefined
-          ? current.transport
-          : {
-              directTargetUrl: patch.directTargetUrl,
-            },
+      transportKind: transport.transportKind,
+      transport: transport.transport,
       workspaces: patch.workspaces ?? current.workspaces,
       updatedAt: nowIso(),
     });

--- a/src/components/ui/codex/codex-remote-widget.test.tsx
+++ b/src/components/ui/codex/codex-remote-widget.test.tsx
@@ -21,6 +21,7 @@ const buildServersPayload = () => ({
       authStrategy: 'none',
       authState: 'authenticated',
       authUrl: null,
+      transportKind: 'direct',
       workspaces: [
         {
           id: 'present',
@@ -340,5 +341,88 @@ describe('CodexRemoteWidget', () => {
 
     expect(await screen.findByText('Auth: Login Expired')).toBeTruthy();
     expect(screen.getByText('Open Login')).toBeTruthy();
+  });
+
+  it('creates an SSH-backed saved server from inside the widget', async () => {
+    const requests: Array<{ url: string; init?: RequestInit }> = [];
+    (global.fetch as jest.Mock).mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      requests.push({ url, init });
+      if (url === '/api/widget-codex/servers' && init?.method === 'POST') {
+        return {
+          ok: true,
+          json: async () => ({
+            server: {
+              ...buildServersPayload().servers[0],
+              id: 'wcsrv_ssh',
+              label: 'Tailnet Codex',
+              transportKind: 'ssh',
+            },
+          }),
+        } as Response;
+      }
+      if (url === '/api/widget-codex/servers') {
+        return {
+          ok: true,
+          json: async () => ({
+            realtimeUrl: null,
+            servers: [],
+          }),
+        } as Response;
+      }
+      return {
+        ok: true,
+        json: async () => ({}),
+      } as Response;
+    });
+
+    render(<CodexRemoteWidget title="Remote Codex" />);
+
+    await screen.findByText('Add Server');
+    fireEvent.click(screen.getByText('Add Server'));
+    fireEvent.change(screen.getByLabelText('Server Label'), { target: { value: 'Tailnet Codex' } });
+    fireEvent.change(screen.getByLabelText('SSH Host'), { target: { value: 'codex-box.tailnet.example' } });
+    fireEvent.change(screen.getByLabelText('SSH Username'), { target: { value: 'ubuntu' } });
+    fireEvent.change(screen.getByLabelText('SSH Private Key'), {
+      target: {
+        value: '-----BEGIN OPENSSH PRIVATE KEY-----\ntest\n-----END OPENSSH PRIVATE KEY-----',
+      },
+    });
+    fireEvent.change(screen.getByLabelText('Host Key SHA256'), { target: { value: 'SHA256:test' } });
+    fireEvent.change(screen.getByLabelText('Workspaces'), {
+      target: {
+        value: 'PRESENT|/srv/codex/repos/PRESENT',
+      },
+    });
+    fireEvent.click(screen.getByText('Create Server'));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/widget-codex/servers',
+        expect.objectContaining({
+          method: 'POST',
+        }),
+      );
+    });
+    const createRequest = requests.find((request) => request.url === '/api/widget-codex/servers' && request.init?.method === 'POST');
+    expect(createRequest).toBeTruthy();
+    expect(JSON.parse(String(createRequest?.init?.body))).toMatchObject({
+      label: 'Tailnet Codex',
+      transportKind: 'ssh',
+      ssh: {
+        host: 'codex-box.tailnet.example',
+        username: 'ubuntu',
+        remotePort: 4500,
+        hostKeySha256: 'SHA256:test',
+        privateKey: expect.stringContaining('OPENSSH PRIVATE KEY'),
+      },
+      workspaces: [
+        {
+          id: 'workspace-present',
+          label: 'PRESENT',
+          path: '/srv/codex/repos/PRESENT',
+        },
+      ],
+    });
   });
 });

--- a/src/components/ui/codex/codex-remote-widget.tsx
+++ b/src/components/ui/codex/codex-remote-widget.tsx
@@ -39,6 +39,7 @@ type WidgetCodexServer = {
   authStrategy: 'none' | 'external_url' | 'iframe';
   authState: 'unknown' | 'login_required' | 'pending' | 'authenticated' | 'expired';
   authUrl: string | null;
+  transportKind: 'direct' | 'ssh';
   workspaces: Array<{
     id: string;
     label: string;
@@ -296,7 +297,17 @@ export function CodexRemoteWidget(props: CanvasCodexRemoteWidgetProps) {
     id: '',
     label: '',
     description: '',
+    transportKind: 'ssh' as 'direct' | 'ssh',
     directTargetUrl: '',
+    sshHost: '',
+    sshPort: '22',
+    sshUsername: '',
+    sshPrivateKey: '',
+    sshPassphrase: '',
+    sshHostKeySha256: '',
+    sshRemoteHost: '127.0.0.1',
+    sshRemotePort: '4500',
+    sshRemoteProtocol: 'http' as 'http' | 'https',
     authStrategy: 'none' as 'none' | 'external_url' | 'iframe',
     authUrl: '',
     workspacesText: '',
@@ -587,11 +598,26 @@ export function CodexRemoteWidget(props: CanvasCodexRemoteWidgetProps) {
 
   const saveServer = useCallback(async () => {
     const workspacesPayload = serializeWorkspacesInput(serverForm.workspacesText);
+    const sshPayload =
+      serverForm.transportKind === 'ssh'
+        ? {
+            host: serverForm.sshHost.trim(),
+            port: Number(serverForm.sshPort || '22'),
+            username: serverForm.sshUsername.trim(),
+            remoteHost: serverForm.sshRemoteHost.trim() || '127.0.0.1',
+            remotePort: Number(serverForm.sshRemotePort || '4500'),
+            remoteProtocol: serverForm.sshRemoteProtocol,
+            hostKeySha256: serverForm.sshHostKeySha256.trim(),
+            privateKey: serverForm.sshPrivateKey.trim() || null,
+            passphrase: serverForm.sshPassphrase.trim() || null,
+          }
+        : null;
     const baseBody = {
       label: serverForm.label.trim(),
       description: serverForm.description.trim() || null,
       authStrategy: serverForm.authStrategy,
       authUrl: serverForm.authUrl.trim() || null,
+      transportKind: serverForm.transportKind,
       workspaces: workspacesPayload,
     };
     setIsBusy(true);
@@ -599,8 +625,11 @@ export function CodexRemoteWidget(props: CanvasCodexRemoteWidgetProps) {
       if (serverForm.id) {
         const body = {
           ...baseBody,
-          ...(serverForm.directTargetUrl.trim()
+          ...(serverForm.transportKind === 'direct' && serverForm.directTargetUrl.trim()
             ? { directTargetUrl: serverForm.directTargetUrl.trim() }
+            : {}),
+          ...(serverForm.transportKind === 'ssh' && sshPayload?.host && sshPayload.username && sshPayload.privateKey
+            ? { ssh: sshPayload }
             : {}),
         };
         await requestJson(`/api/widget-codex/servers/${encodeURIComponent(serverForm.id)}`, {
@@ -611,7 +640,9 @@ export function CodexRemoteWidget(props: CanvasCodexRemoteWidgetProps) {
       } else {
         const body = {
           ...baseBody,
-          directTargetUrl: serverForm.directTargetUrl.trim(),
+          ...(serverForm.transportKind === 'direct'
+            ? { directTargetUrl: serverForm.directTargetUrl.trim() }
+            : { ssh: sshPayload }),
         };
         await requestJson('/api/widget-codex/servers', {
           method: 'POST',
@@ -624,7 +655,17 @@ export function CodexRemoteWidget(props: CanvasCodexRemoteWidgetProps) {
         id: '',
         label: '',
         description: '',
+        transportKind: 'ssh',
         directTargetUrl: '',
+        sshHost: '',
+        sshPort: '22',
+        sshUsername: '',
+        sshPrivateKey: '',
+        sshPassphrase: '',
+        sshHostKeySha256: '',
+        sshRemoteHost: '127.0.0.1',
+        sshRemotePort: '4500',
+        sshRemoteProtocol: 'http',
         authStrategy: 'none',
         authUrl: '',
         workspacesText: '',
@@ -648,7 +689,17 @@ export function CodexRemoteWidget(props: CanvasCodexRemoteWidgetProps) {
       id: selectedServer.id,
       label: selectedServer.label,
       description: selectedServer.description ?? '',
+      transportKind: selectedServer.transportKind,
       directTargetUrl: '',
+      sshHost: '',
+      sshPort: '22',
+      sshUsername: '',
+      sshPrivateKey: '',
+      sshPassphrase: '',
+      sshHostKeySha256: '',
+      sshRemoteHost: '127.0.0.1',
+      sshRemotePort: '4500',
+      sshRemoteProtocol: 'http',
       authStrategy: selectedServer.authStrategy,
       authUrl: selectedServer.authUrl ?? '',
       workspacesText: workspacesToInput(selectedServer.workspaces),
@@ -1282,15 +1333,115 @@ export function CodexRemoteWidget(props: CanvasCodexRemoteWidgetProps) {
                 />
               </label>
               <label className="flex flex-col gap-1">
-                <span className="text-xs text-secondary">Direct Target URL</span>
-                <input
-                  value={serverForm.directTargetUrl}
+                <span className="text-xs text-secondary">Connection Type</span>
+                <select
+                  value={serverForm.transportKind}
                   onPointerDown={stopPointerPropagation}
-                  onChange={(event) => setServerForm((previous) => ({ ...previous, directTargetUrl: event.target.value }))}
+                  onChange={(event) =>
+                    setServerForm((previous) => ({
+                      ...previous,
+                      transportKind: event.target.value as 'direct' | 'ssh',
+                    }))
+                  }
                   className="w-full rounded-lg border border-default bg-[var(--color-panel)] px-3 py-2 text-sm text-primary outline-none"
-                  placeholder="https://remote-codex.example/"
-                />
+                >
+                  <option value="ssh">SSH tunnel to remote Codex</option>
+                  <option value="direct">Direct Codex app URL</option>
+                </select>
               </label>
+              {serverForm.transportKind === 'direct' ? (
+                <label className="flex flex-col gap-1">
+                  <span className="text-xs text-secondary">Direct Target URL</span>
+                  <input
+                    value={serverForm.directTargetUrl}
+                    onPointerDown={stopPointerPropagation}
+                    onChange={(event) => setServerForm((previous) => ({ ...previous, directTargetUrl: event.target.value }))}
+                    className="w-full rounded-lg border border-default bg-[var(--color-panel)] px-3 py-2 text-sm text-primary outline-none"
+                    placeholder="https://remote-codex.example/"
+                  />
+                </label>
+              ) : (
+                <div className="grid gap-3 rounded-lg border border-default bg-[var(--color-panel)] p-3">
+                  <div className="text-xs text-secondary">
+                    SSH credentials are sent to the widget service only. They are not stored in TLDraw shape state or returned by list APIs.
+                  </div>
+                  <div className="grid gap-3 md:grid-cols-2">
+                    <label className="flex flex-col gap-1">
+                      <span className="text-xs text-secondary">SSH Host</span>
+                      <input
+                        value={serverForm.sshHost}
+                        onPointerDown={stopPointerPropagation}
+                        onChange={(event) => setServerForm((previous) => ({ ...previous, sshHost: event.target.value }))}
+                        className="w-full rounded-lg border border-default bg-surface px-3 py-2 text-sm text-primary outline-none"
+                        placeholder="codex-box.tailnet.ts.net"
+                      />
+                    </label>
+                    <label className="flex flex-col gap-1">
+                      <span className="text-xs text-secondary">SSH Port</span>
+                      <input
+                        value={serverForm.sshPort}
+                        onPointerDown={stopPointerPropagation}
+                        onChange={(event) => setServerForm((previous) => ({ ...previous, sshPort: event.target.value }))}
+                        className="w-full rounded-lg border border-default bg-surface px-3 py-2 text-sm text-primary outline-none"
+                        placeholder="22"
+                      />
+                    </label>
+                    <label className="flex flex-col gap-1">
+                      <span className="text-xs text-secondary">SSH Username</span>
+                      <input
+                        value={serverForm.sshUsername}
+                        onPointerDown={stopPointerPropagation}
+                        onChange={(event) => setServerForm((previous) => ({ ...previous, sshUsername: event.target.value }))}
+                        className="w-full rounded-lg border border-default bg-surface px-3 py-2 text-sm text-primary outline-none"
+                        placeholder="ubuntu"
+                      />
+                    </label>
+                    <label className="flex flex-col gap-1">
+                      <span className="text-xs text-secondary">Remote Codex Port</span>
+                      <input
+                        value={serverForm.sshRemotePort}
+                        onPointerDown={stopPointerPropagation}
+                        onChange={(event) => setServerForm((previous) => ({ ...previous, sshRemotePort: event.target.value }))}
+                        className="w-full rounded-lg border border-default bg-surface px-3 py-2 text-sm text-primary outline-none"
+                        placeholder="4500"
+                      />
+                    </label>
+                  </div>
+                  <label className="flex flex-col gap-1">
+                    <span className="text-xs text-secondary">SSH Private Key</span>
+                    <textarea
+                      value={serverForm.sshPrivateKey}
+                      onPointerDown={stopPointerPropagation}
+                      onChange={(event) => setServerForm((previous) => ({ ...previous, sshPrivateKey: event.target.value }))}
+                      className="min-h-24 w-full rounded-lg border border-default bg-surface px-3 py-2 font-mono text-xs text-primary outline-none"
+                      placeholder="-----BEGIN OPENSSH PRIVATE KEY-----"
+                    />
+                  </label>
+                  <div className="grid gap-3 md:grid-cols-2">
+                    <label className="flex flex-col gap-1">
+                      <span className="text-xs text-secondary">Key Passphrase</span>
+                      <input
+                        value={serverForm.sshPassphrase}
+                        type="password"
+                        onPointerDown={stopPointerPropagation}
+                        onChange={(event) => setServerForm((previous) => ({ ...previous, sshPassphrase: event.target.value }))}
+                        className="w-full rounded-lg border border-default bg-surface px-3 py-2 text-sm text-primary outline-none"
+                        placeholder="optional"
+                      />
+                    </label>
+                    <label className="flex flex-col gap-1">
+                      <span className="text-xs text-secondary">Host Key SHA256</span>
+                      <input
+                        value={serverForm.sshHostKeySha256}
+                        onPointerDown={stopPointerPropagation}
+                        onChange={(event) => setServerForm((previous) => ({ ...previous, sshHostKeySha256: event.target.value }))}
+                        className="w-full rounded-lg border border-default bg-surface px-3 py-2 text-sm text-primary outline-none"
+                        placeholder="required, e.g. SHA256:..."
+                      />
+                    </label>
+                  </div>
+                </div>
+              )}
               <label className="flex flex-col gap-1">
                 <span className="text-xs text-secondary">Auth Strategy</span>
                 <select
@@ -1342,13 +1493,23 @@ export function CodexRemoteWidget(props: CanvasCodexRemoteWidgetProps) {
                   onClick={() => {
                     setShowServerForm(false);
                     setServerForm({
-                      id: '',
-                      label: '',
-                      description: '',
-                      directTargetUrl: '',
-                      authStrategy: 'none',
-                      authUrl: '',
-                      workspacesText: '',
+                    id: '',
+                    label: '',
+                    description: '',
+                    transportKind: 'ssh',
+                    directTargetUrl: '',
+                    sshHost: '',
+                    sshPort: '22',
+                    sshUsername: '',
+                    sshPrivateKey: '',
+                    sshPassphrase: '',
+                    sshHostKeySha256: '',
+                    sshRemoteHost: '127.0.0.1',
+                    sshRemotePort: '4500',
+                    sshRemoteProtocol: 'http',
+                    authStrategy: 'none',
+                    authUrl: '',
+                    workspacesText: '',
                     });
                   }}
                 >


### PR DESCRIPTION
## Summary
- Make Remote Codex server setup widget-owned: direct URL or SSH tunnel config can be created from the canvas widget.
- Keep SSH transport private to the widget service/broker path and out of public server responses and TLDraw shape state.
- Relax Railway deploy gates so broker/widget services do not require preseeded default servers or a global broker target.

## Verification
- npm run typecheck
- npm run test:reset
- npm run build
- npx jest --runInBand --runTestsByPath services/widget-codex/src/server.test.ts src/components/ui/codex/codex-remote-widget.test.tsx src/app/api/widget-codex/servers/route.test.ts services/codex-broker/src/server.test.ts
- ruby workflow YAML parse check
