### PR TITLE
Fix Railway deploy auth in GitHub Actions

### DIFF
--- a/.github/workflows/deploy-railway-prod.yml
+++ b/.github/workflows/deploy-railway-prod.yml
@@ -198,7 +198,7 @@ jobs:
             local code=1
             if [ -n "${RAILWAY_API_KEY:-}" ]; then
               set +e
-              RAILWAY_API_TOKEN="" RAILWAY_TOKEN="$RAILWAY_API_KEY" "$@"
+              RAILWAY_API_TOKEN="$RAILWAY_API_KEY" RAILWAY_TOKEN="" "$@"
               code=$?
               set -e
               if [ "$code" -eq 0 ]; then
@@ -278,7 +278,7 @@ jobs:
             local code=1
             if [ -n "${RAILWAY_API_KEY:-}" ]; then
               set +e
-              RAILWAY_API_TOKEN="" RAILWAY_TOKEN="$RAILWAY_API_KEY" "$@"
+              RAILWAY_API_TOKEN="$RAILWAY_API_KEY" RAILWAY_TOKEN="" "$@"
               code=$?
               set -e
               if [ "$code" -eq 0 ]; then
@@ -357,7 +357,7 @@ jobs:
             local code=1
             if [ -n "${RAILWAY_API_KEY:-}" ]; then
               set +e
-              RAILWAY_API_TOKEN="" RAILWAY_TOKEN="$RAILWAY_API_KEY" "$@"
+              RAILWAY_API_TOKEN="$RAILWAY_API_KEY" RAILWAY_TOKEN="" "$@"
               code=$?
               set -e
               if [ "$code" -eq 0 ]; then
@@ -459,7 +459,7 @@ jobs:
             local code=1
             if [ -n "${RAILWAY_API_KEY:-}" ]; then
               set +e
-              RAILWAY_API_TOKEN="" RAILWAY_TOKEN="$RAILWAY_API_KEY" "$@"
+              RAILWAY_API_TOKEN="$RAILWAY_API_KEY" RAILWAY_TOKEN="" "$@"
               code=$?
               set -e
               if [ "$code" -eq 0 ]; then


### PR DESCRIPTION
## Summary
- use RAILWAY_API_TOKEN for the RAILWAY_API_KEY secret path
- keep RAILWAY_TOKEN as the fallback for Railway project tokens

## Verification
- ruby YAML parse check passed
- locally confirmed the Railway login token is accepted through RAILWAY_API_TOKEN and rejected through RAILWAY_TOKEN