### PR TITLE
[codex] avoid duplicate Remote Codex task sorting

### DIFF
--- a/src/components/ui/codex/codex-remote-widget.test.tsx
+++ b/src/components/ui/codex/codex-remote-widget.test.tsx
@@ -1,5 +1,9 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { CodexRemoteWidget, deriveWidgetCodexWsUrl } from './codex-remote-widget';
+import {
+  CodexRemoteWidget,
+  deriveRemoteCodexConversationState,
+  deriveWidgetCodexWsUrl,
+} from './codex-remote-widget';
 
 const componentRegistryUpdateMock = jest.fn().mockResolvedValue(undefined);
 const useComponentRegistrationMock = jest.fn();
@@ -80,6 +84,141 @@ describe('CodexRemoteWidget', () => {
     expect(deriveWidgetCodexWsUrl('/ws', 'https://app.present.best/canvas')).toBe(
       'wss://app.present.best/ws',
     );
+  });
+
+  it('derives remote conversation state with one chronological task sort', () => {
+    const sortSpy = jest.spyOn(Array.prototype, 'sort');
+    const conversation = deriveRemoteCodexConversationState(
+      [
+        {
+          id: 'task_late_created',
+          status: 'succeeded',
+          summary: 'late created',
+          createdAt: '2026-04-22T10:10:00.000Z',
+          updatedAt: '2026-04-22T10:11:00.000Z',
+          startedAt: '2026-04-22T10:10:05.000Z',
+          completedAt: '2026-04-22T10:11:00.000Z',
+          error: null,
+          result: { finalResponse: 'done' },
+          metadata: {},
+        },
+        {
+          id: 'task_latest_update',
+          status: 'queued',
+          summary: 'older created',
+          createdAt: '2026-04-22T10:00:00.000Z',
+          updatedAt: '2026-04-22T10:20:00.000Z',
+          startedAt: null,
+          completedAt: null,
+          error: null,
+          result: { codexThreadId: 'thread_from_result' },
+          metadata: { prompt: 'run queued turn', codexThreadId: 'thread_from_metadata' },
+        },
+      ],
+      'thread_fallback',
+    );
+    const sortCalls = sortSpy.mock.calls.length;
+    sortSpy.mockRestore();
+
+    expect(sortCalls).toBe(1);
+    expect(conversation.messages.map((message) => message.id)).toEqual([
+      'task_latest_update:user',
+      'task_late_created:user',
+      'task_late_created:assistant',
+    ]);
+    expect(conversation.activeTaskRunId).toBe('task_latest_update');
+    expect(conversation.nextThreadId).toBe('thread_from_result');
+  });
+
+  it('preserves latest-task tie and fallback-thread semantics', () => {
+    const conversation = deriveRemoteCodexConversationState(
+      [
+        {
+          id: 'task_payload_first',
+          status: 'running',
+          summary: 'payload first',
+          createdAt: '2026-04-22T10:20:00.000Z',
+          updatedAt: '2026-04-22T10:30:00.000Z',
+          startedAt: '2026-04-22T10:20:05.000Z',
+          completedAt: null,
+          error: null,
+          result: {},
+          metadata: {},
+        },
+        {
+          id: 'task_payload_second',
+          status: 'succeeded',
+          summary: 'payload second',
+          createdAt: '2026-04-22T10:00:00.000Z',
+          updatedAt: '2026-04-22T10:30:00.000Z',
+          startedAt: '2026-04-22T10:00:05.000Z',
+          completedAt: '2026-04-22T10:30:00.000Z',
+          error: null,
+          result: { codexThreadId: 'thread_should_not_win' },
+          metadata: {},
+        },
+      ],
+      'thread_fallback',
+    );
+
+    expect(conversation.messages.map((message) => message.id)).toEqual([
+      'task_payload_second:user',
+      'task_payload_first:user',
+    ]);
+    expect(conversation.activeTaskRunId).toBe('task_payload_first');
+    expect(conversation.nextThreadId).toBe('thread_fallback');
+  });
+
+  it('derives prompt, response, and failure messages from task branches', () => {
+    const conversation = deriveRemoteCodexConversationState([
+      {
+        id: 'task_summary_fallback',
+        status: 'failed',
+        summary: 'summary fallback',
+        createdAt: '2026-04-22T10:00:00.000Z',
+        updatedAt: '2026-04-22T10:05:00.000Z',
+        startedAt: '2026-04-22T10:00:05.000Z',
+        completedAt: '2026-04-22T10:05:00.000Z',
+        error: 'executor failed',
+        result: null,
+        metadata: { prompt: '   ' },
+      },
+      {
+        id: 'task_trimmed_response',
+        status: 'succeeded',
+        summary: 'response task',
+        createdAt: '2026-04-22T10:10:00.000Z',
+        updatedAt: '2026-04-22T10:15:00.000Z',
+        startedAt: '2026-04-22T10:10:05.000Z',
+        completedAt: '2026-04-22T10:15:00.000Z',
+        error: null,
+        result: { finalResponse: '  trimmed response  ' },
+        metadata: { prompt: '  trimmed prompt  ' },
+      },
+    ]);
+
+    expect(conversation.messages).toEqual([
+      expect.objectContaining({
+        id: 'task_summary_fallback:user',
+        role: 'user',
+        text: 'summary fallback',
+      }),
+      expect.objectContaining({
+        id: 'task_summary_fallback:error',
+        role: 'system',
+        text: 'executor failed',
+      }),
+      expect.objectContaining({
+        id: 'task_trimmed_response:user',
+        role: 'user',
+        text: 'trimmed prompt',
+      }),
+      expect.objectContaining({
+        id: 'task_trimmed_response:assistant',
+        role: 'assistant',
+        text: 'trimmed response',
+      }),
+    ]);
   });
 
   it('keeps one websocket subscription alive across snapshot state updates', async () => {

--- a/src/components/ui/codex/codex-remote-widget.tsx
+++ b/src/components/ui/codex/codex-remote-widget.tsx
@@ -538,50 +538,79 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === 'object' && !Array.isArray(value);
 }
 
-function buildMessagesFromTasks(tasks: ResetTaskRun[]) {
-  return tasks
+function buildMessagesFromSortedTasks(tasks: ResetTaskRun[]) {
+  return tasks.flatMap<RemoteCodexMessage>((task) => {
+    const prompt =
+      typeof task.metadata.prompt === 'string' && task.metadata.prompt.trim().length > 0
+        ? task.metadata.prompt.trim()
+        : task.summary;
+    const entries: RemoteCodexMessage[] = [
+      {
+        id: `${task.id}:user`,
+        role: 'user',
+        text: prompt,
+        status: task.status,
+        timestamp: task.createdAt,
+      },
+    ];
+
+    const result = isRecord(task.result) ? task.result : null;
+    const finalResponse =
+      result && typeof result.finalResponse === 'string' && result.finalResponse.trim().length > 0
+        ? result.finalResponse.trim()
+        : null;
+    if (finalResponse) {
+      entries.push({
+        id: `${task.id}:assistant`,
+        role: 'assistant',
+        text: finalResponse,
+        status: task.status,
+        timestamp: task.completedAt ?? task.updatedAt,
+      });
+    } else if (task.status === 'failed' && task.error) {
+      entries.push({
+        id: `${task.id}:error`,
+        role: 'system',
+        text: task.error,
+        status: task.status,
+        timestamp: task.updatedAt,
+      });
+    }
+
+    return entries;
+  });
+}
+
+export function deriveRemoteCodexConversationState(
+  tasks: ResetTaskRun[],
+  fallbackThreadId?: string | null,
+) {
+  let latestTask: ResetTaskRun | undefined;
+  for (const task of tasks) {
+    // Preserve the kernel payload's existing updatedAt tie order for thread/spinner state.
+    if (!latestTask || task.updatedAt.localeCompare(latestTask.updatedAt) > 0) {
+      latestTask = task;
+    }
+  }
+  const sortedTasks = tasks
     .slice()
-    .sort((left, right) => left.createdAt.localeCompare(right.createdAt))
-    .flatMap<RemoteCodexMessage>((task) => {
-      const prompt =
-        typeof task.metadata.prompt === 'string' && task.metadata.prompt.trim().length > 0
-          ? task.metadata.prompt.trim()
-          : task.summary;
-      const entries: RemoteCodexMessage[] = [
-        {
-          id: `${task.id}:user`,
-          role: 'user',
-          text: prompt,
-          status: task.status,
-          timestamp: task.createdAt,
-        },
-      ];
+    .sort((left, right) => left.createdAt.localeCompare(right.createdAt));
 
-      const result = isRecord(task.result) ? task.result : null;
-      const finalResponse =
-        result && typeof result.finalResponse === 'string' && result.finalResponse.trim().length > 0
-          ? result.finalResponse.trim()
-          : null;
-      if (finalResponse) {
-        entries.push({
-          id: `${task.id}:assistant`,
-          role: 'assistant',
-          text: finalResponse,
-          status: task.status,
-          timestamp: task.completedAt ?? task.updatedAt,
-        });
-      } else if (task.status === 'failed' && task.error) {
-        entries.push({
-          id: `${task.id}:error`,
-          role: 'system',
-          text: task.error,
-          status: task.status,
-          timestamp: task.updatedAt,
-        });
-      }
+  const result = latestTask && isRecord(latestTask.result) ? latestTask.result : null;
+  const nextThreadId =
+    result && typeof result.codexThreadId === 'string' && result.codexThreadId.trim().length > 0
+      ? result.codexThreadId.trim()
+      : typeof latestTask?.metadata.codexThreadId === 'string' &&
+          latestTask.metadata.codexThreadId.trim().length > 0
+        ? latestTask.metadata.codexThreadId.trim()
+        : fallbackThreadId;
 
-      return entries;
-    });
+  return {
+    messages: buildMessagesFromSortedTasks(sortedTasks),
+    nextThreadId: nextThreadId ?? undefined,
+    activeTaskRunId:
+      latestTask?.status === 'running' || latestTask?.status === 'queued' ? latestTask.id : null,
+  };
 }
 
 export function CodexRemoteWidget(props: CanvasCodexRemoteWidgetProps) {
@@ -822,29 +851,16 @@ export function CodexRemoteWidget(props: CanvasCodexRemoteWidgetProps) {
       const snapshot = await requestJson<{ tasks: ResetTaskRun[] }>(
         `/api/reset/workspaces/${encodeURIComponent(workspaceSessionId)}/state`,
       );
-      setMessages(buildMessagesFromTasks(snapshot.tasks));
-      const latestTask = snapshot.tasks
-        .slice()
-        .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt))[0];
-      const result = latestTask && isRecord(latestTask.result) ? latestTask.result : null;
-      const nextThreadId =
-        result && typeof result.codexThreadId === 'string' && result.codexThreadId.trim().length > 0
-          ? result.codexThreadId.trim()
-          : typeof latestTask?.metadata.codexThreadId === 'string' &&
-              latestTask.metadata.codexThreadId.trim().length > 0
-            ? latestTask.metadata.codexThreadId.trim()
-            : state.activeThreadId;
+      const conversation = deriveRemoteCodexConversationState(snapshot.tasks, state.activeThreadId);
+      setMessages(conversation.messages);
+      const nextThreadId = conversation.nextThreadId;
       if (nextThreadId !== state.activeThreadId) {
         await persistState({
           ...state,
           activeThreadId: nextThreadId ?? undefined,
         });
       }
-      if (latestTask?.status === 'running' || latestTask?.status === 'queued') {
-        setActiveTaskRunId(latestTask.id);
-      } else {
-        setActiveTaskRunId(null);
-      }
+      setActiveTaskRunId(conversation.activeTaskRunId);
     },
     [persistState, state],
   );


### PR DESCRIPTION
## Summary

This PR removes duplicate task sorting from the Remote Codex widget conversation refresh path. The widget previously sorted workspace tasks once by `createdAt` to render messages and again by `updatedAt` to derive the latest task for thread/spinner state. That path runs on workspace conversation load and after active-turn polling completes.

## Issue and impact

The `/api/reset/workspaces/:workspaceSessionId/state` response can grow with task history. On each refresh, `CodexRemoteWidget` did two full `Array.prototype.sort()` passes over the same task snapshot:

- chronological `createdAt` sort for rendered user/assistant/system messages
- latest-task `updatedAt` sort just to read the first task

For small histories this is not user-visible, but it is unnecessary CPU work on a realtime collaborative surface that already polls while a turn is active.

## Root cause

Task-to-message derivation lived in `buildMessagesFromTasks()`, while latest task, active thread, and active task derivation lived inline in `loadWorkspaceConversation()`. That split duplicated ordering work and made the conversation-state contract harder to test directly.

## What changed

- Extracted `deriveRemoteCodexConversationState()` as a local pure helper in `src/components/ui/codex/codex-remote-widget.tsx`.
- Kept message display order as `createdAt` ascending.
- Replaced the second `updatedAt` sort with a linear scan for the latest task.
- Preserved current latest-task tie behavior by retaining the kernel payload order when `updatedAt` values match.
- Added focused Jest coverage for:
  - one chronological sort call per derivation
  - latest task chosen by `updatedAt`, independent of display order
  - payload-order tie behavior and fallback thread semantics
  - prompt trimming, summary fallback, assistant final response trimming, and failed-task system messages

## Backward compatibility

Browser-only refactor. No API, schema, auth, persistence, or backend contract changes. Existing widget state fields and reset workspace/executor behavior are unchanged.

## Validation

- `npx jest src/components/ui/codex/codex-remote-widget.test.tsx --runInBand`
- `npm run typecheck:app`
- `git diff --check`
- `git fetch origin --prune && git rebase origin/main`

## Review passes

Opening/review lanes checked correctness, maintainability, performance/reliability, security/privacy, and coverage. Follow-up coverage was added for message branch behavior. No material remaining findings.

## Remaining risk

The widget still sorts tasks chronologically on every refresh. If task histories become large, the next higher-leverage fix is to shrink or incrementally page the workspace-state payload rather than further micro-optimize the client helper.
