### PR TITLE
Fix Remote Codex widget stale workspace recovery

### DIFF
--- a/src/components/ui/codex/codex-remote-widget.test.tsx
+++ b/src/components/ui/codex/codex-remote-widget.test.tsx
@@ -357,6 +357,127 @@ describe('CodexRemoteWidget', () => {
     });
   });
 
+  it('recovers a stale reset workspace binding before sending a native turn', async () => {
+    const fetchCalls: Array<{ url: string; init?: RequestInit }> = [];
+    (global.fetch as jest.Mock).mockImplementation(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        fetchCalls.push({ url, init });
+
+        if (url === '/api/widget-codex/servers') {
+          return {
+            ok: true,
+            json: async () => buildServersPayload(),
+          } as Response;
+        }
+        if (url === '/api/reset/workspaces/ws_stale/state') {
+          return {
+            ok: false,
+            status: 404,
+            json: async () => ({ error: 'Workspace session not found' }),
+          } as Response;
+        }
+        if (url === '/api/reset/workspaces' && init?.method === 'POST') {
+          return {
+            ok: true,
+            json: async () => ({
+              workspace: {
+                id: 'ws_recovered',
+                title: 'Widget wcws_recover',
+                workspacePath: '/srv/codex/repos/PRESENT',
+              },
+            }),
+          } as Response;
+        }
+        if (url === '/api/reset/workspaces') {
+          return {
+            ok: true,
+            json: async () => ({ workspaces: [] }),
+          } as Response;
+        }
+        if (url === '/api/reset/executors/register') {
+          return {
+            ok: true,
+            json: async () => ({
+              executorSession: {
+                id: 'exec_recovered',
+              },
+            }),
+          } as Response;
+        }
+        if (url === '/api/reset/turns' && init?.method === 'POST') {
+          return {
+            ok: true,
+            json: async () => ({
+              taskRun: {
+                id: 'task_recovered',
+                status: 'queued',
+                summary: 'can you see this message?',
+                createdAt: '2026-04-22T22:00:00.000Z',
+                updatedAt: '2026-04-22T22:00:00.000Z',
+                startedAt: null,
+                completedAt: null,
+                error: null,
+                result: null,
+                metadata: {},
+              },
+            }),
+          } as Response;
+        }
+        if (url === '/api/reset/workspaces/ws_recovered/state') {
+          return {
+            ok: true,
+            json: async () => ({ tasks: [] }),
+          } as Response;
+        }
+        return {
+          ok: true,
+          json: async () => ({}),
+        } as Response;
+      },
+    );
+
+    render(
+      <CodexRemoteWidget
+        title="Remote Codex"
+        state={{
+          title: 'Remote Codex',
+          frameUrl: 'https://present-codex-broker-production.up.railway.app/sessions/cxs/proxy/token/',
+          widgetSessionId: 'wcws_recover',
+          workspaceSessionId: 'ws_stale',
+          executorSessionId: 'exec_stale',
+          connectionId: 'wccx_recover',
+          remoteSessionId: 'cxs_recover',
+          serverId: 'wcsrv_1',
+          remoteWorkspaceId: 'present',
+          remoteWorkspacePath: '/srv/codex/repos/PRESENT',
+          status: 'ready',
+          authState: 'authenticated',
+        }}
+      />,
+    );
+
+    fireEvent.change(
+      screen.getByPlaceholderText(
+        'Ask Remote Codex to inspect, edit, review, or run something in the selected remote workspace.',
+      ),
+      { target: { value: 'can you see this message?' } },
+    );
+    fireEvent.click(screen.getByText('Send Turn'));
+
+    await waitFor(() => {
+      const turnRequest = fetchCalls.find((call) => call.url === '/api/reset/turns');
+      expect(turnRequest).toBeTruthy();
+      expect(JSON.parse(String(turnRequest?.init?.body))).toEqual(
+        expect.objectContaining({
+          workspaceSessionId: 'ws_recovered',
+          executorSessionId: 'exec_recovered',
+          prompt: 'can you see this message?',
+        }),
+      );
+    });
+  });
+
   it('starts auth inline for a login-required server', async () => {
     (global.fetch as jest.Mock).mockImplementation(async (input: RequestInfo | URL) => {
       const url = String(input);

--- a/src/components/ui/codex/codex-remote-widget.tsx
+++ b/src/components/ui/codex/codex-remote-widget.tsx
@@ -293,6 +293,14 @@ function getWidgetCodexErrorMessage(error: unknown, fallback: string) {
   return getErrorMessage(error, fallback);
 }
 
+function isWorkspaceSessionNotFoundError(error: unknown) {
+  if (!(error instanceof Error)) return false;
+  return (
+    (error as HttpError).status === 404 &&
+    /workspace session not found/i.test(error.message)
+  );
+}
+
 function buildInitialState(
   persistedState: PersistedWidgetState | undefined,
   rest: CodexRemoteWidgetProps,
@@ -844,6 +852,22 @@ export function CodexRemoteWidget(props: CanvasCodexRemoteWidgetProps) {
   const ensureWorkspaceBinding = useCallback(
     async (connection: WidgetCodexConnection) => {
       let workspaceSessionId = state.workspaceSessionId;
+      if (workspaceSessionId) {
+        try {
+          await requestJson<{ tasks: ResetTaskRun[] }>(
+            `/api/reset/workspaces/${encodeURIComponent(workspaceSessionId)}/state`,
+          );
+        } catch (error) {
+          if (!isWorkspaceSessionNotFoundError(error)) throw error;
+          workspaceSessionId = undefined;
+          await persistState({
+            ...state,
+            workspaceSessionId: undefined,
+            executorSessionId: undefined,
+            lastError: undefined,
+          });
+        }
+      }
       if (!workspaceSessionId) {
         const existing = await requestJson<{ workspaces: ResetWorkspaceSession[] }>(
           '/api/reset/workspaces',
@@ -863,6 +887,7 @@ export function CodexRemoteWidget(props: CanvasCodexRemoteWidgetProps) {
               body: JSON.stringify({
                 title: `Widget ${state.widgetSessionId ?? createWidgetSessionId()}`,
                 ownerUserId: 'widget-codex',
+                workspacePath: connection.remoteWorkspacePath || undefined,
               }),
             },
           );
@@ -1262,12 +1287,23 @@ export function CodexRemoteWidget(props: CanvasCodexRemoteWidgetProps) {
     if (!state.workspaceSessionId) return;
     void loadWorkspaceConversation(state.workspaceSessionId).catch((error) => {
       if (!mountedRef.current) return;
+      if (isWorkspaceSessionNotFoundError(error)) {
+        void persistState({
+          ...stateRef.current,
+          workspaceSessionId: undefined,
+          executorSessionId: undefined,
+          lastError: undefined,
+        });
+        setMessages([]);
+        setActiveTaskRunId(null);
+        return;
+      }
       setState((previous) => ({
         ...previous,
         lastError: getErrorMessage(error, 'Failed to load widget Codex conversation.'),
       }));
     });
-  }, [loadWorkspaceConversation, state.workspaceSessionId]);
+  }, [loadWorkspaceConversation, persistState, state.workspaceSessionId]);
 
   useEffect(() => {
     if (


### PR DESCRIPTION
## Summary
- validate saved reset workspace sessions before the widget uses them for native turns
- clear stale workspace/executor bindings when reset state returns Workspace session not found
- create/register a fresh widget workspace/executor and send the turn with recovered IDs

## Tests
- npm test -- src/components/ui/codex/codex-remote-widget.test.tsx
- npm run typecheck
- git diff --check