### PR TITLE
fix: send Widget Codex auth headers

### DIFF
--- a/src/components/ui/codex/codex-remote-widget.test.tsx
+++ b/src/components/ui/codex/codex-remote-widget.test.tsx
@@ -3,12 +3,17 @@ import { CodexRemoteWidget } from './codex-remote-widget';
 
 const componentRegistryUpdateMock = jest.fn().mockResolvedValue(undefined);
 const useComponentRegistrationMock = jest.fn();
+const fetchWithSupabaseAuthMock = jest.fn();
 
 jest.mock('@/lib/component-registry', () => ({
   ComponentRegistry: {
     update: (...args: unknown[]) => componentRegistryUpdateMock(...args),
   },
   useComponentRegistration: (...args: unknown[]) => useComponentRegistrationMock(...args),
+}));
+
+jest.mock('@/lib/supabase/auth-headers', () => ({
+  fetchWithSupabaseAuth: (...args: unknown[]) => fetchWithSupabaseAuthMock(...args),
 }));
 
 const buildServersPayload = () => ({
@@ -41,6 +46,7 @@ describe('CodexRemoteWidget', () => {
   beforeEach(() => {
     componentRegistryUpdateMock.mockClear();
     useComponentRegistrationMock.mockClear();
+    fetchWithSupabaseAuthMock.mockClear();
     (global as any).WebSocket = undefined;
     global.fetch = jest.fn().mockImplementation(async (input: RequestInfo | URL) => {
       const url = String(input);
@@ -55,6 +61,9 @@ describe('CodexRemoteWidget', () => {
         json: async () => ({}),
       } as Response;
     });
+    fetchWithSupabaseAuthMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) =>
+      fetch(input, init),
+    );
   });
 
   afterEach(() => {
@@ -66,6 +75,7 @@ describe('CodexRemoteWidget', () => {
 
     expect(await screen.findByText('Connect Remote Codex')).toBeTruthy();
     expect(await screen.findByText(/saved servers, login handoff/i)).toBeTruthy();
+    expect(fetchWithSupabaseAuthMock).toHaveBeenCalledWith('/api/widget-codex/servers', undefined);
     expect(global.fetch).toHaveBeenCalledWith('/api/widget-codex/servers', undefined);
     expect(screen.getByRole('option', { name: 'Remote Prod' })).toBeTruthy();
   });

--- a/src/components/ui/codex/codex-remote-widget.tsx
+++ b/src/components/ui/codex/codex-remote-widget.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Button } from '@/components/ui/shared/button';
 import { ComponentRegistry, useComponentRegistration } from '@/lib/component-registry';
+import { fetchWithSupabaseAuth } from '@/lib/supabase/auth-headers';
 import { cn } from '@/lib/utils';
 import { codexRemoteWidgetSchema, type CodexRemoteWidgetProps } from './codex-remote-widget-schema';
 
@@ -210,7 +211,7 @@ function createWidgetSessionId() {
 }
 
 async function requestJson<T>(input: string, init?: RequestInit): Promise<T> {
-  const response = await fetch(input, init);
+  const response = await fetchWithSupabaseAuth(input, init);
   const payload = (await response.json().catch(() => null)) as Record<string, unknown> | null;
   if (!response.ok) {
     const error = new Error(


### PR DESCRIPTION
## Summary
- route Widget Codex widget API calls through the existing Supabase auth-header fetch helper
- preserve the new form validation/error handling while allowing signed-in browser sessions to reach admin action routes
- cover the helper usage in widget tests

## Tests
- npx jest --runInBand --runTestsByPath src/components/ui/codex/codex-remote-widget.test.tsx
- npm run typecheck
- npm run test:reset
- npm run build