### PR TITLE
Fix Remote Codex widget canvas auto-fit

### DIFF
--- a/src/components/ui/tldraw/tldraw-canvas.test.tsx
+++ b/src/components/ui/tldraw/tldraw-canvas.test.tsx
@@ -106,6 +106,30 @@ function setMeasuredSize(element: Element, width: number, height: number) {
   }
 }
 
+function emitMeasuredResize(width: number, height: number) {
+  if (!mockResizeObserverCallback) return;
+  if (observedElement) {
+    setMeasuredSize(observedElement, width, height);
+  }
+  mockResizeObserverCallback(
+    [
+      {
+        contentRect: {
+          width,
+          height,
+          x: 0,
+          y: 0,
+          top: 0,
+          bottom: 0,
+          left: 0,
+          right: 0,
+        },
+      },
+    ] as ResizeObserverEntry[],
+    {} as ResizeObserver,
+  );
+}
+
 // Mock editor
 // mockUpdateShapes/mocked editor defined above for useEditor stub
 
@@ -216,6 +240,47 @@ describe('customShapeUtil.component - ResizeObserver Logic', () => {
     expect(mockUpdateShapes).toHaveBeenCalledTimes(1);
     expect(mockUpdateShapes).toHaveBeenCalledWith([
       { id: defaultTestShape.id, type: 'custom', props: { w: 300, h: 250 } },
+    ]);
+  });
+
+  it('continues fitting growing Remote Codex widget content', () => {
+    const codexShape = {
+      ...defaultTestShape,
+      props: { ...defaultTestShape.props, name: 'CodexRemoteWidget' },
+    };
+    const { rerender } = render(<TestShapeRenderer shape={codexShape} />);
+    expect(mockResizeObserverCallback).not.toBeNull();
+
+    act(() => {
+      emitMeasuredResize(720, 640);
+    });
+    act(() => {
+      jest.advanceTimersByTime(150);
+      jest.runOnlyPendingTimers();
+    });
+
+    expect(mockUpdateShapes).toHaveBeenCalledTimes(1);
+    expect(mockUpdateShapes).toHaveBeenLastCalledWith([
+      { id: defaultTestShape.id, type: 'custom', props: { w: 720, h: 640 } },
+    ]);
+
+    rerender(
+      <TestShapeRenderer
+        shape={{ ...codexShape, props: { ...codexShape.props, w: 720, h: 640 } }}
+      />,
+    );
+
+    act(() => {
+      emitMeasuredResize(720, 860);
+    });
+    act(() => {
+      jest.advanceTimersByTime(150);
+      jest.runOnlyPendingTimers();
+    });
+
+    expect(mockUpdateShapes).toHaveBeenCalledTimes(2);
+    expect(mockUpdateShapes).toHaveBeenLastCalledWith([
+      { id: defaultTestShape.id, type: 'custom', props: { w: 720, h: 860 } },
     ]);
   });
 

--- a/src/lib/component-sizing.ts
+++ b/src/lib/component-sizing.ts
@@ -178,7 +178,7 @@ export const componentSizeInfo: Record<string, ComponentSizeInfo> = {
     minWidth: 420,
     minHeight: 420,
     resizeMode: 'free',
-    sizingPolicy: 'fit_until_user_resize',
+    sizingPolicy: 'always_fit', // Setup, workspace lists, and chat output expand in-place
   },
   ResearchPanel: {
     naturalWidth: 600,


### PR DESCRIPTION
## Summary
- make the Remote Codex TLDraw shape use the existing always-fit sizing policy
- add a regression test proving the shape keeps growing as widget content expands

## Verification
- npx jest --runInBand --runTestsByPath src/components/ui/tldraw/tldraw-canvas.test.tsx
- npm run typecheck