### PR TITLE
Fix broker SSH host key verification

### DIFF
--- a/services/codex-broker/src/ssh-tunnel.test.ts
+++ b/services/codex-broker/src/ssh-tunnel.test.ts
@@ -1,0 +1,20 @@
+/** @jest-environment node */
+
+const {
+  normalizeSha256Fingerprint,
+  sha256FingerprintForHostKey,
+} = require('./ssh-tunnel') as typeof import('./ssh-tunnel');
+
+describe('Codex broker SSH host key fingerprints', () => {
+  it('normalizes OpenSSH SHA256 fingerprints', () => {
+    expect(normalizeSha256Fingerprint('SHA256:abc123=')).toBe('abc123');
+    expect(normalizeSha256Fingerprint(' abc123 ')).toBe('abc123');
+  });
+
+  it('computes OpenSSH-compatible base64 SHA256 fingerprints from raw host keys', () => {
+    const key = Buffer.from('test host key bytes');
+    expect(`SHA256:${sha256FingerprintForHostKey(key)}`).toBe(
+      'SHA256:i8RAo8FepaZh9Zk1g11kAg4bPC81Xk9YFVtnzGVO4co',
+    );
+  });
+});

--- a/services/codex-broker/src/ssh-tunnel.ts
+++ b/services/codex-broker/src/ssh-tunnel.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs/promises';
 import net from 'node:net';
 import { once } from 'node:events';
+import crypto from 'node:crypto';
 import { Client } from 'ssh2';
 
 export type CodexBrokerSshTunnelConfig = {
@@ -22,8 +23,16 @@ export type CodexBrokerSshTunnel = {
   close: () => Promise<void>;
 };
 
-const normalizeSha256Fingerprint = (value: string | null | undefined) =>
-  value?.trim().replace(/^SHA256:/i, '').trim() || '';
+export const normalizeSha256Fingerprint = (value: string | null | undefined) =>
+  value?.trim().replace(/^SHA256:/i, '').replace(/=+$/, '').trim() || '';
+
+export const sha256FingerprintForHostKey = (hostKey: Buffer | string) => {
+  const digest = crypto
+    .createHash('sha256')
+    .update(typeof hostKey === 'string' ? Buffer.from(hostKey, 'binary') : hostKey)
+    .digest('base64');
+  return normalizeSha256Fingerprint(digest);
+};
 
 export async function createCodexBrokerSshTunnel(
   config: CodexBrokerSshTunnelConfig,
@@ -49,14 +58,13 @@ export async function createCodexBrokerSshTunnel(
     privateKey,
     passphrase: config.passphrase ?? undefined,
     agent: config.agentSocketPath ?? undefined,
-    hostHash: 'sha256',
-    hostVerifier: (hashedKey) => {
+    hostVerifier: (hostKey) => {
       if (!expectedFingerprint) {
         throw new Error(
           'CODEX_BROKER_SSH_HOST_KEY_SHA256 is required when CODEX_BROKER_DIRECT_TARGET_URL is not configured.',
         );
       }
-      return normalizeSha256Fingerprint(hashedKey) === expectedFingerprint;
+      return sha256FingerprintForHostKey(hostKey) === expectedFingerprint;
     },
   });
 


### PR DESCRIPTION
## Summary
- verify SSH host keys by hashing the raw server key into OpenSSH-compatible SHA256/base64 fingerprints
- normalize SHA256 prefixes and trailing base64 padding before comparison
- add a focused broker fingerprint test

## Tests
- npm test -- services/codex-broker/src/ssh-tunnel.test.ts
- npm run typecheck