### PR TITLE
Support Railway project-token redeploys

### DIFF
--- a/.github/workflows/deploy-railway-prod.yml
+++ b/.github/workflows/deploy-railway-prod.yml
@@ -236,6 +236,13 @@ jobs:
             exit 1
           fi
 
+          if [ -n "${RAILWAY_PROJECT_TOKEN:-}" ]; then
+            echo "auth_source=RAILWAY_TOKEN action=redeploy"
+            echo "Project token mode: skipping variable sync; Railway project tokens are deployment-scoped."
+            RAILWAY_API_TOKEN="" RAILWAY_TOKEN="$RAILWAY_PROJECT_TOKEN" railway redeploy --service "$RAILWAY_CONDUCTOR_SERVICE" --yes
+            exit 0
+          fi
+
           run_with_railway_auth link railway link -p "$RAILWAY_PROJECT_ID" -e "$RAILWAY_ENVIRONMENT"
           # Keep core runtime flags synced before the deploy.
           run_with_railway_auth variables railway variables \
@@ -298,6 +305,12 @@ jobs:
             fi
             return "$code"
           }
+
+          if [ -n "${RAILWAY_PROJECT_TOKEN:-}" ]; then
+            echo "auth_source=RAILWAY_TOKEN action=redeploy"
+            RAILWAY_API_TOKEN="" RAILWAY_TOKEN="$RAILWAY_PROJECT_TOKEN" railway redeploy --service "$RAILWAY_REALTIME_SERVICE" --yes
+            exit 0
+          fi
 
           run_with_railway_auth link railway link -p "$RAILWAY_PROJECT_ID" -e "$RAILWAY_ENVIRONMENT"
           run_with_railway_auth redeploy railway redeploy --service "$RAILWAY_REALTIME_SERVICE" --yes
@@ -384,6 +397,13 @@ jobs:
               variable_args+=(--set "$name=$value")
             fi
           }
+
+          if [ -n "${RAILWAY_PROJECT_TOKEN:-}" ]; then
+            echo "auth_source=RAILWAY_TOKEN action=redeploy"
+            echo "Project token mode: skipping variable sync; Railway project tokens are deployment-scoped."
+            RAILWAY_API_TOKEN="" RAILWAY_TOKEN="$RAILWAY_PROJECT_TOKEN" railway redeploy --service "$RAILWAY_CODEX_BROKER_SERVICE" --yes
+            exit 0
+          fi
 
           run_with_railway_auth link railway link -p "$RAILWAY_PROJECT_ID" -e "$RAILWAY_ENVIRONMENT"
           variable_args=(
@@ -479,6 +499,13 @@ jobs:
             fi
             return "$code"
           }
+
+          if [ -n "${RAILWAY_PROJECT_TOKEN:-}" ]; then
+            echo "auth_source=RAILWAY_TOKEN action=redeploy"
+            echo "Project token mode: skipping variable sync; Railway project tokens are deployment-scoped."
+            RAILWAY_API_TOKEN="" RAILWAY_TOKEN="$RAILWAY_PROJECT_TOKEN" railway redeploy --service "$RAILWAY_WIDGET_CODEX_SERVICE" --yes
+            exit 0
+          fi
 
           run_with_railway_auth link railway link -p "$RAILWAY_PROJECT_ID" -e "$RAILWAY_ENVIRONMENT"
           run_with_railway_auth variables railway variables \


### PR DESCRIPTION
## Summary
- use Railway project tokens for redeploy-only CI paths
- skip Railway variable sync when only RAILWAY_TOKEN is available because project tokens are deployment-scoped
- keep account/workspace token variable sync path available when no project token is configured

## Verification
- ruby YAML parse check passed