### PR TITLE
[codex] batch local scope task claims

### DIFF
--- a/src/lib/agents/shared/queue.test.ts
+++ b/src/lib/agents/shared/queue.test.ts
@@ -23,18 +23,21 @@ type QueryStub = {
   maybeSingle: jest.Mock;
 };
 
+type QueryResult = { data: any; error: any };
+type MaybeSingleEntry = QueryResult | ((query: QueryStub) => Promise<QueryResult> | QueryResult);
+
 type QueryHarness = {
   queries: QueryStub[];
-  listQueue: Array<{ data: any; error: any }>;
-  maybeSingleQueue: Array<{ data: any; error: any }>;
-  singleQueue: Array<{ data: any; error: any }>;
+  listQueue: QueryResult[];
+  maybeSingleQueue: MaybeSingleEntry[];
+  singleQueue: QueryResult[];
 };
 
 const createHarness = (): QueryHarness => {
   const queries: QueryStub[] = [];
-  const listQueue: Array<{ data: any; error: any }> = [];
-  const maybeSingleQueue: Array<{ data: any; error: any }> = [];
-  const singleQueue: Array<{ data: any; error: any }> = [];
+  const listQueue: QueryResult[] = [];
+  const maybeSingleQueue: MaybeSingleEntry[] = [];
+  const singleQueue: QueryResult[] = [];
   createClientMock.mockImplementation(() => {
     const supabase = {
       from: jest.fn(() => {
@@ -54,7 +57,13 @@ const createHarness = (): QueryHarness => {
         query.update = jest.fn(() => query);
         query.insert = jest.fn(() => query);
         query.single = jest.fn(async () => singleQueue.shift() ?? { data: null, error: null });
-        query.maybeSingle = jest.fn(async () => maybeSingleQueue.shift() ?? { data: null, error: null });
+        query.maybeSingle = jest.fn(async () => {
+          const next = maybeSingleQueue.shift();
+          if (typeof next === 'function') {
+            return next(query);
+          }
+          return next ?? { data: null, error: null };
+        });
         queries.push(query);
         return query;
       }),
@@ -453,5 +462,137 @@ describe('AgentTaskQueue enqueue dedupe behavior', () => {
     expect(staleLeasedQuery?.or.mock.invocationCallOrder[0]).toBeLessThan(
       staleLeasedQuery?.limit.mock.invocationCallOrder[0],
     );
+  });
+
+  test('claimLocalScopeTasks refills claim slots when early candidates race away', async () => {
+    const harness = createHarness();
+    const makeTask = (id: string, priority: number, createdAt: string) => ({
+      id,
+      room: 'room-local',
+      task: 'fairy.intent',
+      params: {} as JsonObject,
+      trace_id: null,
+      status: 'running',
+      priority,
+      run_at: null,
+      attempt: 0,
+      error: null,
+      request_id: id,
+      dedupe_key: null,
+      resource_keys: ['room:room-local', 'runtime-scope:local', 'queue-mode:local-scope-direct-claim'],
+      lease_token: null,
+      lease_expires_at: null,
+      created_at: createdAt,
+      updated_at: createdAt,
+      result: null,
+    });
+    const raced = makeTask('task-raced', 10, '2026-02-19T11:00:00.000Z');
+    const firstClaimed = makeTask('task-first-claimed', 9, '2026-02-19T11:01:00.000Z');
+    const refillClaimed = makeTask('task-refill-claimed', 8, '2026-02-19T11:02:00.000Z');
+    harness.listQueue.push({ data: [refillClaimed, firstClaimed, raced], error: null });
+    harness.listQueue.push({ data: [], error: null });
+    harness.maybeSingleQueue.push(
+      { data: null, error: null },
+      { data: firstClaimed, error: null },
+      { data: refillClaimed, error: null },
+    );
+
+    const { AgentTaskQueue } = await import('@/lib/agents/shared/queue');
+    const queue = new AgentTaskQueue({ url: 'http://localhost:54321', serviceRoleKey: 'test-key' });
+    const result = await queue.claimLocalScopeTasks({ runtimeScope: 'local', limit: 2 });
+
+    expect(result.tasks.map((task) => task.id)).toEqual(['task-first-claimed', 'task-refill-claimed']);
+    expect(harness.queries).toHaveLength(5);
+  });
+
+  test('claimLocalScopeTasks starts a full available-capacity window before any claim resolves', async () => {
+    const harness = createHarness();
+    const makeTask = (id: string) => ({
+      id,
+      room: 'room-local',
+      task: 'fairy.intent',
+      params: {} as JsonObject,
+      trace_id: null,
+      status: 'running',
+      priority: 1,
+      run_at: null,
+      attempt: 0,
+      error: null,
+      request_id: id,
+      dedupe_key: null,
+      resource_keys: ['room:room-local', 'runtime-scope:local', 'queue-mode:local-scope-direct-claim'],
+      lease_token: null,
+      lease_expires_at: null,
+      created_at: '2026-02-19T11:00:00.000Z',
+      updated_at: '2026-02-19T11:00:00.000Z',
+      result: null,
+    });
+    const tasks = [makeTask('task-1'), makeTask('task-2'), makeTask('task-3')];
+    harness.listQueue.push({ data: tasks, error: null });
+    harness.listQueue.push({ data: [], error: null });
+    let resolveClaims: (() => void) | null = null;
+    const allClaimsStarted = new Promise<void>((resolve) => {
+      resolveClaims = resolve;
+    });
+    const startedIds: string[] = [];
+    harness.maybeSingleQueue.push(
+      ...tasks.map((task) => async () => {
+        startedIds.push(task.id);
+        if (startedIds.length === tasks.length) {
+          resolveClaims?.();
+        }
+        await allClaimsStarted;
+        return { data: task, error: null };
+      }),
+    );
+
+    const { AgentTaskQueue } = await import('@/lib/agents/shared/queue');
+    const queue = new AgentTaskQueue({ url: 'http://localhost:54321', serviceRoleKey: 'test-key' });
+    const result = await queue.claimLocalScopeTasks({ runtimeScope: 'local', limit: 3 });
+
+    expect(result.tasks.map((task) => task.id)).toEqual(['task-1', 'task-2', 'task-3']);
+    expect(startedIds).toEqual(['task-1', 'task-2', 'task-3']);
+  });
+
+  test('claimLocalScopeTasks returns successful sibling claims when one batch claim fails', async () => {
+    const harness = createHarness();
+    const makeTask = (id: string) => ({
+      id,
+      room: 'room-local',
+      task: 'fairy.intent',
+      params: {} as JsonObject,
+      trace_id: null,
+      status: 'running',
+      priority: 1,
+      run_at: null,
+      attempt: 0,
+      error: null,
+      request_id: id,
+      dedupe_key: null,
+      resource_keys: ['room:room-local', 'runtime-scope:local', 'queue-mode:local-scope-direct-claim'],
+      lease_token: null,
+      lease_expires_at: null,
+      created_at: '2026-02-19T11:00:00.000Z',
+      updated_at: '2026-02-19T11:00:00.000Z',
+      result: null,
+    });
+    const firstClaimed = makeTask('task-first-claimed');
+    const failed = makeTask('task-failed');
+    const secondClaimed = makeTask('task-second-claimed');
+    harness.listQueue.push({ data: [firstClaimed, failed, secondClaimed], error: null });
+    harness.listQueue.push({ data: [], error: null });
+    harness.maybeSingleQueue.push(
+      { data: firstClaimed, error: null },
+      async () => {
+        throw new Error('transient claim failure');
+      },
+      { data: secondClaimed, error: null },
+    );
+
+    const { AgentTaskQueue } = await import('@/lib/agents/shared/queue');
+    const queue = new AgentTaskQueue({ url: 'http://localhost:54321', serviceRoleKey: 'test-key' });
+    const result = await queue.claimLocalScopeTasks({ runtimeScope: 'local', limit: 3 });
+
+    expect(result.tasks.map((task) => task.id)).toEqual(['task-first-claimed', 'task-second-claimed']);
   });
 });

--- a/src/lib/agents/shared/queue.ts
+++ b/src/lib/agents/shared/queue.ts
@@ -580,9 +580,7 @@ export class AgentTaskQueue {
       return runAtMs <= nowMs;
     });
 
-    const claimed: AgentTask[] = [];
-    for (const candidate of claimableCandidates) {
-      if (claimed.length >= limit) break;
+    const claimCandidate = async (candidate: AgentTask): Promise<AgentTask | null> => {
       let updateQuery = this.supabase
         .from('agent_tasks')
         .update({
@@ -599,8 +597,28 @@ export class AgentTaskQueue {
       }
       const { data: updated, error: updateError } = await updateQuery.select('*').maybeSingle();
       if (updateError) throw updateError;
-      if (!updated) continue;
-      claimed.push(updated as AgentTask);
+      return updated ? (updated as AgentTask) : null;
+    };
+
+    const claimed: AgentTask[] = [];
+    for (let index = 0; index < claimableCandidates.length && claimed.length < limit;) {
+      const batchSize = Math.min(limit - claimed.length, claimableCandidates.length - index);
+      const batch = claimableCandidates.slice(index, index + batchSize);
+      index += batchSize;
+      const batchResults = await Promise.allSettled(batch.map(claimCandidate));
+      let batchClaimedCount = 0;
+      let batchError: unknown;
+      for (const result of batchResults) {
+        if (result.status === 'rejected') {
+          batchError ??= result.reason;
+          continue;
+        }
+        if (result.value && claimed.length < limit) {
+          claimed.push(result.value);
+          batchClaimedCount += 1;
+        }
+      }
+      if (batchError && batchClaimedCount === 0) throw batchError;
     }
 
     for (const task of claimed) {


### PR DESCRIPTION
## Issue and impact
Local-scope conductor workers claim tasks through `claimLocalScopeTasks`. On `origin/main`, candidate reads are parallel, but each candidate update is awaited one-by-one until capacity is filled. Under bursty realtime agent work, that makes dequeue latency grow with the number of available worker slots before model/tool execution even starts.

## Root cause
`claimLocalScopeTasks` had a sequential optimistic-update loop after selecting and sorting local-scope candidates. The row guards were correct, but the latency shape was one update round trip per claimed task.

## What changed
- Claim local-scope candidates in available-capacity batches with `Promise.allSettled`.
- Preserve the existing candidate filters, priority/created_at order, due-time filtering, stale-lease token guard, unleased guard, hard `limit`, and per-task trace emission.
- Keep successful sibling claims when one batch claim fails, avoiding hidden leased tasks waiting for TTL after partial failure.
- Add focused queue tests for race refill, concurrent batch start, and partial batch failure.

## Backward compatibility
No API, schema, migration, env, or queue payload contract changes. This only changes the local worker claim execution strategy after the same candidate set has already been selected.

## Validation
- `npm test -- --runTestsByPath src/lib/agents/shared/queue.test.ts --runInBand`
- `npm run typecheck:agent`
- `git diff --check`

## Review passes
Opening-shift rabbits compared queue, reset shell, component invalidation, LiveKit, and collaboration hot paths. This PR intentionally chose the narrow backend queue claim lane because it is current on `origin/main`, does not overlap open PR #184, and directly affects conductor dequeue latency.

Review swarm found one reliability issue in the first implementation: `Promise.all` could orphan successful sibling leases when one claim failed. The patch now uses `Promise.allSettled`, returns successful siblings, and has a regression test for that case. Follow-up reliability review found no remaining material issue.

## Remaining risk
Proof is unit-harness based, not a live Supabase contention benchmark. A future audit should measure p50/p95 claim latency with real Supabase/PostgREST under multi-worker contention.