### PR TITLE
fix: stop prod canvas auth loading loops

### DIFF
--- a/packages/ui/src/reset-workspace-shell.tsx
+++ b/packages/ui/src/reset-workspace-shell.tsx
@@ -322,6 +322,36 @@ export function ResetWorkspaceShell({
   const formatCommand = (command: AgentInteropPack['commands'][keyof AgentInteropPack['commands']]) =>
     [command.command, ...command.args].join(' ');
 
+  const handleRoomTelemetryChange = useEffectEvent((telemetry: {
+    roomName: string;
+    connectionState: string;
+    participantCount: number;
+    agentStatus: string;
+    media: PresenceMember['media'];
+  }) => {
+    setRoomTelemetry((current) => {
+      if (
+        current.roomName === telemetry.roomName &&
+        current.connectionState === telemetry.connectionState &&
+        current.participantCount === telemetry.participantCount &&
+        current.agentStatus === telemetry.agentStatus &&
+        current.media.audio === telemetry.media.audio &&
+        current.media.video === telemetry.media.video &&
+        current.media.screen === telemetry.media.screen
+      ) {
+        return current;
+      }
+
+      return {
+        roomName: telemetry.roomName,
+        connectionState: telemetry.connectionState,
+        participantCount: telemetry.participantCount,
+        agentStatus: telemetry.agentStatus,
+        media: telemetry.media,
+      };
+    });
+  });
+
   useEffect(() => {
     const nextSelectedExecutorId = workspace.activeExecutorSessionId ?? executors[0]?.id ?? '';
     setSelectedExecutorSessionId((current) => (current === nextSelectedExecutorId ? current : nextSelectedExecutorId));
@@ -1112,15 +1142,7 @@ export function ResetWorkspaceShell({
             <ResetCollaborationSurface
               workspaceSessionId={workspace.id}
               operatorLabel={localPresenceLabel}
-              onTelemetryChange={(telemetry) => {
-                setRoomTelemetry({
-                  roomName: telemetry.roomName,
-                  connectionState: telemetry.connectionState,
-                  participantCount: telemetry.participantCount,
-                  agentStatus: telemetry.agentStatus,
-                  media: telemetry.media,
-                });
-              }}
+              onTelemetryChange={handleRoomTelemetryChange}
             />
           </div>
           <CodexRemoteWidget

--- a/src/app/canvas/CanvasPageClient.tsx
+++ b/src/app/canvas/CanvasPageClient.tsx
@@ -97,10 +97,18 @@ export function CanvasPageClient() {
         const error = res?.error;
         if (error) {
           setDemoError(error.message || 'Failed to start demo session');
+          setDemoNameDraft(storedName);
+          try {
+            window.localStorage.removeItem('present:display_name');
+          } catch { }
           setDemoAuthAttempted(false);
         }
       } catch (err: any) {
         setDemoError(err?.message || 'Failed to start demo session');
+        setDemoNameDraft(storedName);
+        try {
+          window.localStorage.removeItem('present:display_name');
+        } catch { }
         setDemoAuthAttempted(false);
       }
     })();
@@ -639,10 +647,16 @@ export function CanvasPageClient() {
         const error = res?.error;
         if (error) {
           setDemoError(error.message || 'Failed to start demo session');
+          try {
+            window.localStorage.removeItem('present:display_name');
+          } catch { }
           setDemoAuthAttempted(false);
         }
       } catch (err: any) {
         setDemoError(err?.message || 'Failed to start demo session');
+        try {
+          window.localStorage.removeItem('present:display_name');
+        } catch { }
         setDemoAuthAttempted(false);
       }
     };

--- a/src/hooks/use-auth.ts
+++ b/src/hooks/use-auth.ts
@@ -3,16 +3,49 @@ import { User } from '@supabase/supabase-js';
 import { supabase } from '@/lib/supabase';
 import { DEFAULT_POST_AUTH_PATH, sanitizeInternalRedirectPath } from '@/lib/auth/redirects';
 
+const AUTH_SESSION_TIMEOUT_MS = 3500;
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timeout = window.setTimeout(() => {
+      reject(new Error('Timed out while checking auth session'));
+    }, timeoutMs);
+
+    promise.then(
+      (value) => {
+        window.clearTimeout(timeout);
+        resolve(value);
+      },
+      (error) => {
+        window.clearTimeout(timeout);
+        reject(error);
+      },
+    );
+  });
+}
+
 export function useAuth() {
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
+    let active = true;
+
     // Get initial session
-    supabase.auth.getSession().then(({ data: { session } }) => {
-      setUser(session?.user ?? null);
-      setLoading(false);
-    });
+    withTimeout(supabase.auth.getSession(), AUTH_SESSION_TIMEOUT_MS)
+      .then(({ data: { session } }) => {
+        if (!active) return;
+        setUser(session?.user ?? null);
+      })
+      .catch((error) => {
+        if (!active) return;
+        console.warn('[auth] Initial session check failed:', error instanceof Error ? error.message : error);
+        setUser(null);
+      })
+      .finally(() => {
+        if (!active) return;
+        setLoading(false);
+      });
 
     // Listen for auth changes
     const {
@@ -22,7 +55,10 @@ export function useAuth() {
       setLoading(false);
     });
 
-    return () => subscription.unsubscribe();
+    return () => {
+      active = false;
+      subscription.unsubscribe();
+    };
   }, []);
 
   const signInWithGoogle = async (next: string = DEFAULT_POST_AUTH_PATH) => {


### PR DESCRIPTION
## Summary
- add a bounded initial Supabase session check so /canvas exits Loading when auth is unreachable
- clear stored demo display names after anonymous auth failures so demo mode does not auto-retry forever
- guard reset-shell room telemetry updates to stop render/fetch storms on the root reset page

## Verification
- npm run typecheck:app
- npm test -- --runInBand --runTestsByPath src/app/canvas/page.test.tsx packages/ui/src/reset-workspace-shell.test.tsx

## Notes
- Live prod Browser/Playwright evidence showed /canvas stuck on Loading/Connecting while Supabase anonymous auth requests to zrrdcztzztihbjewlqde.supabase.co failed DNS and retried.
- Local /canvas runtime smoke was blocked by Next dev hanging during /canvas compilation, so preview/prod smoke should be checked after deploy.