### PR TITLE
[codex] speed reset workspace snapshots

### DIFF
--- a/services/kernel/src/index.test.ts
+++ b/services/kernel/src/index.test.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import fs from 'node:fs';
 import {
   buildAgentInteropPack,
   buildRuntimeManifest,
@@ -7,11 +8,16 @@ import {
   createArtifact,
   createTraceId,
   createTaskRun,
+  getWorkspaceStateSnapshot,
   listApprovalRequests,
   listArtifacts,
+  listExecutorSessions,
+  listPresenceMembers,
   listTaskRuns,
   listTraceEvents,
+  listWorkspaceTraceEvents,
   openWorkspaceSession,
+  recordKernelEvent,
   resetKernelStateForTests,
 } from '@present/kernel';
 
@@ -67,7 +73,66 @@ describe('reset kernel', () => {
 
     expect(listApprovalRequests(workspace.id).some((entry) => entry.id === approval.id)).toBe(true);
     expect(listTraceEvents(traceId).some((event) => event.type === 'approval.requested')).toBe(true);
+    expect(listWorkspaceTraceEvents(workspace.id).map((event) => event.id)).toEqual([
+      expect.stringMatching(/^evt_/),
+    ]);
     expect(buildRuntimeManifest().mcp.serverName).toBe('present-mcp');
+  });
+
+  it('lists only workspace-scoped trace events in newest-first order', () => {
+    const firstWorkspace = openWorkspaceSession({
+      workspacePath: `/tmp/present-reset-trace-first-${Date.now()}`,
+      title: 'Trace First',
+      branch: 'codex/reset',
+    });
+    const secondWorkspace = openWorkspaceSession({
+      workspacePath: `/tmp/present-reset-trace-second-${Date.now()}`,
+      title: 'Trace Second',
+      branch: 'codex/reset',
+    });
+
+    recordKernelEvent({
+      id: 'evt_first_workspace_older',
+      type: 'approval.requested',
+      workspaceSessionId: firstWorkspace.id,
+      traceId: createTraceId(),
+      approvalRequestId: 'approval_first_older',
+      state: 'pending',
+      summary: 'Older first workspace event',
+      metadata: { emittedAt: 'old' },
+      emittedAt: '2026-01-01T00:00:00.000Z',
+    });
+    recordKernelEvent({
+      id: 'evt_second_workspace',
+      type: 'approval.requested',
+      workspaceSessionId: secondWorkspace.id,
+      traceId: createTraceId(),
+      approvalRequestId: 'approval_second',
+      state: 'pending',
+      summary: 'Other workspace event',
+      emittedAt: '2026-01-01T00:01:00.000Z',
+    });
+    recordKernelEvent({
+      id: 'evt_first_workspace_newer',
+      type: 'approval.requested',
+      workspaceSessionId: firstWorkspace.id,
+      traceId: createTraceId(),
+      approvalRequestId: 'approval_first_newer',
+      state: 'pending',
+      summary: 'Newer first workspace event',
+      metadata: { emittedAt: 'new' },
+      emittedAt: '2026-01-01T00:02:00.000Z',
+    });
+
+    const scopedEvents = listWorkspaceTraceEvents(firstWorkspace.id);
+
+    expect(scopedEvents).toHaveLength(2);
+    expect(scopedEvents.map((event) => event.workspaceSessionId)).toEqual([
+      firstWorkspace.id,
+      firstWorkspace.id,
+    ]);
+    expect(scopedEvents[0]?.summary).toBe('Newer first workspace event');
+    expect(scopedEvents[1]?.summary).toBe('Older first workspace event');
   });
 
   it('persists task lifecycle across kernel reads', () => {
@@ -92,6 +157,94 @@ describe('reset kernel', () => {
     expect(persisted).toHaveLength(1);
     expect(persisted[0]?.status).toBe('succeeded');
     expect(persisted[0]?.result?.['finalResponse']).toBe('done');
+  });
+
+  it('builds workspace snapshots with the same scoped collection contracts as selectors', async () => {
+    const workspace = openWorkspaceSession({
+      workspacePath: `/tmp/present-reset-snapshot-${Date.now()}`,
+      title: 'Snapshot Test',
+      branch: 'codex/reset',
+    });
+    const otherWorkspace = openWorkspaceSession({
+      workspacePath: `/tmp/present-reset-snapshot-other-${Date.now()}`,
+      title: 'Other Snapshot Test',
+      branch: 'codex/reset',
+    });
+
+    createTaskRun({
+      workspaceSessionId: workspace.id,
+      summary: 'Run codex turn',
+      taskType: 'codex.turn',
+    });
+    createTaskRun({
+      workspaceSessionId: otherWorkspace.id,
+      summary: 'Other codex turn',
+      taskType: 'codex.turn',
+    });
+    createArtifact({
+      workspaceSessionId: workspace.id,
+      kind: 'widget_bundle',
+      title: 'Snapshot Widget',
+      mimeType: 'text/html',
+      content: '<html></html>',
+    });
+    createApprovalRequest({
+      workspaceSessionId: workspace.id,
+      traceId: createTraceId(),
+      kind: 'git_action',
+      title: 'Snapshot approval',
+      detail: 'Approve',
+      requestedBy: 'jest',
+    });
+
+    const snapshot = await getWorkspaceStateSnapshot(workspace.id);
+
+    expect(snapshot?.workspace.id).toBe(workspace.id);
+    expect(snapshot?.tasks).toEqual(listTaskRuns(workspace.id));
+    expect(snapshot?.artifacts).toEqual(listArtifacts(workspace.id));
+    expect(snapshot?.approvals).toEqual(listApprovalRequests(workspace.id));
+    expect(snapshot?.executors).toEqual(listExecutorSessions(workspace.id));
+    expect(snapshot?.presence).toEqual(listPresenceMembers(workspace.id));
+    expect(snapshot?.traces).toEqual(listWorkspaceTraceEvents(workspace.id));
+    expect(snapshot?.tasks.map((task) => task.workspaceSessionId)).toEqual([workspace.id]);
+  });
+
+  it('reads persisted state once when building a workspace snapshot', async () => {
+    const workspace = openWorkspaceSession({
+      workspacePath: `/tmp/present-reset-snapshot-read-count-${Date.now()}`,
+      title: 'Snapshot Read Count',
+      branch: 'codex/reset',
+    });
+    createTaskRun({
+      workspaceSessionId: workspace.id,
+      summary: 'Run codex turn',
+      taskType: 'codex.turn',
+    });
+    createArtifact({
+      workspaceSessionId: workspace.id,
+      kind: 'widget_bundle',
+      title: 'Read Count Widget',
+      mimeType: 'text/html',
+      content: '<html></html>',
+    });
+    createApprovalRequest({
+      workspaceSessionId: workspace.id,
+      traceId: createTraceId(),
+      kind: 'git_action',
+      title: 'Read count approval',
+      detail: 'Approve',
+      requestedBy: 'jest',
+    });
+
+    const readSpy = jest.spyOn(fs, 'readFileSync');
+
+    await getWorkspaceStateSnapshot(workspace.id);
+
+    expect(
+      readSpy.mock.calls.filter((call) => call[0] === process.env.PRESENT_RESET_STATE_PATH),
+    ).toHaveLength(1);
+
+    readSpy.mockRestore();
   });
 
   it('builds a BYO-agent interop pack for external clients', () => {

--- a/services/kernel/src/persistence.test.ts
+++ b/services/kernel/src/persistence.test.ts
@@ -6,6 +6,9 @@ import type { KernelEvent, ModelProfile, WorkspaceSession } from '@present/contr
 type SupabaseRow = Record<string, unknown>;
 
 const supabaseTables: Record<string, SupabaseRow[]> = {};
+let supabaseSelectDelayMs = 0;
+let activeSupabaseSelects = 0;
+let maxConcurrentSupabaseSelects = 0;
 
 const resetSupabaseTables = () => {
   Object.keys(supabaseTables).forEach((key) => {
@@ -18,6 +21,12 @@ jest.mock('@supabase/supabase-js', () => ({
     from(table: string) {
       return {
         async select(columns = '*') {
+          activeSupabaseSelects += 1;
+          maxConcurrentSupabaseSelects = Math.max(maxConcurrentSupabaseSelects, activeSupabaseSelects);
+          if (supabaseSelectDelayMs > 0) {
+            await new Promise((resolve) => setTimeout(resolve, supabaseSelectDelayMs));
+          }
+          activeSupabaseSelects -= 1;
           const data = [...(supabaseTables[table] ?? [])];
           if (columns === 'id') {
             return { data: data.map((row) => ({ id: row.id })), error: null };
@@ -70,12 +79,18 @@ describe('reset persistence', () => {
     process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://example.supabase.co';
     process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-service-key';
     resetSupabaseTables();
+    supabaseSelectDelayMs = 0;
+    activeSupabaseSelects = 0;
+    maxConcurrentSupabaseSelects = 0;
     resetKernelStateForTests();
   });
 
   afterEach(() => {
     resetKernelStateForTests();
     resetSupabaseTables();
+    supabaseSelectDelayMs = 0;
+    activeSupabaseSelects = 0;
+    maxConcurrentSupabaseSelects = 0;
     delete process.env.PRESENT_RESET_STATE_PATH;
     delete process.env.PRESENT_RESET_SUPABASE_CACHE_TTL_MS;
     delete process.env.VERCEL;
@@ -234,6 +249,29 @@ describe('reset persistence', () => {
 
     await ensureResetKernelHydrated();
     expect(readResetCollection('workspaces').map((workspace) => workspace.id)).toEqual(['ws_new']);
+  });
+
+  it('hydrates reset collections with concurrent Supabase reads', async () => {
+    supabaseSelectDelayMs = 15;
+    supabaseTables.workspace_sessions = [
+      {
+        id: 'ws_parallel',
+        workspace_path: '/tmp/parallel',
+        branch: 'codex/reset',
+        title: 'Parallel',
+        state: 'active',
+        owner_user_id: null,
+        active_executor_session_id: null,
+        metadata: {},
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      },
+    ];
+
+    await ensureResetKernelHydrated();
+
+    expect(maxConcurrentSupabaseSelects).toBeGreaterThan(1);
+    expect(readResetCollection('workspaces').map((workspace) => workspace.id)).toEqual(['ws_parallel']);
   });
 
   it('preserves model profile timestamps when mirroring to Supabase', async () => {

--- a/services/kernel/src/persistence.ts
+++ b/services/kernel/src/persistence.ts
@@ -533,9 +533,15 @@ export async function ensureResetKernelHydrated(input: { force?: boolean } = {})
     const mutableState = nextState as Record<ResetCollectionKey, unknown>;
     const localCollections = localState as Record<ResetCollectionKey, unknown>;
 
-    for (const key of Object.keys(resetCollectionTables) as ResetCollectionKey[]) {
-      const hydratedValue = (await loadCollectionFromSupabase(key)) ?? localCollections[key];
-      mutableState[key] = hydratedValue;
+    const hydratedCollections = await Promise.all(
+      (Object.keys(resetCollectionTables) as ResetCollectionKey[]).map(async (key) => ({
+        key,
+        value: (await loadCollectionFromSupabase(key)) ?? localCollections[key],
+      })),
+    );
+
+    for (const { key, value } of hydratedCollections) {
+      mutableState[key] = value;
     }
 
     const parsed = resetKernelStateSchema.parse(nextState);

--- a/services/kernel/src/traces.ts
+++ b/services/kernel/src/traces.ts
@@ -35,6 +35,12 @@ export function listTraceEvents(traceId?: string) {
   return traces.sort((left, right) => right.emittedAt.localeCompare(left.emittedAt));
 }
 
+export function listWorkspaceTraceEvents(workspaceSessionId: string) {
+  return readResetCollection('traces')
+    .filter((event) => event.workspaceSessionId === workspaceSessionId)
+    .sort((left, right) => right.emittedAt.localeCompare(left.emittedAt));
+}
+
 export function searchTraceEvents(query: string) {
   const normalized = query.trim().toLowerCase();
   if (!normalized) return listTraceEvents();

--- a/services/kernel/src/workspace-state.ts
+++ b/services/kernel/src/workspace-state.ts
@@ -1,38 +1,60 @@
-import type { ModelProfile } from '@present/contracts';
+import type {
+  ApprovalRequest,
+  Artifact,
+  ExecutorSession,
+  KernelEvent,
+  ModelProfile,
+  PresenceMember,
+  TaskRun,
+  WorkspaceSession,
+} from '@present/contracts';
 import { buildRuntimeManifest } from './runtime-manifest';
-import { listApprovalRequests } from './approvals';
-import { listArtifacts } from './artifacts';
-import { listExecutorSessions } from './executor-sessions';
 import { resolveKernelModelProfiles } from './model-profiles';
-import { listPresenceMembers } from './presence';
-import { listTaskRuns } from './tasks';
-import { listTraceEvents } from './traces';
-import { getWorkspaceSession } from './workspace-sessions';
+import { readResetKernelState } from './persistence';
 
 export type WorkspaceStateSnapshot = {
-  workspace: ReturnType<typeof getWorkspaceSession>;
-  executors: ReturnType<typeof listExecutorSessions>;
-  tasks: ReturnType<typeof listTaskRuns>;
-  artifacts: ReturnType<typeof listArtifacts>;
-  approvals: ReturnType<typeof listApprovalRequests>;
-  presence: ReturnType<typeof listPresenceMembers>;
-  traces: ReturnType<typeof listTraceEvents>;
+  workspace: WorkspaceSession;
+  executors: ExecutorSession[];
+  tasks: TaskRun[];
+  artifacts: Artifact[];
+  approvals: ApprovalRequest[];
+  presence: PresenceMember[];
+  traces: KernelEvent[];
   modelProfiles: ModelProfile[];
   manifest: ReturnType<typeof buildRuntimeManifest>;
 };
 
+const byUpdatedAtDesc = <T extends { updatedAt: string }>(left: T, right: T) =>
+  right.updatedAt.localeCompare(left.updatedAt);
+
+const byEmittedAtDesc = (left: KernelEvent, right: KernelEvent) =>
+  right.emittedAt.localeCompare(left.emittedAt);
+
 export async function getWorkspaceStateSnapshot(workspaceSessionId: string): Promise<WorkspaceStateSnapshot | null> {
-  const workspace = getWorkspaceSession(workspaceSessionId);
+  const state = readResetKernelState();
+  const workspace = state.workspaces.find((session) => session.id === workspaceSessionId) ?? null;
   if (!workspace) return null;
 
   return {
     workspace,
-    executors: listExecutorSessions(workspaceSessionId),
-    tasks: listTaskRuns(workspaceSessionId),
-    artifacts: listArtifacts(workspaceSessionId),
-    approvals: listApprovalRequests(workspaceSessionId),
-    presence: listPresenceMembers(workspaceSessionId),
-    traces: listTraceEvents().filter((event) => event.workspaceSessionId === workspaceSessionId),
+    executors: state.executors
+      .filter((session) => session.workspaceSessionId === workspaceSessionId)
+      .sort(byUpdatedAtDesc),
+    tasks: state.tasks
+      .filter((task) => task.workspaceSessionId === workspaceSessionId)
+      .sort(byUpdatedAtDesc),
+    artifacts: state.artifacts
+      .filter((artifact) => artifact.workspaceSessionId === workspaceSessionId)
+      .sort(byUpdatedAtDesc),
+    approvals: state.approvals
+      .filter((approval) => approval.workspaceSessionId === workspaceSessionId)
+      .sort(byUpdatedAtDesc),
+    presence: state.presence
+      .filter((member) => member.workspaceSessionId === workspaceSessionId)
+      .sort(byUpdatedAtDesc),
+    traces: state.traces
+      .filter((event) => event.workspaceSessionId === workspaceSessionId)
+      .sort(byEmittedAtDesc),
     modelProfiles: await resolveKernelModelProfiles(),
     manifest: buildRuntimeManifest(),
   };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,13 +5,12 @@ import {
   buildRuntimeManifest,
   createArtifact,
   ensureResetKernelHydrated,
-  getWorkspaceSession,
   listExecutorSessions,
   listApprovalRequests,
   listArtifacts,
   listPresenceMembers,
   listTaskRuns,
-  listTraceEvents,
+  listWorkspaceTraceEvents,
   listWorkspaceSessions,
   openWorkspaceSession,
   resolveKernelModelProfiles,
@@ -53,7 +52,9 @@ export default async function Home({
   const existingWorkspaces = listWorkspaceSessions();
 
   const workspace =
-    (requestedWorkspaceSessionId ? getWorkspaceSession(requestedWorkspaceSessionId) : null) ??
+    (requestedWorkspaceSessionId
+      ? (existingWorkspaces.find((session) => session.id === requestedWorkspaceSessionId) ?? null)
+      : null) ??
     existingWorkspaces[0] ??
     openWorkspaceSession({
       workspacePath: process.cwd(),
@@ -63,6 +64,9 @@ export default async function Home({
         shell: 'root',
       },
     });
+  const initialWorkspaces = existingWorkspaces.some((session) => session.id === workspace.id)
+    ? existingWorkspaces
+    : [workspace, ...existingWorkspaces];
 
   const artifacts = listArtifacts(workspace.id);
   if (!artifacts.some((artifact) => artifact.kind === 'widget_bundle')) {
@@ -85,14 +89,14 @@ export default async function Home({
       initialManifest={manifest}
       initialAgentPack={buildAgentInteropPack(workspace)}
       initialWorkspace={workspace}
-      initialWorkspaces={listWorkspaceSessions().slice(0, 6)}
+      initialWorkspaces={initialWorkspaces.slice(0, 6)}
       initialExecutors={listExecutorSessions(workspace.id)}
       initialTasks={listTaskRuns(workspace.id)}
       initialArtifacts={listArtifacts(workspace.id)}
       initialApprovals={listApprovalRequests(workspace.id)}
       initialPresence={listPresenceMembers(workspace.id)}
       initialModelProfiles={modelProfiles}
-      initialTraceEvents={listTraceEvents()}
+      initialTraceEvents={listWorkspaceTraceEvents(workspace.id)}
     />
   );
 }


### PR DESCRIPTION
## Issue and impact

The reset runtime workspace-state path was doing avoidable request work on hot reset shell/API paths. On the synthetic 50k-trace corpus used for this audit, the pre-patch snapshot path measured about 544 ms while returning only 1k workspace-scoped trace rows. First-run Supabase hydration also loaded reset collections sequentially, creating additive round-trip latency before request handling.

## Root cause

- `ensureResetKernelHydrated()` loaded every reset collection from Supabase in a sequential loop.
- `getWorkspaceStateSnapshot()` composed a snapshot by calling multiple collection selectors, each re-reading persisted state and sorting independently.
- Workspace state traces were built by sorting all trace events before filtering to the requested workspace.
- The root page reused a pre-open workspace list after creating the fallback workspace, which review caught as a cold-start bootstrap risk.

## What changed

- Parallelized reset Supabase collection hydration while preserving per-collection local fallback behavior.
- Added `listWorkspaceTraceEvents()` for workspace-scoped trace reads.
- Rebuilt `getWorkspaceStateSnapshot()` from one persisted-state read, preserving selector-equivalent workspace filtering and ordering.
- Kept cold-start root shell payload consistent by including the fallback-created workspace in `initialWorkspaces`.
- Seeded root `initialTraceEvents` with workspace-scoped traces instead of all trace rows.

## Backward compatibility

No schema, route, or payload-shape breaking changes. The reset state route still returns the same top-level snapshot fields; the implementation reduces repeated local reads and sorts. Supabase hydration still falls back to local collection state when an individual collection cannot hydrate.

## Evidence and validation

- Synthetic trace corpus proof, 50k trace rows / 1k matching workspace rows:
  - before single-read snapshot optimization observed: snapshot path about 544 ms
  - after patch: `oldPatternMs=124.9`, `newHelperMs=91.81`, `snapshotMs=120.27`
- Added test proving Supabase collection reads fan out concurrently.
- Added snapshot parity test against scoped selectors.
- Added test proving workspace snapshot reads persisted state once.
- Added trace helper scope/order coverage.

Checks run:

- `npm test -- services/kernel/src/index.test.ts services/kernel/src/persistence.test.ts 'src/app/api/reset/workspaces/[workspaceSessionId]/state/route.test.ts' src/app/api/reset/runtime-manifest/route.test.ts --runInBand`
- `npm test -- --runTestsByPath 'src/app/api/reset/workspaces/[workspaceSessionId]/state/route.test.ts' --runInBand`
- `npm run typecheck`
- `npm run typecheck:reset`
- `git diff --check`

## Review swarm

Read-only reviewers found one material regression: cold-start `initialWorkspaces` could be stale after creating the fallback workspace. Fixed by deriving `initialWorkspaces` from the selected workspace plus the preexisting list. Reviewers also requested stronger proof for the single-read snapshot goal; added an `fs.readFileSync` assertion around `getWorkspaceStateSnapshot()`.

No material security/privacy findings were reported.

## Follow-ups

Next high-leverage candidates from this audit, intentionally left out of this PR to avoid scope mixing:

- suppress no-op `widget-codex` refresh saves/snapshot fanout
- reduce LiveKit room-level packet listener duplication/demux parsing
- avoid redundant reset shell polling/trace rescans
- clean up `codex-adapter` command output cache after completed stream items
