### PR TITLE
feat: add Railway tailnet bridge service

### DIFF
--- a/.github/workflows/deploy-railway-prod.yml
+++ b/.github/workflows/deploy-railway-prod.yml
@@ -38,6 +38,11 @@ on:
         required: false
         default: false
         type: boolean
+      force_railtail:
+        description: 'Force deploy present-railtail'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -53,6 +58,7 @@ env:
   RAILWAY_REALTIME_SERVICE: present-realtime
   RAILWAY_CODEX_BROKER_SERVICE: present-codex-broker
   RAILWAY_WIDGET_CODEX_SERVICE: present-widget-codex
+  RAILWAY_RAILTAIL_SERVICE: present-railtail
 
 jobs:
   plan:
@@ -62,6 +68,7 @@ jobs:
       deploy_realtime: ${{ steps.plan.outputs.deploy_realtime }}
       deploy_codex_broker: ${{ steps.plan.outputs.deploy_codex_broker }}
       deploy_widget_codex: ${{ steps.plan.outputs.deploy_widget_codex }}
+      deploy_railtail: ${{ steps.plan.outputs.deploy_railtail }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -103,6 +110,7 @@ jobs:
           deploy_realtime=false
           deploy_codex_broker=false
           deploy_widget_codex=false
+          deploy_railtail=false
           is_dispatch_from_main=false
 
           if [ "${{ github.event_name }}" != "workflow_dispatch" ] || [ "${{ github.ref }}" = "refs/heads/main" ]; then
@@ -148,21 +156,28 @@ jobs:
             deploy_widget_codex=true
           fi
 
+          if [ "${{ github.event.inputs.force_railtail || 'false' }}" = "true" ]; then
+            deploy_railtail=true
+          fi
+
           if [ "$is_dispatch_from_main" = false ]; then
             deploy_conductor=false
             deploy_realtime=false
             deploy_codex_broker=false
             deploy_widget_codex=false
+            deploy_railtail=false
           fi
 
           echo "deploy_conductor=$deploy_conductor" >> "$GITHUB_OUTPUT"
           echo "deploy_realtime=$deploy_realtime" >> "$GITHUB_OUTPUT"
           echo "deploy_codex_broker=$deploy_codex_broker" >> "$GITHUB_OUTPUT"
           echo "deploy_widget_codex=$deploy_widget_codex" >> "$GITHUB_OUTPUT"
+          echo "deploy_railtail=$deploy_railtail" >> "$GITHUB_OUTPUT"
           echo "deploy_conductor=$deploy_conductor"
           echo "deploy_realtime=$deploy_realtime"
           echo "deploy_codex_broker=$deploy_codex_broker"
           echo "deploy_widget_codex=$deploy_widget_codex"
+          echo "deploy_railtail=$deploy_railtail"
 
   deploy-conductor:
     runs-on: ubuntu-latest
@@ -527,3 +542,103 @@ jobs:
               --skip-deploys
           fi
           run_with_railway_auth redeploy railway redeploy --service "$RAILWAY_WIDGET_CODEX_SERVICE" --yes
+
+  deploy-railtail:
+    runs-on: ubuntu-latest
+    needs: plan
+    if: needs.plan.outputs.deploy_railtail == 'true'
+    steps:
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install Railway CLI
+        run: npm install --global @railway/cli
+
+      - name: Redeploy present-railtail
+        env:
+          RAILWAY_API_KEY: ${{ secrets.RAILWAY_API_KEY || '' }}
+          RAILWAY_PROJECT_TOKEN: ${{ secrets.RAILWAY_TOKEN || '' }}
+          RAILTAIL_TARGET_ADDR: ${{ vars.RAILTAIL_TARGET_ADDR || 'bens-macbook-pro.tailb3d6e9.ts.net:22' }}
+          RAILTAIL_LISTEN_PORT: ${{ vars.RAILTAIL_LISTEN_PORT || '2222' }}
+          RAILTAIL_TS_HOSTNAME: ${{ vars.RAILTAIL_TS_HOSTNAME || 'present-railtail' }}
+          RAILTAIL_TS_STATEDIR_PATH: ${{ vars.RAILTAIL_TS_STATEDIR_PATH || '/tmp/railtail' }}
+          RAILTAIL_TS_EXTRA_ARGS: ${{ vars.RAILTAIL_TS_EXTRA_ARGS || '' }}
+          TAILSCALE_AUTH_KEY: ${{ secrets.TAILSCALE_AUTH_KEY || secrets.RAILTAIL_TS_AUTH_KEY || '' }}
+        run: |
+          set -euo pipefail
+          if [ -z "${RAILWAY_API_KEY:-}" ] && [ -z "${RAILWAY_PROJECT_TOKEN:-}" ]; then
+            echo "::error::Missing Railway auth. Set RAILWAY_API_KEY and/or RAILWAY_TOKEN in GitHub Actions secrets."
+            exit 1
+          fi
+          if [ -z "${TAILSCALE_AUTH_KEY:-}" ]; then
+            echo "::error::Missing TAILSCALE_AUTH_KEY secret for present-railtail."
+            exit 1
+          fi
+          if [ -z "${RAILTAIL_TARGET_ADDR:-}" ]; then
+            echo "::error::Missing RAILTAIL_TARGET_ADDR repository variable."
+            exit 1
+          fi
+          if [ -z "${RAILTAIL_LISTEN_PORT:-}" ]; then
+            echo "::error::Missing RAILTAIL_LISTEN_PORT repository variable."
+            exit 1
+          fi
+          if ! [[ "$RAILTAIL_LISTEN_PORT" =~ ^[0-9]+$ ]] || [ "$RAILTAIL_LISTEN_PORT" -eq 0 ]; then
+            echo "::error::RAILTAIL_LISTEN_PORT must be a positive integer."
+            exit 1
+          fi
+          if [ -z "${RAILTAIL_TS_HOSTNAME:-}" ]; then
+            echo "::error::Missing RAILTAIL_TS_HOSTNAME repository variable."
+            exit 1
+          fi
+
+          tmp_dir="$(mktemp -d)"
+          cd "$tmp_dir"
+          run_with_railway_auth() {
+            local action="$1"
+            shift
+            local code=1
+            if [ -n "${RAILWAY_API_KEY:-}" ]; then
+              set +e
+              RAILWAY_API_TOKEN="$RAILWAY_API_KEY" RAILWAY_TOKEN="" "$@"
+              code=$?
+              set -e
+              if [ "$code" -eq 0 ]; then
+                echo "auth_source=RAILWAY_API_KEY action=$action"
+                return 0
+              fi
+            fi
+            if [ -n "${RAILWAY_PROJECT_TOKEN:-}" ]; then
+              set +e
+              RAILWAY_API_TOKEN="" RAILWAY_TOKEN="$RAILWAY_PROJECT_TOKEN" "$@"
+              code=$?
+              set -e
+              if [ "$code" -eq 0 ]; then
+                echo "auth_source=RAILWAY_TOKEN action=$action"
+                return 0
+              fi
+            fi
+            return "$code"
+          }
+
+          if [ -n "${RAILWAY_PROJECT_TOKEN:-}" ]; then
+            echo "auth_source=RAILWAY_TOKEN action=redeploy"
+            echo "Project token mode: skipping variable sync; Railway project tokens are deployment-scoped."
+            RAILWAY_API_TOKEN="" RAILWAY_TOKEN="$RAILWAY_PROJECT_TOKEN" railway redeploy --service "$RAILWAY_RAILTAIL_SERVICE" --yes
+            exit 0
+          fi
+
+          run_with_railway_auth link railway link -p "$RAILWAY_PROJECT_ID" -e "$RAILWAY_ENVIRONMENT"
+          run_with_railway_auth variables railway variables \
+            --service "$RAILWAY_RAILTAIL_SERVICE" \
+            --environment "$RAILWAY_ENVIRONMENT" \
+            --set "SERVICE_TYPE=railtail" \
+            --set "TARGET_ADDR=$RAILTAIL_TARGET_ADDR" \
+            --set "LISTEN_PORT=$RAILTAIL_LISTEN_PORT" \
+            --set "TS_HOSTNAME=$RAILTAIL_TS_HOSTNAME" \
+            --set "TS_AUTH_KEY=$TAILSCALE_AUTH_KEY" \
+            --set "TS_STATEDIR_PATH=$RAILTAIL_TS_STATEDIR_PATH" \
+            --set "TS_EXTRA_ARGS=$RAILTAIL_TS_EXTRA_ARGS" \
+            --skip-deploys
+          run_with_railway_auth redeploy railway redeploy --service "$RAILWAY_RAILTAIL_SERVICE" --yes

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,11 @@ FROM node:22-bookworm-slim
 
 WORKDIR /app
 
+# Tailscale is used only by SERVICE_TYPE=railtail. Keeping the binaries in the
+# shared image lets Railway run the bridge as another repo service.
+COPY --from=docker.io/tailscale/tailscale:stable /usr/local/bin/tailscale /usr/local/bin/tailscale
+COPY --from=docker.io/tailscale/tailscale:stable /usr/local/bin/tailscaled /usr/local/bin/tailscaled
+
 # Ensure TLS trust store exists for LiveKit Cloud HTTPS calls.
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates \
   && rm -rf /var/lib/apt/lists/*

--- a/docs/widget-codex-tailnet-bridge.md
+++ b/docs/widget-codex-tailnet-bridge.md
@@ -1,0 +1,67 @@
+# Widget Codex Tailnet Bridge
+
+The `/canvas` Remote Codex widget can connect to a Codex app server that is reachable only inside a Tailscale tailnet by adding a private Railway bridge service.
+
+## Network Shape
+
+```text
+present-widget-codex -> present-railtail.railway.internal:2222 -> bens-macbook-pro.tailb3d6e9.ts.net:22
+```
+
+`present-railtail` joins the tailnet and forwards TCP traffic to the target Mac over Tailscale. The broker still creates an SSH tunnel from the Widget Codex service to the Mac, so the remote Codex app server can remain bound to `127.0.0.1` on the Mac.
+
+## Railway Service
+
+Create the service once from this repo:
+
+```sh
+railway add --service present-railtail --repo human-bee/PRESENT
+```
+
+Do not add a public Railway domain for this service. It is intended to be consumed through Railway private networking only.
+
+## GitHub Secrets And Variables
+
+Required secret:
+
+```text
+TAILSCALE_AUTH_KEY
+```
+
+Use a pre-authorized, ephemeral Tailscale auth key. Prefer a tagged key such as `tag:present-railtail`, then restrict that tag with Tailscale ACLs so it can reach only the Mac SSH endpoint required by Widget Codex.
+
+Optional repository variables:
+
+```text
+RAILTAIL_TARGET_ADDR=bens-macbook-pro.tailb3d6e9.ts.net:22
+RAILTAIL_LISTEN_PORT=2222
+RAILTAIL_TS_HOSTNAME=present-railtail
+RAILTAIL_TS_STATEDIR_PATH=/tmp/railtail
+RAILTAIL_TS_EXTRA_ARGS=
+```
+
+The production Railway workflow defaults to those values when the variables are not set.
+
+## Deploy
+
+After the service exists and `TAILSCALE_AUTH_KEY` is set, run:
+
+```sh
+gh workflow run "Deploy Railway Prod" --ref main -f force_railtail=true
+```
+
+The workflow syncs `SERVICE_TYPE=railtail`, `TARGET_ADDR`, `LISTEN_PORT`, `TS_HOSTNAME`, `TS_AUTH_KEY`, `TS_STATEDIR_PATH`, and `TS_EXTRA_ARGS` to the `present-railtail` Railway service and redeploys it.
+
+## Widget Server Form
+
+Once `present-railtail` is healthy, use the Railway private host in the widget server form:
+
+```text
+SSH Host: present-railtail.railway.internal
+SSH Port: 2222
+SSH Username: bsteinher
+Remote Codex Port: 8390
+Remote Workspace: /Users/bsteinher/PRESENT
+```
+
+Keep the SSH private key and host-key fingerprint in the widget service. Do not persist them in TLDraw shape state.

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "present:mcp": "npx tsx services/present-mcp/src/server.ts",
     "codex:broker": "npx tsx services/codex-broker/src/run.ts",
     "widget:codex": "npx tsx services/widget-codex/src/run.ts",
+    "railtail": "npx tsx services/railtail/src/run.ts",
     "codex:manifest": "npx tsx services/codex-adapter/src/print-manifest.ts",
     "bench:canvas": "npx tsx scripts/canvas-benchmark.ts",
     "bench:canvas:enrich": "npx tsx scripts/canvas-benchmark-enrich.ts",

--- a/scripts/start-service.sh
+++ b/scripts/start-service.sh
@@ -25,6 +25,10 @@ case "$SERVICE_TYPE" in
     echo "Starting Widget Codex Service..."
     exec npm run widget:codex
     ;;
+  railtail|tailnet-bridge)
+    echo "Starting Railtail Bridge..."
+    exec npm run railtail
+    ;;
   web|present|app)
     echo "Starting Web App..."
     if [ ! -d ".next" ]; then
@@ -35,7 +39,7 @@ case "$SERVICE_TYPE" in
     ;;
   *)
     echo "Error: unsupported SERVICE_TYPE value: ${SERVICE_TYPE:-<unset>}" >&2
-    echo "Expected one of: sync, agent, conductor, realtime, codex-broker, broker, widget-codex, codex-widget, web, present, app" >&2
+    echo "Expected one of: sync, agent, conductor, realtime, codex-broker, broker, widget-codex, codex-widget, railtail, tailnet-bridge, web, present, app" >&2
     exit 1
     ;;
 esac

--- a/services/railtail/src/run.ts
+++ b/services/railtail/src/run.ts
@@ -1,0 +1,183 @@
+import * as net from 'node:net';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+
+const TAILSCALE_SOCKET = process.env.TAILSCALE_SOCKET || '/tmp/present-railtail/tailscaled.sock';
+const DEFAULT_STATE_DIR = process.env.RAILWAY_VOLUME_MOUNT_PATH
+  ? `${process.env.RAILWAY_VOLUME_MOUNT_PATH}/railtail`
+  : '/tmp/present-railtail/state';
+
+type Target = {
+  host: string;
+  port: number;
+};
+
+function requireEnv(name: string) {
+  const value = process.env[name]?.trim();
+  if (!value) {
+    throw new Error(`${name} is required.`);
+  }
+  return value;
+}
+
+function parsePort(name: string, value: string) {
+  if (!/^\d+$/.test(value)) {
+    throw new Error(`${name} must be a positive integer.`);
+  }
+  const port = Number(value);
+  if (!Number.isSafeInteger(port) || port < 1 || port > 65_535) {
+    throw new Error(`${name} must be between 1 and 65535.`);
+  }
+  return port;
+}
+
+export function parseTargetAddress(value: string): Target {
+  const trimmed = value.trim();
+  const ipv6Match = trimmed.match(/^\[([^\]]+)\]:(\d+)$/);
+  if (ipv6Match) {
+    return { host: ipv6Match[1] ?? '', port: parsePort('TARGET_ADDR port', ipv6Match[2] ?? '') };
+  }
+
+  const separator = trimmed.lastIndexOf(':');
+  if (separator <= 0 || separator === trimmed.length - 1) {
+    throw new Error('TARGET_ADDR must be formatted as host:port.');
+  }
+  const host = trimmed.slice(0, separator);
+  const port = parsePort('TARGET_ADDR port', trimmed.slice(separator + 1));
+  if (!host) {
+    throw new Error('TARGET_ADDR host is required.');
+  }
+  return { host, port };
+}
+
+function spawnLogged(command: string, args: string[], options?: { redactArgs?: Set<string> }) {
+  const printableArgs = args.map((arg) => (options?.redactArgs?.has(arg) ? '<redacted>' : arg));
+  console.log(`[railtail] starting ${command} ${printableArgs.join(' ')}`);
+  const child = spawn(command, args, {
+    env: process.env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  child.stdout.on('data', (chunk) => process.stdout.write(`[railtail:${command}] ${chunk}`));
+  child.stderr.on('data', (chunk) => process.stderr.write(`[railtail:${command}] ${chunk}`));
+  return child;
+}
+
+async function runChecked(command: string, args: string[], options?: { redactArgs?: Set<string> }) {
+  const child = spawnLogged(command, args, options);
+  const [code] = (await once(child, 'exit')) as [number | null, NodeJS.Signals | null];
+  if (code !== 0) {
+    throw new Error(`${command} exited with code ${code ?? 'signal'}.`);
+  }
+}
+
+function startTailscaled(stateDir: string) {
+  return spawnLogged('tailscaled', [
+    `--socket=${TAILSCALE_SOCKET}`,
+    '--tun=userspace-networking',
+    `--statedir=${stateDir}`,
+    '--socks5-server=127.0.0.1:1055',
+    '--outbound-http-proxy-listen=127.0.0.1:1055',
+  ]);
+}
+
+async function waitForTailscale() {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < 20_000) {
+    const child = spawn('tailscale', ['--socket', TAILSCALE_SOCKET, 'status', '--json'], {
+      stdio: ['ignore', 'ignore', 'ignore'],
+    });
+    const [code] = (await once(child, 'exit')) as [number | null, NodeJS.Signals | null];
+    if (code === 0) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  throw new Error('Timed out waiting for tailscaled LocalAPI.');
+}
+
+function startTcpProxy(target: Target, listenPort: number) {
+  const server = net.createServer((socket) => {
+    const remote = `${socket.remoteAddress ?? 'unknown'}:${socket.remotePort ?? 0}`;
+    console.log(`[railtail] connection from ${remote} -> ${target.host}:${target.port}`);
+    const child = spawn('tailscale', [
+      '--socket',
+      TAILSCALE_SOCKET,
+      'nc',
+      target.host,
+      String(target.port),
+    ]);
+
+    socket.pipe(child.stdin);
+    child.stdout.pipe(socket);
+    child.stderr.on('data', (chunk) => process.stderr.write(`[railtail:nc] ${chunk}`));
+
+    const close = () => {
+      socket.destroy();
+      if (!child.killed) {
+        child.kill('SIGTERM');
+      }
+    };
+    socket.on('error', close);
+    socket.on('close', close);
+    child.on('error', close);
+    child.on('exit', close);
+  });
+
+  server.listen(listenPort, '0.0.0.0', () => {
+    console.log(`[railtail] listening on 0.0.0.0:${listenPort} for ${target.host}:${target.port}`);
+  });
+
+  return server;
+}
+
+async function main() {
+  const authKey = requireEnv('TS_AUTH_KEY');
+  const target = parseTargetAddress(requireEnv('TARGET_ADDR'));
+  const listenPort = parsePort('LISTEN_PORT', process.env.LISTEN_PORT?.trim() || process.env.PORT || '2222');
+  const hostname = process.env.TS_HOSTNAME?.trim() || 'present-railtail';
+  const stateDir = process.env.TS_STATEDIR_PATH?.trim() || DEFAULT_STATE_DIR;
+  fs.mkdirSync(path.dirname(TAILSCALE_SOCKET), { recursive: true });
+  fs.mkdirSync(stateDir, { recursive: true });
+
+  const tailscaled = startTailscaled(stateDir);
+  tailscaled.on('exit', (code, signal) => {
+    if (code !== null && code !== 0) {
+      console.error(`[railtail] tailscaled exited with code ${code}`);
+      process.exit(code);
+    }
+    if (signal) {
+      console.error(`[railtail] tailscaled exited from signal ${signal}`);
+      process.exit(1);
+    }
+  });
+
+  await waitForTailscale();
+
+  const upArgs = [
+    '--socket',
+    TAILSCALE_SOCKET,
+    'up',
+    `--auth-key=${authKey}`,
+    `--hostname=${hostname}`,
+    '--accept-dns=true',
+    ...(process.env.TS_EXTRA_ARGS?.trim().split(/\s+/).filter(Boolean) ?? []),
+  ];
+  await runChecked('tailscale', upArgs, { redactArgs: new Set([`--auth-key=${authKey}`]) });
+
+  const server = startTcpProxy(target, listenPort);
+
+  const shutdown = () => {
+    console.log('[railtail] shutting down');
+    server.close();
+    tailscaled.kill('SIGTERM');
+  };
+  process.once('SIGTERM', shutdown);
+  process.once('SIGINT', shutdown);
+}
+
+main().catch((error) => {
+  console.error(`[railtail] ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a first-party railtail service that runs Tailscale userspace networking and proxies TCP with `tailscale nc`
- wire `SERVICE_TYPE=railtail` into the Railway service entrypoint and Docker image
- add a manual `force_railtail` Railway deploy lane that syncs railtail variables without auto-deploying before the Tailscale key exists
- document the Widget Codex tailnet bridge setup

## Tests
- npm run typecheck
- npm run test:reset
- npm run build
- git diff --check

## Notes
- Created Railway service `present-railtail` in project `present-prod` / `production`.
- Set non-secret GitHub repo variables: `RAILTAIL_TARGET_ADDR`, `RAILTAIL_LISTEN_PORT`, `RAILTAIL_TS_HOSTNAME`, `RAILTAIL_TS_STATEDIR_PATH`.
- Still needs GitHub secret `TAILSCALE_AUTH_KEY` before running `force_railtail=true`.