### PR TITLE
[codex] cleanup livekit state bridge listeners

### DIFF
--- a/src/app/canvas/CanvasPageClient.tsx
+++ b/src/app/canvas/CanvasPageClient.tsx
@@ -24,7 +24,7 @@ import { ToolDispatcher } from '@/components/tool-dispatcher';
 import { SystemRegistrySync } from '@/components/ui/diagnostics/system-registry-sync';
 import { initializeMCPBridge } from '@/lib/mcp-bridge';
 import { AgentCapabilitiesBridge } from '@/components/ui/integrations/agent-capabilities-bridge';
-import { LiveKitStateBridge } from '@/lib/livekit/livekit-state-bridge';
+import { attachLiveKitStateBridge } from '@/lib/livekit/livekit-state-bridge';
 import LiveKitDebugConsole from '@/components/LiveKitDebugConsole';
 import { RealtimeSyncHealth } from '@/components/ui/diagnostics/realtime-sync-health';
 import {
@@ -600,14 +600,7 @@ export function CanvasPageClient() {
   useEffect(() => {
     if (!room) return;
     try {
-      // Avoid double-start in dev/StrictMode by using a per-room guard
-      const key = `present:state-bridge:${room.name || 'default'}`;
-      const w = window as any;
-      if (typeof window !== 'undefined' && w[key]) return;
-      if (typeof window !== 'undefined') w[key] = true;
-
-      const bridge = new LiveKitStateBridge(room);
-      bridge.start();
+      return attachLiveKitStateBridge(room);
     } catch { }
   }, [room]);
 
@@ -694,11 +687,8 @@ export function CanvasPageClient() {
 
   // If not authenticated, don't render the canvas
   if (!user && !bypassAuth) {
-    console.log('[CanvasPageClient] Not authenticated and bypassAuth is false. Returning null.');
     return null;
   }
-
-  console.log('[CanvasPageClient] Rendering main UI', { user: user?.id, roomName });
 
   return (
     <div

--- a/src/lib/livekit/livekit-state-bridge.test.ts
+++ b/src/lib/livekit/livekit-state-bridge.test.ts
@@ -1,0 +1,288 @@
+import { type Room, RoomEvent } from 'livekit-client';
+import { attachLiveKitStateBridge, LiveKitStateBridge } from '@/lib/livekit/livekit-state-bridge';
+import { systemRegistry } from '@/lib/system-registry';
+
+type Listener = (...args: unknown[]) => void;
+
+type MockRoom = Room & {
+  emit(event: unknown, ...args: unknown[]): void;
+  listenerCount(event: unknown): number;
+};
+
+function createMockRoom() {
+  const listeners = new Map<unknown, Set<Listener>>();
+  const publishData = jest.fn().mockResolvedValue(undefined);
+  const room = {
+    localParticipant: {
+      publishData,
+    },
+    on: jest.fn((event: unknown, handler: Listener) => {
+      const set = listeners.get(event) ?? new Set<Listener>();
+      set.add(handler);
+      listeners.set(event, set);
+    }),
+    off: jest.fn((event: unknown, handler: Listener) => {
+      listeners.get(event)?.delete(handler);
+    }),
+    emit(event: unknown, ...args: unknown[]) {
+      const handlers = listeners.get(event);
+      if (!handlers) return;
+      for (const handler of Array.from(handlers)) {
+        handler(...args);
+      }
+    },
+    listenerCount(event: unknown) {
+      return listeners.get(event)?.size ?? 0;
+    },
+  } as unknown as MockRoom;
+
+  return { room, publishData };
+}
+
+function encode(value: unknown) {
+  return new TextEncoder().encode(JSON.stringify(value));
+}
+
+describe('LiveKitStateBridge', () => {
+  it('removes room and registry listeners when stopped', () => {
+    const { room, publishData } = createMockRoom();
+    const bridge = new LiveKitStateBridge(room);
+    const stop = bridge.start();
+
+    expect(room.listenerCount(RoomEvent.DataReceived)).toBe(1);
+
+    systemRegistry.ingestState({
+      id: 'livekit-bridge-outbound-cleanup',
+      kind: 'component_snapshot',
+      payload: { count: 1 },
+      version: 1,
+      ts: Date.now(),
+      origin: 'browser',
+    });
+
+    expect(publishData).toHaveBeenCalledTimes(1);
+
+    stop();
+    expect(room.listenerCount(RoomEvent.DataReceived)).toBe(0);
+
+    systemRegistry.ingestState({
+      id: 'livekit-bridge-outbound-cleanup',
+      kind: 'component_snapshot',
+      payload: { count: 2 },
+      version: 2,
+      ts: Date.now(),
+      origin: 'browser',
+    });
+
+    expect(publishData).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps start idempotent for one bridge instance', () => {
+    const { room } = createMockRoom();
+    const bridge = new LiveKitStateBridge(room);
+    const firstStop = bridge.start();
+    const secondStop = bridge.start();
+
+    expect(firstStop).toBe(secondStop);
+    expect(room.listenerCount(RoomEvent.DataReceived)).toBe(1);
+
+    firstStop();
+    expect(room.listenerCount(RoomEvent.DataReceived)).toBe(0);
+  });
+
+  it('stops ingesting inbound room state after cleanup', () => {
+    const { room } = createMockRoom();
+    const bridge = new LiveKitStateBridge(room);
+    const stop = bridge.start();
+    const id = 'livekit-bridge-inbound-cleanup';
+
+    room.emit(
+      RoomEvent.DataReceived,
+      encode({
+        id,
+        kind: 'remote_state',
+        payload: { count: 1 },
+        version: 1,
+        ts: Date.now(),
+        origin: 'agent',
+      }),
+      { isLocal: false },
+      undefined,
+      'state_change',
+    );
+
+    expect(systemRegistry.getState(id)?.version).toBe(1);
+
+    stop();
+
+    room.emit(
+      RoomEvent.DataReceived,
+      encode({
+        id,
+        kind: 'remote_state',
+        payload: { count: 2 },
+        version: 2,
+        ts: Date.now(),
+        origin: 'agent',
+      }),
+      { isLocal: false },
+      undefined,
+      'state_change',
+    );
+
+    expect(systemRegistry.getState(id)?.version).toBe(1);
+  });
+
+  it('ignores local browser echo packets', () => {
+    const { room } = createMockRoom();
+    const bridge = new LiveKitStateBridge(room);
+    const stop = bridge.start();
+    const id = 'livekit-bridge-local-echo';
+
+    room.emit(
+      RoomEvent.DataReceived,
+      encode({
+        id,
+        kind: 'local_echo',
+        payload: { count: 1 },
+        version: 1,
+        ts: Date.now(),
+        origin: 'browser',
+      }),
+      { isLocal: true },
+      undefined,
+      'state_change',
+    );
+
+    expect(systemRegistry.getState(id)).toBeUndefined();
+    stop();
+  });
+
+  it('does not publish non-browser origin state updates', () => {
+    const { room, publishData } = createMockRoom();
+    const bridge = new LiveKitStateBridge(room);
+    const stop = bridge.start();
+
+    systemRegistry.ingestState({
+      id: 'livekit-bridge-non-browser-origin',
+      kind: 'remote_state',
+      payload: { count: 1 },
+      version: 1,
+      ts: Date.now(),
+      origin: 'agent',
+    });
+
+    expect(publishData).not.toHaveBeenCalled();
+    stop();
+  });
+
+  it('ignores non-state data-channel topics', () => {
+    const { room } = createMockRoom();
+    const bridge = new LiveKitStateBridge(room);
+    const stop = bridge.start();
+    const id = 'livekit-bridge-topic-filter';
+
+    room.emit(
+      RoomEvent.DataReceived,
+      encode({
+        id,
+        kind: 'remote_state',
+        payload: { count: 1 },
+        version: 1,
+        ts: Date.now(),
+        origin: 'agent',
+      }),
+      { isLocal: false },
+      undefined,
+      'tool_call',
+    );
+
+    expect(systemRegistry.getState(id)).toBeUndefined();
+    stop();
+  });
+
+  it('ignores state-shaped packets without the state-change topic', () => {
+    const { room } = createMockRoom();
+    const bridge = new LiveKitStateBridge(room);
+    const stop = bridge.start();
+    const id = 'livekit-bridge-missing-topic-filter';
+
+    room.emit(
+      RoomEvent.DataReceived,
+      encode({
+        id,
+        kind: 'remote_state',
+        payload: { count: 1 },
+        version: 1,
+        ts: Date.now(),
+        origin: 'agent',
+      }),
+      { isLocal: false },
+    );
+
+    expect(systemRegistry.getState(id)).toBeUndefined();
+    stop();
+  });
+
+  it('shares one bridge attachment per room until all callers release it', () => {
+    const { room, publishData } = createMockRoom();
+    const stopFirst = attachLiveKitStateBridge(room);
+    const stopSecond = attachLiveKitStateBridge(room);
+
+    expect(room.listenerCount(RoomEvent.DataReceived)).toBe(1);
+
+    systemRegistry.ingestState({
+      id: 'livekit-bridge-shared-attachment',
+      kind: 'component_snapshot',
+      payload: { count: 1 },
+      version: 1,
+      ts: Date.now(),
+      origin: 'browser',
+    });
+
+    expect(publishData).toHaveBeenCalledTimes(1);
+
+    stopFirst();
+    expect(room.listenerCount(RoomEvent.DataReceived)).toBe(1);
+
+    systemRegistry.ingestState({
+      id: 'livekit-bridge-shared-attachment',
+      kind: 'component_snapshot',
+      payload: { count: 2 },
+      version: 2,
+      ts: Date.now(),
+      origin: 'browser',
+    });
+
+    expect(publishData).toHaveBeenCalledTimes(2);
+
+    stopSecond();
+    expect(room.listenerCount(RoomEvent.DataReceived)).toBe(0);
+
+    systemRegistry.ingestState({
+      id: 'livekit-bridge-shared-attachment',
+      kind: 'component_snapshot',
+      payload: { count: 3 },
+      version: 3,
+      ts: Date.now(),
+      origin: 'browser',
+    });
+
+    expect(publishData).toHaveBeenCalledTimes(2);
+  });
+
+  it('reattaches cleanly after all callers release a room', () => {
+    const { room } = createMockRoom();
+    const stopFirst = attachLiveKitStateBridge(room);
+
+    expect(room.listenerCount(RoomEvent.DataReceived)).toBe(1);
+    stopFirst();
+    expect(room.listenerCount(RoomEvent.DataReceived)).toBe(0);
+
+    const stopSecond = attachLiveKitStateBridge(room);
+    expect(room.listenerCount(RoomEvent.DataReceived)).toBe(1);
+
+    stopSecond();
+    expect(room.listenerCount(RoomEvent.DataReceived)).toBe(0);
+  });
+});

--- a/src/lib/livekit/livekit-state-bridge.ts
+++ b/src/lib/livekit/livekit-state-bridge.ts
@@ -1,6 +1,8 @@
-import { Room } from 'livekit-client';
+import { Room, RoomEvent } from 'livekit-client';
 import { systemRegistry } from '../system-registry';
 import { StateEnvelope } from '../shared-state';
+
+type StopLiveKitStateBridge = () => void;
 
 /**
  * Bridges SystemRegistry state events to LiveKit data channel messages and back.
@@ -8,14 +10,18 @@ import { StateEnvelope } from '../shared-state';
 export class LiveKitStateBridge {
   private room: Room;
   private topic = 'state_change';
+  private stop: StopLiveKitStateBridge | null = null;
 
   constructor(room: Room) {
     this.room = room;
   }
 
   start() {
+    if (this.stop) return this.stop;
+
     // listen for messages from others
-    this.room.on('dataReceived', (payload, participant) => {
+    const onDataReceived = (payload: Uint8Array, participant?: { isLocal?: boolean }, _kind?: unknown, topic?: string) => {
+      if (topic !== this.topic) return;
       try {
         const decoded = JSON.parse(new TextDecoder().decode(payload)) as StateEnvelope;
         if (!decoded || !decoded.kind) return;
@@ -25,10 +31,11 @@ export class LiveKitStateBridge {
       } catch (_) {
         /* ignore non JSON */
       }
-    });
+    };
+    this.room.on(RoomEvent.DataReceived, onDataReceived);
 
     // listen to local state updates and broadcast
-    systemRegistry.onState(async (env) => {
+    const stopStateListener = systemRegistry.onState(async (env) => {
       // Only broadcast if we are the originator
       if (env.origin !== 'browser') return;
 
@@ -47,5 +54,53 @@ export class LiveKitStateBridge {
         console.warn('[LiveKit State Bridge] Failed to publish data:', error);
       }
     });
+
+    this.stop = () => {
+      this.room.off(RoomEvent.DataReceived, onDataReceived);
+      stopStateListener();
+      this.stop = null;
+    };
+
+    return this.stop;
   }
+}
+
+type BridgeAttachment = {
+  refs: number;
+  stop: StopLiveKitStateBridge;
+};
+
+const attachmentsByRoom = new WeakMap<Room, BridgeAttachment>();
+
+export function attachLiveKitStateBridge(room: Room): StopLiveKitStateBridge {
+  const existing = attachmentsByRoom.get(room);
+  if (existing) {
+    existing.refs += 1;
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      existing.refs -= 1;
+      if (existing.refs > 0) return;
+      existing.stop();
+      attachmentsByRoom.delete(room);
+    };
+  }
+
+  const bridge = new LiveKitStateBridge(room);
+  const attachment: BridgeAttachment = {
+    refs: 1,
+    stop: bridge.start(),
+  };
+  attachmentsByRoom.set(room, attachment);
+
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    attachment.refs -= 1;
+    if (attachment.refs > 0) return;
+    attachment.stop();
+    attachmentsByRoom.delete(room);
+  };
 }


### PR DESCRIPTION
## Issue and impact

The canvas route started `LiveKitStateBridge` from a React effect without returning any cleanup. `LiveKitStateBridge.start()` registered a LiveKit `dataReceived` listener and a `systemRegistry.onState` listener, but discarded the unsubscribe handle. A remount/reconnect could therefore multiply state broadcasts and inbound state ingestion in a realtime collaborative room.

Opening-shift runtime audit also found the page-level `window` guard used `room.name || default` and was never cleared, which made ownership brittle and could skip future attach attempts.

## Root cause

Bridge lifecycle ownership was split between `CanvasPageClient` and the bridge class. The class had no disposer, and the page used a process-global sentinel instead of a room-scoped attachment contract.

## What changed

- Added idempotent `LiveKitStateBridge.start()` that returns a disposer.
- Added `attachLiveKitStateBridge(room)` with `WeakMap<Room, ...>` ref-counting so duplicate owners of the same `Room` share one listener pair and cleanup happens after final release.
- Updated `CanvasPageClient` to return the bridge disposer from its effect and removed the stale `window` sentinel.
- Made inbound bridge state strict to the `state_change` LiveKit topic.
- Removed two render-path `console.log` calls from `CanvasPageClient`.
- Added focused lifecycle tests for cleanup, idempotent start, shared attachment, reattach, topic filtering, local echo filtering, and non-browser origin publish gating.

## Backward compatibility

No backend/API/schema change. Existing callers that instantiate `LiveKitStateBridge` can still call `start()`; the only production caller now uses the safer attach helper. State publish/ingest semantics stay the same for `state_change` packets and browser-origin local state. Topic-less state-shaped packets are now intentionally ignored.

## Validation

- `git fetch origin --prune` and rebase onto `origin/main`: clean/up to date.
- `npm test -- --runTestsByPath src/lib/livekit/livekit-state-bridge.test.ts src/lib/livekit/livekit-bus.test.ts --runInBand`: PASS, 12 tests.
- `npm run typecheck:app`: PASS.
- `npx biome lint src/lib/livekit/livekit-state-bridge.ts src/lib/livekit/livekit-state-bridge.test.ts --max-diagnostics=200`: PASS.
- `git diff --check`: PASS.

Note: repo-level `npm run lint -- <paths>` is not path-scoped in this package script and scans all `src`; it still reports pre-existing warnings outside this patch.

## Review swarm

- Intent/regression: no material findings.
- Contracts/coverage: no material findings; helper-level lifecycle proof judged sufficient for this patch.
- Performance/reliability: no material findings; residual unproven edges are real LiveKit room integration and in-flight publish after disposal, not concrete regressions.
- Security/privacy: found fail-open topic filter for missing topic. Fixed by requiring `topic === state_change` and adding a regression test.

## Remaining risk

This PR proves the room-scoped lifecycle contract with unit tests. It does not run a live multi-user browser/LiveKit remount harness, so live network timing remains the residual validation gap.