### PR TITLE
Fix reset browser smoke contracts

### DIFF
--- a/playwright.reset.config.ts
+++ b/playwright.reset.config.ts
@@ -9,7 +9,8 @@ export default defineConfig({
   reporter: [['list'], ['html', { open: 'never' }]],
   webServer: [
     {
-      command: 'npm run build && CODEX_BROKER_URL=http://127.0.0.1:4101 PORT=3011 npm run start',
+      command:
+        'NEXT_PUBLIC_CANVAS_DEV_BYPASS=true npm run build && NEXT_PUBLIC_CANVAS_DEV_BYPASS=true CODEX_BROKER_URL=http://127.0.0.1:4101 PORT=3011 npm run start',
       url: 'http://127.0.0.1:3011',
       reuseExistingServer: false,
       timeout: 240000,

--- a/tests/reset-workspace.e2e.spec.ts
+++ b/tests/reset-workspace.e2e.spec.ts
@@ -1,5 +1,7 @@
 import { test, expect } from '@playwright/test';
 
+const brokeredProxyUrl = /127\.0\.0\.1:4101\/sessions\/.+\/proxy\/(?:[^/]+\/)?$/;
+
 test.describe('reset workspace shell', () => {
   test('renders the reset mission control shell as the primary entrypoint', async ({ page }) => {
     await page.goto('/');
@@ -34,16 +36,16 @@ test.describe('reset workspace shell', () => {
     await expect(page.locator('select')).toContainText('remote-codex:');
 
     const remoteFrame = page.locator('iframe[title="Remote Codex"]');
-    await expect(remoteFrame).toHaveAttribute('src', /127\.0\.0\.1:4101\/sessions\/.+\/proxy\/$/);
+    await expect(remoteFrame).toHaveAttribute('src', brokeredProxyUrl);
     await expect(page.getByRole('link', { name: 'Pop Out' })).toHaveAttribute(
       'href',
-      /127\.0\.0\.1:4101\/sessions\/.+\/proxy\/$/,
+      brokeredProxyUrl,
     );
 
     await page.reload();
     await expect(page.locator('iframe[title="Remote Codex"]')).toHaveAttribute(
       'src',
-      /127\.0\.0\.1:4101\/sessions\/.+\/proxy\/$/,
+      brokeredProxyUrl,
     );
   });
 });


### PR DESCRIPTION
## Summary
- run the reset Playwright build with canvas dev bypass so /canvas can load unauthenticated in CI
- allow tokenized broker proxy iframe URLs in reset smoke assertions

## Verification
- npm run test:reset:e2e
- npm run typecheck