### PR TITLE
Fix custom widget sizing when shape name is a label

### DIFF
--- a/src/components/ui/tldraw/canvas/components/CustomShapeComponent.tsx
+++ b/src/components/ui/tldraw/canvas/components/CustomShapeComponent.tsx
@@ -11,7 +11,7 @@ import React, {
 } from 'react';
 import { createPortal } from 'react-dom';
 import { useEditor } from '@tldraw/tldraw';
-import { getComponentSizeInfo } from '@/lib/component-sizing';
+import { componentSizeInfo, getComponentSizeInfo } from '@/lib/component-sizing';
 import { ComponentStoreContext } from '../hooks/useCanvasStore';
 import type { CustomShape } from '../utils/shapeUtils';
 import { useContextKey } from '@/components/RoomScopedProviders';
@@ -42,6 +42,51 @@ export class ComponentErrorBoundary extends Component<
   }
 }
 
+function getStoredComponentTypeName(stored: ReactNode | null | undefined): string | null {
+  const readTypeName = (type: unknown): string | null => {
+    if (!type || typeof type === 'string') return null;
+    const record = type as { displayName?: unknown; name?: unknown };
+    if (typeof record.displayName === 'string' && record.displayName.trim()) {
+      return record.displayName.trim();
+    }
+    if (typeof record.name === 'string' && record.name.trim()) {
+      return record.name.trim();
+    }
+    return null;
+  };
+
+  if (React.isValidElement(stored)) {
+    return readTypeName(stored.type);
+  }
+
+  if (stored && typeof stored === 'object') {
+    const record = stored as {
+      type?: unknown;
+      Component?: unknown;
+      component?: unknown;
+      props?: { componentType?: unknown; type?: unknown };
+    };
+    const propComponentType = record.props?.componentType ?? record.props?.type;
+    if (typeof propComponentType === 'string' && propComponentType.trim()) {
+      return propComponentType.trim();
+    }
+    return readTypeName(record.type ?? record.Component ?? record.component);
+  }
+
+  return null;
+}
+
+function resolveSizingComponentName(shapeName: string, stored: ReactNode | null | undefined): string {
+  if (componentSizeInfo[shapeName]) return shapeName;
+
+  const storedTypeName = getStoredComponentTypeName(stored);
+  if (!storedTypeName) return shapeName;
+  if (componentSizeInfo[storedTypeName]) return storedTypeName;
+
+  const embeddedKnownName = Object.keys(componentSizeInfo).find((name) => storedTypeName.includes(name));
+  return embeddedKnownName ?? shapeName;
+}
+
 export function CustomShapeComponent({ shape }: { shape: CustomShape }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const scaleWrapperRef = useRef<HTMLDivElement>(null);
@@ -58,7 +103,9 @@ export function CustomShapeComponent({ shape }: { shape: CustomShape }) {
   const autoFittedRef = useRef(false);
   const lastMeasuredSizeRef = useRef<{ w: number; h: number } | null>(null);
 
-  const sizeInfo = getComponentSizeInfo(shape.props.name);
+  const storedComponent = componentStore?.get(shape.props.customComponent);
+  const sizingComponentName = resolveSizingComponentName(shape.props.name, storedComponent);
+  const sizeInfo = getComponentSizeInfo(sizingComponentName);
   const sizingPolicy = sizeInfo.sizingPolicy || 'fit_until_user_resize';
   const isFixedLivekitTile =
     shape.props.name === 'LivekitParticipantTile' || shape.props.name === 'LivekitScreenShareTile';

--- a/src/components/ui/tldraw/tldraw-canvas.test.tsx
+++ b/src/components/ui/tldraw/tldraw-canvas.test.tsx
@@ -1,7 +1,13 @@
 import React from 'react';
 import { render, act, cleanup } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { customShapeUtil, customShape, TldrawCanvasProps, TldrawCanvas } from './tldraw-canvas'; // Assuming customShape type is exported
+import {
+  ComponentStoreContext,
+  customShapeUtil,
+  customShape,
+  TldrawCanvasProps,
+  TldrawCanvas,
+} from './tldraw-canvas'; // Assuming customShape type is exported
 import { Editor, TLBaseShape } from '@tldraw/tldraw';
 
 const mockUpdateShapes = jest.fn();
@@ -172,6 +178,10 @@ const defaultTestShape: customShape = {
   meta: {},
 };
 
+function CodexRemoteWidget() {
+  return <div>Remote Codex</div>;
+}
+
 describe('customShapeUtil.component - ResizeObserver Logic', () => {
   beforeEach(() => {
     jest.useFakeTimers();
@@ -268,6 +278,62 @@ describe('customShapeUtil.component - ResizeObserver Logic', () => {
       <TestShapeRenderer
         shape={{ ...codexShape, props: { ...codexShape.props, w: 720, h: 640 } }}
       />,
+    );
+
+    act(() => {
+      emitMeasuredResize(720, 860);
+    });
+    act(() => {
+      jest.advanceTimersByTime(150);
+      jest.runOnlyPendingTimers();
+    });
+
+    expect(mockUpdateShapes).toHaveBeenCalledTimes(2);
+    expect(mockUpdateShapes).toHaveBeenLastCalledWith([
+      { id: defaultTestShape.id, type: 'custom', props: { w: 720, h: 860 } },
+    ]);
+  });
+
+  it('uses the stored widget component type for sizing when the shape name is a display label', () => {
+    const codexMessageId = 'codex-widget-message';
+    const codexShape = {
+      ...defaultTestShape,
+      props: {
+        ...defaultTestShape.props,
+        customComponent: codexMessageId,
+        name: 'Remote Codex',
+      },
+    };
+    const componentStore = new Map<string, React.ReactNode>([
+      [codexMessageId, <CodexRemoteWidget key="codex" />],
+    ]);
+
+    const { rerender } = render(
+      <ComponentStoreContext.Provider value={componentStore}>
+        <TestShapeRenderer shape={codexShape} />
+      </ComponentStoreContext.Provider>,
+    );
+    expect(mockResizeObserverCallback).not.toBeNull();
+
+    act(() => {
+      emitMeasuredResize(720, 640);
+    });
+    act(() => {
+      jest.advanceTimersByTime(150);
+      jest.runOnlyPendingTimers();
+    });
+
+    expect(mockUpdateShapes).toHaveBeenCalledTimes(1);
+    expect(mockUpdateShapes).toHaveBeenLastCalledWith([
+      { id: defaultTestShape.id, type: 'custom', props: { w: 720, h: 640 } },
+    ]);
+
+    rerender(
+      <ComponentStoreContext.Provider value={componentStore}>
+        <TestShapeRenderer
+          shape={{ ...codexShape, props: { ...codexShape.props, w: 720, h: 640 } }}
+        />
+      </ComponentStoreContext.Provider>,
     );
 
     act(() => {


### PR DESCRIPTION
## Summary
- resolve custom shape sizing from the stored React component type when shape.props.name is only a display label
- fixes Remote Codex shapes labeled "Remote Codex" falling back to default one-shot sizing instead of CodexRemoteWidget always-fit sizing
- adds a regression for stored CodexRemoteWidget + display-label sizing growth

## Verification
- npx jest --runInBand --runTestsByPath src/components/ui/tldraw/tldraw-canvas.test.tsx src/components/ui/codex/codex-remote-widget.test.tsx
- npm run typecheck