### PR TITLE
fix: use secure Widget Codex websockets

### DIFF
--- a/src/components/ui/codex/codex-remote-widget.test.tsx
+++ b/src/components/ui/codex/codex-remote-widget.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { CodexRemoteWidget } from './codex-remote-widget';
+import { CodexRemoteWidget, deriveWidgetCodexWsUrl } from './codex-remote-widget';
 
 const componentRegistryUpdateMock = jest.fn().mockResolvedValue(undefined);
 const useComponentRegistrationMock = jest.fn();
@@ -68,6 +68,18 @@ describe('CodexRemoteWidget', () => {
 
   afterEach(() => {
     (global as any).WebSocket = originalWebSocket;
+  });
+
+  it('upgrades insecure widget websocket urls when the canvas is served over https', () => {
+    expect(
+      deriveWidgetCodexWsUrl(
+        'ws://present-widget-codex-production.up.railway.app/ws',
+        'https://app.present.best/canvas',
+      ),
+    ).toBe('wss://present-widget-codex-production.up.railway.app/ws');
+    expect(deriveWidgetCodexWsUrl('/ws', 'https://app.present.best/canvas')).toBe(
+      'wss://app.present.best/ws',
+    );
   });
 
   it('loads the multi-server setup flow when no widget session exists yet', async () => {

--- a/src/components/ui/codex/codex-remote-widget.tsx
+++ b/src/components/ui/codex/codex-remote-widget.tsx
@@ -266,11 +266,27 @@ function buildInitialState(
   } satisfies PersistedWidgetState;
 }
 
-function deriveWsUrl(value: string | null) {
+export function deriveWidgetCodexWsUrl(value: string | null, baseHref?: string) {
   if (!value) return null;
   try {
-    const url = new URL(value);
-    url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+    const fallbackBase = typeof window !== 'undefined' ? window.location.href : 'http://localhost/';
+    const url = new URL(value, baseHref ?? fallbackBase);
+    const pageProtocol =
+      baseHref !== undefined
+        ? new URL(baseHref).protocol
+        : typeof window !== 'undefined'
+          ? window.location.protocol
+          : 'http:';
+    const shouldUseSecureWebSocket = pageProtocol === 'https:' || url.protocol === 'https:';
+
+    if (url.protocol === 'http:' || url.protocol === 'ws:') {
+      url.protocol = shouldUseSecureWebSocket ? 'wss:' : 'ws:';
+    } else if (url.protocol === 'https:' || url.protocol === 'wss:') {
+      url.protocol = 'wss:';
+    } else {
+      return null;
+    }
+
     return url.toString();
   } catch {
     return null;
@@ -765,7 +781,7 @@ export function CodexRemoteWidget(props: CanvasCodexRemoteWidgetProps) {
   );
 
   useEffect(() => {
-    const wsUrl = deriveWsUrl(realtimeUrl);
+    const wsUrl = deriveWidgetCodexWsUrl(realtimeUrl);
     if (!wsUrl || typeof window === 'undefined' || typeof WebSocket === 'undefined') return;
     const url = new URL(wsUrl);
     if (state.widgetSessionId) {


### PR DESCRIPTION
## Summary
- force Widget Codex websocket URLs to use wss on HTTPS canvas pages
- support relative realtime websocket URLs against the current origin
- add regression coverage for the Railway ws:// mixed-content failure

## Tests
- npx jest --runInBand --runTestsByPath src/components/ui/codex/codex-remote-widget.test.tsx
- npm run typecheck
- npm run test:reset
- npm run build